### PR TITLE
add Avault

### DIFF
--- a/src/adaptors/avault/index.js
+++ b/src/adaptors/avault/index.js
@@ -1,0 +1,13 @@
+const axios = require('axios');
+
+const main = async () => {
+  const res = (await axios.get('https://www.avault.network/api/v0/yield/info'))
+    .data.data;
+  return res;
+};
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+  url: 'https://www.avault.network/vault',
+};


### PR DESCRIPTION
```
npm run test --adapter=avault

> defillama-apy-server@1.0.0 test
> jest

watchman warning:  Recrawled this watch 1 times, most recently because:
MustScanSubDirs UserDroppedTo resolve, please review the information on
https://facebook.github.io/watchman/docs/troubleshooting.html#recrawl
To clear this warning, run:
`watchman watch-del '/Users/hailiting/Desktop/work/AVaultFinance/yield-server' ; watchman watch-project '/Users/hailiting/Desktop/work/AVaultFinance/yield-server'`

 PASS  src/adaptors/test.js
  Running avault Test
    ✓ Check if link to the pool's page exist (1 ms)
    ✓ Check for unique pool ids (1 ms)
    ✓ Check project field is constant in all pools and if folder name and project field in pool objects matches the information in /protocols slug
    Check for allowed field names
      ✓ Expects pool id 0x5f612d4155b1cede2a2cda61146834280f706b78 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (2 ms)
      ✓ Expects pool id 0xdad1d300e9a6f4f36aed40213ef473fd019704e9 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0xe66560c1b5faae4e4f77ba40f61f21f4adbb6924 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x8964fae92bb4b79d408e9bd3d48e7c9ecaa5f163 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (1 ms)
      ✓ Expects pool id 0xc59b9d3ecc93967e697accdbfe9eab74bb3fba22 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0xdaac872a9098ac5620c9d8eaf2dd50fbabc50bb1 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x945bc42819f4f612d07dabd1d57f10aac494405f to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x347e53263f8fb843ec605a1577ec7c8c0cac7a58 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (1 ms)
      ✓ Expects pool id 0x9914bff0437f914549c673b34808af6020e2b453 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x02dac4898b2c2ca9d50ff8d6a7726166cf7bcfd0 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x360d125366c60ba20dc11ebb7120bdeaa0cc007c to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (1 ms)
      ✓ Expects pool id 0x8d90e9c50af206a2757e09b56160991dd7548db9 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (1 ms)
      ✓ Expects pool id 0x9a45b203af044adacced4d95ca3cda020e082c8a to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (1 ms)
      ✓ Expects pool id 0xdbd71969ac2583a9a20af3fb81fe9c20547f30f3 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x383c69e3bae31ef1d7dc154cd351b0d734537626 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (1 ms)
      ✓ Expects pool id 0x898bf9c743a436c9c3f332af445aad69c15b10b8 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x5417f117e4a2283623b3b9a07ec2b2f269d19a75 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (1 ms)
      ✓ Expects pool id 0x13e01d7da7b3f211c6972c331da88c142df571d8 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x8f0fd0a3b767a67e992f33063817a2d472eff74f to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x40b18bc7aee5a03515fcf241ad89d548899fb74f to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0xe7465336baa2efbe52e3e67a8b06a97630d76882 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x6b13ddf4d1e1f2e036619920746318fb79f9ea84 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (1 ms)
      ✓ Expects pool id 0x58ad25aa6b14c3fd5921ea5bb731c3b2ade0a099 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0xc730151a27a4ce6a09d51cfab115233c2e73d471 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x57d942953d416835f7b60be2a8b49870cc7bcfe1 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens (1 ms)
      ✓ Expects pool id 0x46c3773bd40ba20bd77c3b246783ce941f3db574 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
      ✓ Expects pool id 0x7d7b744cb50eb228fe23bbb29bc5918c507180b7 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,tvlUsd and has: pool,chain,project,symbol,tvlUsd,apy,rewardTokens,underlyingTokens
    Check apy data types
      ✓ Expects pool with id 0x5f612d4155b1cede2a2cda61146834280f706b78 to have at least one number apy field (1 ms)
      ✓ Expects pool with id 0xdad1d300e9a6f4f36aed40213ef473fd019704e9 to have at least one number apy field
      ✓ Expects pool with id 0xe66560c1b5faae4e4f77ba40f61f21f4adbb6924 to have at least one number apy field
      ✓ Expects pool with id 0x8964fae92bb4b79d408e9bd3d48e7c9ecaa5f163 to have at least one number apy field (1 ms)
      ✓ Expects pool with id 0xc59b9d3ecc93967e697accdbfe9eab74bb3fba22 to have at least one number apy field
      ✓ Expects pool with id 0xdaac872a9098ac5620c9d8eaf2dd50fbabc50bb1 to have at least one number apy field
      ✓ Expects pool with id 0x945bc42819f4f612d07dabd1d57f10aac494405f to have at least one number apy field
      ✓ Expects pool with id 0x347e53263f8fb843ec605a1577ec7c8c0cac7a58 to have at least one number apy field
      ✓ Expects pool with id 0x9914bff0437f914549c673b34808af6020e2b453 to have at least one number apy field
      ✓ Expects pool with id 0x02dac4898b2c2ca9d50ff8d6a7726166cf7bcfd0 to have at least one number apy field
      ✓ Expects pool with id 0x360d125366c60ba20dc11ebb7120bdeaa0cc007c to have at least one number apy field
      ✓ Expects pool with id 0x8d90e9c50af206a2757e09b56160991dd7548db9 to have at least one number apy field
      ✓ Expects pool with id 0x9a45b203af044adacced4d95ca3cda020e082c8a to have at least one number apy field
      ✓ Expects pool with id 0xdbd71969ac2583a9a20af3fb81fe9c20547f30f3 to have at least one number apy field
      ✓ Expects pool with id 0x383c69e3bae31ef1d7dc154cd351b0d734537626 to have at least one number apy field
      ✓ Expects pool with id 0x898bf9c743a436c9c3f332af445aad69c15b10b8 to have at least one number apy field
      ✓ Expects pool with id 0x5417f117e4a2283623b3b9a07ec2b2f269d19a75 to have at least one number apy field
      ✓ Expects pool with id 0x13e01d7da7b3f211c6972c331da88c142df571d8 to have at least one number apy field
      ✓ Expects pool with id 0x8f0fd0a3b767a67e992f33063817a2d472eff74f to have at least one number apy field
      ✓ Expects pool with id 0x40b18bc7aee5a03515fcf241ad89d548899fb74f to have at least one number apy field (2 ms)
      ✓ Expects pool with id 0xe7465336baa2efbe52e3e67a8b06a97630d76882 to have at least one number apy field
      ✓ Expects pool with id 0x6b13ddf4d1e1f2e036619920746318fb79f9ea84 to have at least one number apy field (1 ms)
      ✓ Expects pool with id 0x58ad25aa6b14c3fd5921ea5bb731c3b2ade0a099 to have at least one number apy field
      ✓ Expects pool with id 0xc730151a27a4ce6a09d51cfab115233c2e73d471 to have at least one number apy field
      ✓ Expects pool with id 0x57d942953d416835f7b60be2a8b49870cc7bcfe1 to have at least one number apy field
      ✓ Expects pool with id 0x46c3773bd40ba20bd77c3b246783ce941f3db574 to have at least one number apy field
      ✓ Expects pool with id 0x7d7b744cb50eb228fe23bbb29bc5918c507180b7 to have at least one number apy field
    Check tvl data type
      ✓ tvlUsd field of pool with id 0x5f612d4155b1cede2a2cda61146834280f706b78 should be number 
      ✓ tvlUsd field of pool with id 0xdad1d300e9a6f4f36aed40213ef473fd019704e9 should be number 
      ✓ tvlUsd field of pool with id 0xe66560c1b5faae4e4f77ba40f61f21f4adbb6924 should be number 
      ✓ tvlUsd field of pool with id 0x8964fae92bb4b79d408e9bd3d48e7c9ecaa5f163 should be number  (1 ms)
      ✓ tvlUsd field of pool with id 0xc59b9d3ecc93967e697accdbfe9eab74bb3fba22 should be number 
      ✓ tvlUsd field of pool with id 0xdaac872a9098ac5620c9d8eaf2dd50fbabc50bb1 should be number 
      ✓ tvlUsd field of pool with id 0x945bc42819f4f612d07dabd1d57f10aac494405f should be number 
      ✓ tvlUsd field of pool with id 0x347e53263f8fb843ec605a1577ec7c8c0cac7a58 should be number 
      ✓ tvlUsd field of pool with id 0x9914bff0437f914549c673b34808af6020e2b453 should be number 
      ✓ tvlUsd field of pool with id 0x02dac4898b2c2ca9d50ff8d6a7726166cf7bcfd0 should be number  (1 ms)
      ✓ tvlUsd field of pool with id 0x360d125366c60ba20dc11ebb7120bdeaa0cc007c should be number 
      ✓ tvlUsd field of pool with id 0x8d90e9c50af206a2757e09b56160991dd7548db9 should be number  (1 ms)
      ✓ tvlUsd field of pool with id 0x9a45b203af044adacced4d95ca3cda020e082c8a should be number 
      ✓ tvlUsd field of pool with id 0xdbd71969ac2583a9a20af3fb81fe9c20547f30f3 should be number 
      ✓ tvlUsd field of pool with id 0x383c69e3bae31ef1d7dc154cd351b0d734537626 should be number 
      ✓ tvlUsd field of pool with id 0x898bf9c743a436c9c3f332af445aad69c15b10b8 should be number 
      ✓ tvlUsd field of pool with id 0x5417f117e4a2283623b3b9a07ec2b2f269d19a75 should be number 
      ✓ tvlUsd field of pool with id 0x13e01d7da7b3f211c6972c331da88c142df571d8 should be number 
      ✓ tvlUsd field of pool with id 0x8f0fd0a3b767a67e992f33063817a2d472eff74f should be number 
      ✓ tvlUsd field of pool with id 0x40b18bc7aee5a03515fcf241ad89d548899fb74f should be number  (1 ms)
      ✓ tvlUsd field of pool with id 0xe7465336baa2efbe52e3e67a8b06a97630d76882 should be number 
      ✓ tvlUsd field of pool with id 0x6b13ddf4d1e1f2e036619920746318fb79f9ea84 should be number 
      ✓ tvlUsd field of pool with id 0x58ad25aa6b14c3fd5921ea5bb731c3b2ade0a099 should be number 
      ✓ tvlUsd field of pool with id 0xc730151a27a4ce6a09d51cfab115233c2e73d471 should be number 
      ✓ tvlUsd field of pool with id 0x57d942953d416835f7b60be2a8b49870cc7bcfe1 should be number 
      ✓ tvlUsd field of pool with id 0x46c3773bd40ba20bd77c3b246783ce941f3db574 should be number 
      ✓ tvlUsd field of pool with id 0x7d7b744cb50eb228fe23bbb29bc5918c507180b7 should be number 
    Check tokens data types
      ✓ rewardTokens field of pool with id 0x5f612d4155b1cede2a2cda61146834280f706b78 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x5f612d4155b1cede2a2cda61146834280f706b78 should be an Array of strings
      ✓ rewardTokens field of pool with id 0xdad1d300e9a6f4f36aed40213ef473fd019704e9 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0xdad1d300e9a6f4f36aed40213ef473fd019704e9 should be an Array of strings (1 ms)
      ✓ rewardTokens field of pool with id 0xe66560c1b5faae4e4f77ba40f61f21f4adbb6924 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0xe66560c1b5faae4e4f77ba40f61f21f4adbb6924 should be an Array of strings (1 ms)
      ✓ rewardTokens field of pool with id 0x8964fae92bb4b79d408e9bd3d48e7c9ecaa5f163 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x8964fae92bb4b79d408e9bd3d48e7c9ecaa5f163 should be an Array of strings (1 ms)
      ✓ rewardTokens field of pool with id 0xc59b9d3ecc93967e697accdbfe9eab74bb3fba22 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0xc59b9d3ecc93967e697accdbfe9eab74bb3fba22 should be an Array of strings (1 ms)
      ✓ rewardTokens field of pool with id 0xdaac872a9098ac5620c9d8eaf2dd50fbabc50bb1 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0xdaac872a9098ac5620c9d8eaf2dd50fbabc50bb1 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x945bc42819f4f612d07dabd1d57f10aac494405f should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x945bc42819f4f612d07dabd1d57f10aac494405f should be an Array of strings
      ✓ rewardTokens field of pool with id 0x347e53263f8fb843ec605a1577ec7c8c0cac7a58 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x347e53263f8fb843ec605a1577ec7c8c0cac7a58 should be an Array of strings (2 ms)
      ✓ rewardTokens field of pool with id 0x9914bff0437f914549c673b34808af6020e2b453 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x9914bff0437f914549c673b34808af6020e2b453 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x02dac4898b2c2ca9d50ff8d6a7726166cf7bcfd0 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x02dac4898b2c2ca9d50ff8d6a7726166cf7bcfd0 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x360d125366c60ba20dc11ebb7120bdeaa0cc007c should be an Array of strings (1 ms)
      ✓ underlyingTokens field of pool with id 0x360d125366c60ba20dc11ebb7120bdeaa0cc007c should be an Array of strings
      ✓ rewardTokens field of pool with id 0x8d90e9c50af206a2757e09b56160991dd7548db9 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x8d90e9c50af206a2757e09b56160991dd7548db9 should be an Array of strings (1 ms)
      ✓ rewardTokens field of pool with id 0x9a45b203af044adacced4d95ca3cda020e082c8a should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x9a45b203af044adacced4d95ca3cda020e082c8a should be an Array of strings
      ✓ rewardTokens field of pool with id 0xdbd71969ac2583a9a20af3fb81fe9c20547f30f3 should be an Array of strings (1 ms)
      ✓ underlyingTokens field of pool with id 0xdbd71969ac2583a9a20af3fb81fe9c20547f30f3 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x383c69e3bae31ef1d7dc154cd351b0d734537626 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x383c69e3bae31ef1d7dc154cd351b0d734537626 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x898bf9c743a436c9c3f332af445aad69c15b10b8 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x898bf9c743a436c9c3f332af445aad69c15b10b8 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x5417f117e4a2283623b3b9a07ec2b2f269d19a75 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x5417f117e4a2283623b3b9a07ec2b2f269d19a75 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x13e01d7da7b3f211c6972c331da88c142df571d8 should be an Array of strings (1 ms)
      ✓ underlyingTokens field of pool with id 0x13e01d7da7b3f211c6972c331da88c142df571d8 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x8f0fd0a3b767a67e992f33063817a2d472eff74f should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x8f0fd0a3b767a67e992f33063817a2d472eff74f should be an Array of strings
      ✓ rewardTokens field of pool with id 0x40b18bc7aee5a03515fcf241ad89d548899fb74f should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x40b18bc7aee5a03515fcf241ad89d548899fb74f should be an Array of strings
      ✓ rewardTokens field of pool with id 0xe7465336baa2efbe52e3e67a8b06a97630d76882 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0xe7465336baa2efbe52e3e67a8b06a97630d76882 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x6b13ddf4d1e1f2e036619920746318fb79f9ea84 should be an Array of strings (1 ms)
      ✓ underlyingTokens field of pool with id 0x6b13ddf4d1e1f2e036619920746318fb79f9ea84 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x58ad25aa6b14c3fd5921ea5bb731c3b2ade0a099 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x58ad25aa6b14c3fd5921ea5bb731c3b2ade0a099 should be an Array of strings (1 ms)
      ✓ rewardTokens field of pool with id 0xc730151a27a4ce6a09d51cfab115233c2e73d471 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0xc730151a27a4ce6a09d51cfab115233c2e73d471 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x57d942953d416835f7b60be2a8b49870cc7bcfe1 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x57d942953d416835f7b60be2a8b49870cc7bcfe1 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x46c3773bd40ba20bd77c3b246783ce941f3db574 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x46c3773bd40ba20bd77c3b246783ce941f3db574 should be an Array of strings
      ✓ rewardTokens field of pool with id 0x7d7b744cb50eb228fe23bbb29bc5918c507180b7 should be an Array of strings
      ✓ underlyingTokens field of pool with id 0x7d7b744cb50eb228fe23bbb29bc5918c507180b7 should be an Array of strings (1 ms)
    Check other fields data types
      ✓ Expect other fields of pool with id 0x5f612d4155b1cede2a2cda61146834280f706b78 to match thier data types
      ✓ Expect other fields of pool with id 0xdad1d300e9a6f4f36aed40213ef473fd019704e9 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0xe66560c1b5faae4e4f77ba40f61f21f4adbb6924 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x8964fae92bb4b79d408e9bd3d48e7c9ecaa5f163 to match thier data types
      ✓ Expect other fields of pool with id 0xc59b9d3ecc93967e697accdbfe9eab74bb3fba22 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0xdaac872a9098ac5620c9d8eaf2dd50fbabc50bb1 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x945bc42819f4f612d07dabd1d57f10aac494405f to match thier data types
      ✓ Expect other fields of pool with id 0x347e53263f8fb843ec605a1577ec7c8c0cac7a58 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x9914bff0437f914549c673b34808af6020e2b453 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x02dac4898b2c2ca9d50ff8d6a7726166cf7bcfd0 to match thier data types
      ✓ Expect other fields of pool with id 0x360d125366c60ba20dc11ebb7120bdeaa0cc007c to match thier data types
      ✓ Expect other fields of pool with id 0x8d90e9c50af206a2757e09b56160991dd7548db9 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x9a45b203af044adacced4d95ca3cda020e082c8a to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0xdbd71969ac2583a9a20af3fb81fe9c20547f30f3 to match thier data types
      ✓ Expect other fields of pool with id 0x383c69e3bae31ef1d7dc154cd351b0d734537626 to match thier data types
      ✓ Expect other fields of pool with id 0x898bf9c743a436c9c3f332af445aad69c15b10b8 to match thier data types
      ✓ Expect other fields of pool with id 0x5417f117e4a2283623b3b9a07ec2b2f269d19a75 to match thier data types
      ✓ Expect other fields of pool with id 0x13e01d7da7b3f211c6972c331da88c142df571d8 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x8f0fd0a3b767a67e992f33063817a2d472eff74f to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x40b18bc7aee5a03515fcf241ad89d548899fb74f to match thier data types
      ✓ Expect other fields of pool with id 0xe7465336baa2efbe52e3e67a8b06a97630d76882 to match thier data types
      ✓ Expect other fields of pool with id 0x6b13ddf4d1e1f2e036619920746318fb79f9ea84 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x58ad25aa6b14c3fd5921ea5bb731c3b2ade0a099 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0xc730151a27a4ce6a09d51cfab115233c2e73d471 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x57d942953d416835f7b60be2a8b49870cc7bcfe1 to match thier data types (1 ms)
      ✓ Expect other fields of pool with id 0x46c3773bd40ba20bd77c3b246783ce941f3db574 to match thier data types
      ✓ Expect other fields of pool with id 0x7d7b744cb50eb228fe23bbb29bc5918c507180b7 to match thier data types
    Check if pool has a rewardApy then rewardTokens must also exist
      ✓ The pool 0x5f612d4155b1cede2a2cda61146834280f706b78 is expected to have a rewardTokens field
      ✓ The pool 0xdad1d300e9a6f4f36aed40213ef473fd019704e9 is expected to have a rewardTokens field
      ✓ The pool 0xe66560c1b5faae4e4f77ba40f61f21f4adbb6924 is expected to have a rewardTokens field (1 ms)
      ✓ The pool 0x8964fae92bb4b79d408e9bd3d48e7c9ecaa5f163 is expected to have a rewardTokens field
      ✓ The pool 0xc59b9d3ecc93967e697accdbfe9eab74bb3fba22 is expected to have a rewardTokens field
      ✓ The pool 0xdaac872a9098ac5620c9d8eaf2dd50fbabc50bb1 is expected to have a rewardTokens field
      ✓ The pool 0x945bc42819f4f612d07dabd1d57f10aac494405f is expected to have a rewardTokens field
      ✓ The pool 0x347e53263f8fb843ec605a1577ec7c8c0cac7a58 is expected to have a rewardTokens field
      ✓ The pool 0x9914bff0437f914549c673b34808af6020e2b453 is expected to have a rewardTokens field (1 ms)
      ✓ The pool 0x02dac4898b2c2ca9d50ff8d6a7726166cf7bcfd0 is expected to have a rewardTokens field
      ✓ The pool 0x360d125366c60ba20dc11ebb7120bdeaa0cc007c is expected to have a rewardTokens field
      ✓ The pool 0x8d90e9c50af206a2757e09b56160991dd7548db9 is expected to have a rewardTokens field
      ✓ The pool 0x9a45b203af044adacced4d95ca3cda020e082c8a is expected to have a rewardTokens field
      ✓ The pool 0xdbd71969ac2583a9a20af3fb81fe9c20547f30f3 is expected to have a rewardTokens field
      ✓ The pool 0x383c69e3bae31ef1d7dc154cd351b0d734537626 is expected to have a rewardTokens field
      ✓ The pool 0x898bf9c743a436c9c3f332af445aad69c15b10b8 is expected to have a rewardTokens field
      ✓ The pool 0x5417f117e4a2283623b3b9a07ec2b2f269d19a75 is expected to have a rewardTokens field
      ✓ The pool 0x13e01d7da7b3f211c6972c331da88c142df571d8 is expected to have a rewardTokens field
      ✓ The pool 0x8f0fd0a3b767a67e992f33063817a2d472eff74f is expected to have a rewardTokens field
      ✓ The pool 0x40b18bc7aee5a03515fcf241ad89d548899fb74f is expected to have a rewardTokens field (1 ms)
      ✓ The pool 0xe7465336baa2efbe52e3e67a8b06a97630d76882 is expected to have a rewardTokens field
      ✓ The pool 0x6b13ddf4d1e1f2e036619920746318fb79f9ea84 is expected to have a rewardTokens field
      ✓ The pool 0x58ad25aa6b14c3fd5921ea5bb731c3b2ade0a099 is expected to have a rewardTokens field
      ✓ The pool 0xc730151a27a4ce6a09d51cfab115233c2e73d471 is expected to have a rewardTokens field
      ✓ The pool 0x57d942953d416835f7b60be2a8b49870cc7bcfe1 is expected to have a rewardTokens field
      ✓ The pool 0x46c3773bd40ba20bd77c3b246783ce941f3db574 is expected to have a rewardTokens field
      ✓ The pool 0x7d7b744cb50eb228fe23bbb29bc5918c507180b7 is expected to have a rewardTokens field
    Check if pool id already used by other project
      ✓ Expect duplicate ids array to be empty

Test Suites: 1 passed, 1 total
Tests:       193 passed, 193 total
Snapshots:   0 total
Time:        0.511 s, estimated 1 s
Ran all test suites.

Nb of pools: 27
 

Sample pools: [
  {
    pool: '0x5f612d4155b1cede2a2cda61146834280f706b78',
    chain: 'astar',
    project: 'avault',
    symbol: 'WSDN-WASTR LP',
    tvlUsd: 2112123.83,
    apy: 26.64,
    rewardTokens: [ '0xccefddff4808f3e1e0340e19e43f1e9fd088b3f2' ],
    underlyingTokens: [
      '0x75364d4f779d0bd0facd9a218c67f87dd9aff3b4',
      '0xaeaaf0e2c81af264101b9129c00f4440ccf0f720'
    ]
  },
  {
    pool: '0xdad1d300e9a6f4f36aed40213ef473fd019704e9',
    chain: 'astar',
    project: 'avault',
    symbol: 'USDC-WASTR LP',
    tvlUsd: 1001834.88,
    apy: 27.15,
    rewardTokens: [ '0xbb1290c1829007f440c771b37718fabf309cd527' ],
    underlyingTokens: [
      '0x6a2d262d56735dba19dd70682b39f6be9a931d98',
      '0xaeaaf0e2c81af264101b9129c00f4440ccf0f720'
    ]
  },
  {
    pool: '0xe66560c1b5faae4e4f77ba40f61f21f4adbb6924',
    chain: 'astar',
    project: 'avault',
    symbol: 'DOT-WASTR LP',
    tvlUsd: 666161.31,
    apy: 28.58,
    rewardTokens: [ '0x40e938688a121370092a06745704c112c5ee5791' ],
    underlyingTokens: [
      '0xffffffffffffffffffffffffffffffffffffffff',
      '0xaeaaf0e2c81af264101b9129c00f4440ccf0f720'
    ]
  },
  {
    pool: '0x8964fae92bb4b79d408e9bd3d48e7c9ecaa5f163',
    chain: 'astar',
    project: 'avault',
    symbol: 'USDT-WASTR LP',
    tvlUsd: 451349.53,
    apy: 12.03,
    rewardTokens: [ '0x806f746a7c4293092ac7aa604347be123322df1e' ],
    underlyingTokens: [
      '0x3795c36e7d12a8c252a20c5a7b455f7c57b60283',
      '0xaeaaf0e2c81af264101b9129c00f4440ccf0f720'
    ]
  },
  {
    pool: '0xc59b9d3ecc93967e697accdbfe9eab74bb3fba22',
    chain: 'astar',
    project: 'avault',
    symbol: 'LAY-WASTR LP',
    tvlUsd: 408334.98,
    apy: 2.12,
    rewardTokens: [ '0x78d5c2adeb11be00033cc4edb2c2889cf945415e' ],
    underlyingTokens: [
      '0xc4335b1b76fa6d52877b3046eca68f6e708a27dd',
      '0xaeaaf0e2c81af264101b9129c00f4440ccf0f720'
    ]
  },
  {
    pool: '0xdaac872a9098ac5620c9d8eaf2dd50fbabc50bb1',
    chain: 'astar',
    project: 'avault',
    symbol: 'WETH-WASTR LP',
    tvlUsd: 290301.58,
    apy: 6.74,
    rewardTokens: [ '0x87988ebde7e661f44eb3a586c5e0ceab533a2d9c' ],
    underlyingTokens: [
      '0x81ecac0d6be0550a00ff064a4f9dd2400585fe9c',
      '0xaeaaf0e2c81af264101b9129c00f4440ccf0f720'
    ]
  },
  {
    pool: '0x945bc42819f4f612d07dabd1d57f10aac494405f',
    chain: 'astar',
    project: 'avault',
    symbol: 'WBTC-WASTR LP',
    tvlUsd: 261162.53,
    apy: 2.07,
    rewardTokens: [ '0x61a49ba86e168cd25ca795b07b0a93236bb25127' ],
    underlyingTokens: [
      '0xad543f18cff85c77e140e3e5e3c3392f6ba9d5ca',
      '0xaeaaf0e2c81af264101b9129c00f4440ccf0f720'
    ]
  },
  {
    pool: '0x347e53263f8fb843ec605a1577ec7c8c0cac7a58',
    chain: 'astar',
    project: 'avault',
    symbol: 'BUSD-USDC LP',
    tvlUsd: 148613.46,
    apy: 17.98,
    rewardTokens: [ '0xeee106aa8a0de519e8eb21c66a5c2275b46b3f4d' ],
    underlyingTokens: [
      '0x4bf769b05e832fcdc9053fffbc78ca889acb5e1e',
      '0x6a2d262d56735dba19dd70682b39f6be9a931d98'
    ]
  },
  {
    pool: '0x9914bff0437f914549c673b34808af6020e2b453',
    chain: 'astar',
    project: 'avault',
    symbol: 'DAI-USDC LP',
    tvlUsd: 128733.15,
    apy: 94.84,
    rewardTokens: [ '0x996d73ac8f97cf15bd476b77cb92ce47ca0e71fe' ],
    underlyingTokens: [
      '0x6de33698e9e9b787e09d3bd7771ef63557e148bb',
      '0x6a2d262d56735dba19dd70682b39f6be9a931d98'
    ]
  },
  {
    pool: '0x02dac4898b2c2ca9d50ff8d6a7726166cf7bcfd0',
    chain: 'astar',
    project: 'avault',
    symbol: 'USDT-USDC LP',
    tvlUsd: 120447.15,
    apy: 19.67,
    rewardTokens: [ '0xd72a602c714ae36d990dc835ea5f96ef87657d5e' ],
    underlyingTokens: [
      '0x3795c36e7d12a8c252a20c5a7b455f7c57b60283',
      '0x6a2d262d56735dba19dd70682b39f6be9a931d98'
    ]
  }
]
```