### PR TITLE
Add sideshift adaptor

### DIFF
--- a/src/adaptors/sideshift/index.js
+++ b/src/adaptors/sideshift/index.js
@@ -1,0 +1,21 @@
+const utils = require('../utils');
+
+const main = async () => {
+  const stats = await utils.getData('https://sideshift.ai/api/v2/xai/stats');
+
+  return [
+    {
+      pool: '0x3808708e761b988d23ae011ed0e12674fb66bd62',
+      chain: utils.formatChain('ethereum'),
+      project: 'sideshift',
+      symbol: utils.formatSymbol('svXAI'),
+      tvlUsd: Number(stats.totalValueLocked),
+      apy: Number(stats.averageAnnualPercentageYield),
+    },
+  ];
+};
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+};


### PR DESCRIPTION
Adds an adaptor for SideShift.ai's svXAI pool:

```
$ node src/adaptors/test.js src/adaptors/sideshift/index.js
==== Testing src/adaptors/sideshift/index.js ====

Nb of pools: 1
 

Sample pools: [
  {
    pool: '0x3808708e761b988d23ae011ed0e12674fb66bd62',
    chain: 'Ethereum',
    project: 'sideshift',
    symbol: 'svXAI',
    tvlUsd: 4501533.25044498,
    apy: 27.38
  }
]

Runtime: 0.68 sec
```

