### PR TITLE
Update Earnmos adapter

### DIFF
--- a/src/adaptors/earnmos/index.js
+++ b/src/adaptors/earnmos/index.js
@@ -2,7 +2,7 @@ const utils = require('../utils');
 
 const poolsFunction = async () => {
   const poolData = await utils.getData(
-    'https://app.earnmos.fi/em-api/tvl/getTvlAndApy'
+    'https://app.earnmos.fi/defi-llama/yields'
   );
 
   return poolData?.data?.map((poolInfo) => ({


### PR DESCRIPTION
It's working:
```
npm test --adapter=earnmos

> defillama-apy-server@1.0.0 test /Users/yu/work/bs/defillama/yield-server
> jest

 PASS  src/adaptors/test.js
  Running earnmos Test
    ✓ Check for unique pool ids (1 ms)
    ✓ Check project field is constant in all pools and if folder name and project field in pool objects matches the information in /protocols slug (1 ms)
    Check for allowed field names
      ✓ Expects pool id 0xeAc03a4E60717Ba3017a8F45135800FE27BAF01e to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy (1 ms)
      ✓ Expects pool id 0x9dd87A3593080198366a5D6653C4D62F6D76f14A to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy (1 ms)
      ✓ Expects pool id 0x0f91bF3e5a3e4450Ad4f8Af09d03A35069A726D9 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy
      ✓ Expects pool id 0x676C0FA342f7B9B6A089A82A3B97Db8756C74B88 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy
      ✓ Expects pool id 0xda00D069e509c17fa903b22B6B10ab5d1aD3C460 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy (1 ms)
      ✓ Expects pool id 0xB10eb79B6A381F58f234CB90936E76Ae4a97A476 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy
      ✓ Expects pool id 0xBe1BCB2724519c71d905917a902EFD533aeB9e52 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy
      ✓ Expects pool id 0x7a2ff76ed75E7e105ECbBE9B11f3dF0Fa89bd369 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy
      ✓ Expects pool id 0x517e0fC2466cd341D970E95891D4B1f57656576f to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy (1 ms)
      ✓ Expects pool id 0x1f9040f8D48198B98f51D7ad918c74791A0e2A70 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy
    Check apy data types
      ✓ Expects pool with id 0xeAc03a4E60717Ba3017a8F45135800FE27BAF01e to have at least one number apy field
      ✓ Expects pool with id 0x9dd87A3593080198366a5D6653C4D62F6D76f14A to have at least one number apy field
      ✓ Expects pool with id 0x0f91bF3e5a3e4450Ad4f8Af09d03A35069A726D9 to have at least one number apy field (1 ms)
      ✓ Expects pool with id 0x676C0FA342f7B9B6A089A82A3B97Db8756C74B88 to have at least one number apy field
      ✓ Expects pool with id 0xda00D069e509c17fa903b22B6B10ab5d1aD3C460 to have at least one number apy field
      ✓ Expects pool with id 0xB10eb79B6A381F58f234CB90936E76Ae4a97A476 to have at least one number apy field (1 ms)
      ✓ Expects pool with id 0xBe1BCB2724519c71d905917a902EFD533aeB9e52 to have at least one number apy field
      ✓ Expects pool with id 0x7a2ff76ed75E7e105ECbBE9B11f3dF0Fa89bd369 to have at least one number apy field (1 ms)
      ✓ Expects pool with id 0x517e0fC2466cd341D970E95891D4B1f57656576f to have at least one number apy field
      ✓ Expects pool with id 0x1f9040f8D48198B98f51D7ad918c74791A0e2A70 to have at least one number apy field
    Check tvl data type
      ✓ tvlUsd field of pool with id 0xeAc03a4E60717Ba3017a8F45135800FE27BAF01e should be number
      ✓ tvlUsd field of pool with id 0x9dd87A3593080198366a5D6653C4D62F6D76f14A should be number
      ✓ tvlUsd field of pool with id 0x0f91bF3e5a3e4450Ad4f8Af09d03A35069A726D9 should be number  (1 ms)
      ✓ tvlUsd field of pool with id 0x676C0FA342f7B9B6A089A82A3B97Db8756C74B88 should be number
      ✓ tvlUsd field of pool with id 0xda00D069e509c17fa903b22B6B10ab5d1aD3C460 should be number
      ✓ tvlUsd field of pool with id 0xB10eb79B6A381F58f234CB90936E76Ae4a97A476 should be number
      ✓ tvlUsd field of pool with id 0xBe1BCB2724519c71d905917a902EFD533aeB9e52 should be number  (1 ms)
      ✓ tvlUsd field of pool with id 0x7a2ff76ed75E7e105ECbBE9B11f3dF0Fa89bd369 should be number
      ✓ tvlUsd field of pool with id 0x517e0fC2466cd341D970E95891D4B1f57656576f should be number  (1 ms)
      ✓ tvlUsd field of pool with id 0x1f9040f8D48198B98f51D7ad918c74791A0e2A70 should be number
    Check other fields data types
      ✓ Expect other fields of pool with id 0xeAc03a4E60717Ba3017a8F45135800FE27BAF01e to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x9dd87A3593080198366a5D6653C4D62F6D76f14A to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x0f91bF3e5a3e4450Ad4f8Af09d03A35069A726D9 to match thier data types
      ✓ Expect other fields of pool with id 0x676C0FA342f7B9B6A089A82A3B97Db8756C74B88 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0xda00D069e509c17fa903b22B6B10ab5d1aD3C460 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0xB10eb79B6A381F58f234CB90936E76Ae4a97A476 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0xBe1BCB2724519c71d905917a902EFD533aeB9e52 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x7a2ff76ed75E7e105ECbBE9B11f3dF0Fa89bd369 to match thier data types (4 ms)
      ✓ Expect other fields of pool with id 0x517e0fC2466cd341D970E95891D4B1f57656576f to match thier data types
      ✓ Expect other fields of pool with id 0x1f9040f8D48198B98f51D7ad918c74791A0e2A70 to match thier data types
    Check if pool has a rewardApy then rewardTokens must also exist
      ✓ The pool 0xeAc03a4E60717Ba3017a8F45135800FE27BAF01e is expected to have a rewardTokens field
      ✓ The pool 0x9dd87A3593080198366a5D6653C4D62F6D76f14A is expected to have a rewardTokens field
      ✓ The pool 0x0f91bF3e5a3e4450Ad4f8Af09d03A35069A726D9 is expected to have a rewardTokens field
      ✓ The pool 0x676C0FA342f7B9B6A089A82A3B97Db8756C74B88 is expected to have a rewardTokens field
      ✓ The pool 0xda00D069e509c17fa903b22B6B10ab5d1aD3C460 is expected to have a rewardTokens field
      ✓ The pool 0xB10eb79B6A381F58f234CB90936E76Ae4a97A476 is expected to have a rewardTokens field
      ✓ The pool 0xBe1BCB2724519c71d905917a902EFD533aeB9e52 is expected to have a rewardTokens field
      ✓ The pool 0x7a2ff76ed75E7e105ECbBE9B11f3dF0Fa89bd369 is expected to have a rewardTokens field
      ✓ The pool 0x517e0fC2466cd341D970E95891D4B1f57656576f is expected to have a rewardTokens field
      ✓ The pool 0x1f9040f8D48198B98f51D7ad918c74791A0e2A70 is expected to have a rewardTokens field
    Check if pool id already used by other project
      ✓ Expect duplicate ids array to be empty

Test Suites: 1 passed, 1 total
Tests:       53 passed, 53 total
Snapshots:   0 total
Time:        0.305 s, estimated 1 s
Ran all test suites.

Nb of pools: 10


curl https://app.earnmos.fi/defi-llama/yields
{"data":[{"symbol":"DLP madUSDC/WEVMOS(Auto Compounder)","pool":"0x0f91bF3e5a3e4450Ad4f8Af09d03A35069A726D9","chain":"Evmos","totalValueLock":"50590.533358889185104979","apy":0},{"symbol":"DLP DIFF/WEVMOS(Auto Compounder)","pool":"0xB10eb79B6A381F58f234CB90936E76Ae4a97A476","chain":"Evmos","totalValueLock":"17618.57213492707498077","apy":4.96240717570658},{"symbol":"DLP madWETH/WEVMOS(Auto Compounder)","pool":"0x7a2ff76ed75E7e105ECbBE9B11f3dF0Fa89bd369","chain":"Evmos","totalValueLock":"8909.12581246713165114","apy":0},{"symbol":"DLP DIFF/madUSDC(Auto Compounder)","pool":"0x1f9040f8D48198B98f51D7ad918c74791A0e2A70","chain":"Evmos","totalValueLock":"1765.824610045593558526","apy":0},{"symbol":"LP madUSDC/WEVMOS(EMO Reward Boost)","pool":"0x517e0fC2466cd341D970E95891D4B1f57656576f","chain":"Evmos","totalValueLock":"2865.926123731275146486","apy":3.6923573314756197},{"symbol":"LP madDAI/madUSDC/madUSDT(EMO Reward Boost)","pool":"0x9dd87A3593080198366a5D6653C4D62F6D76f14A","chain":"Evmos","totalValueLock":"153318.57146748506263061","apy":0.3054796707792845},{"symbol":"DLP madUSDC/WEVMOS(Auto Stake)","pool":"0xeAc03a4E60717Ba3017a8F45135800FE27BAF01e","chain":"Evmos","totalValueLock":"176926.913441875014679258","apy":0},{"symbol":"DLP DIFF/WEVMOS(Auto Stake)","pool":"0x676C0FA342f7B9B6A089A82A3B97Db8756C74B88","chain":"Evmos","totalValueLock":"46679.584987053682869391","apy":26.593342739022688},{"symbol":"DLP madWETH/WEVMOS(Auto Stake)","pool":"0xda00D069e509c17fa903b22B6B10ab5d1aD3C460","chain":"Evmos","totalValueLock":"24258.441920811301090293","apy":0},{"symbol":"DLP DIFF/madUSDC(Auto Stake)","pool":"0xBe1BCB2724519c71d905917a902EFD533aeB9e52","chain":"Evmos","totalValueLock":"12311.381494060666694384","apy":0}]}

```