### PR TITLE
fix cal apr to apy and cal baseApy and reward apy

### DIFF
--- a/src/adaptors/beethoven-x/index.js
+++ b/src/adaptors/beethoven-x/index.js
@@ -5,20 +5,25 @@ const utils = require('../utils');
 // Subgraph URLs
 const urlFantom = 'https://backend.beets-ftm-node.com/graphql';
 const urlOp = 'https://backend-optimism.beets-ftm-node.com/';
-
+const rewardToken = "fantom:0xf24bcf4d1e507740041c9cfd2dddb29585adce1e";
+// aprToApy
 const buildPool = (el, chainString) => {
   const symbol = el.linearPools
     ? utils.formatSymbol(
         el.linearPools.map((item) => item.mainToken.symbol).join('-')
       )
     : utils.formatSymbol(el.tokens.map((item) => item.symbol).join('-'));
+  const aprFee = el.apr.items.find((e) => e.title === 'Swap fees APR');
+  const aprReward = el.apr.items.find((e) => e.title !== 'Swap fees APR');
   const newObj = {
     pool: el.id,
     chain: utils.formatChain(chainString),
     project: 'beethoven-x',
     symbol: symbol,
     tvlUsd: parseFloat(el.totalLiquidity),
-    apy: parseFloat(el.apr.total) * 100,
+    apyBase: utils.aprToApy(Number(aprFee?.apr || 0)) * 100,
+    apyReward: utils.aprToApy(Number(aprReward?.apr || 0)) * 100,
+    rewardTokens: [rewardToken]
   };
 
   return newObj;

--- a/src/adaptors/beethoven-x/index.js
+++ b/src/adaptors/beethoven-x/index.js
@@ -5,7 +5,7 @@ const utils = require('../utils');
 // Subgraph URLs
 const urlFantom = 'https://backend.beets-ftm-node.com/graphql';
 const urlOp = 'https://backend-optimism.beets-ftm-node.com/';
-const rewardToken = "fantom:0xf24bcf4d1e507740041c9cfd2dddb29585adce1e";
+const rewardToken = "0xf24bcf4d1e507740041c9cfd2dddb29585adce1e";
 // aprToApy
 const buildPool = (el, chainString) => {
   const symbol = el.linearPools


### PR DESCRIPTION
I found cal apy beethoven-x is has some issue
1. apr -> apy
2. graphql include info for cal baseApy and rewardApy 
```
"apr": {
          "total": "0.1952290326510398",
          "hasRewardApr": true,
          "swapApr": "0.026468315795940896",
          "beetsApr": "0.1687607168550989",
          "thirdPartyApr": "0",
          "items": [
            {
              "title": "Swap fees APR",
              "apr": "0.026468315795940896",
              "subItems": null
            },
            {
              "title": "BEETS reward APR",
              "apr": "0.1687607168550989",
              "subItems": null
            },
            {
              "title": "LQDR reward APR",
              "apr": "0",
              "subItems": null
            }
          ]
        }
```