### PR TITLE
Adding missing harvest.finance assets

### DIFF
--- a/src/adaptors/harvest-finance/index.js
+++ b/src/adaptors/harvest-finance/index.js
@@ -32,7 +32,7 @@ async function apy() {
   // for binance inactive !== true
   for (let chain of Object.keys(chains)) {
     const activeFarms = Object.values(farmsResponse[chain]).filter(
-      (v) => !v.inactive && v.category !== 'INACTIVE'
+      (v) => !v.category?.includes("INACTIVE")
     );
     const farms = activeFarms.map((v) => {
       const s = v.displayName.split(' ');


### PR DESCRIPTION
There are a few assets missing on defi llama's feed, some examples are jJPY/JPYC and jCAD/CADC (both on Polygon).

This happens because `.inactive` field is `true` for quite a few of the pools that are active.

The source of truth for inactivity is the `.category` field, which currently can take 3 values: `INACTIVE`, `POLYGON_INACTIVE`, `BSC_INACTIVE`.
