### PR TITLE
Filtering active assets on Beefy

### DIFF
--- a/src/adaptors/beefy/index.js
+++ b/src/adaptors/beefy/index.js
@@ -66,7 +66,7 @@ const main = async () => {
         project: 'beefy',
         symbol: utils.formatSymbol(pool.split('-').slice(1).join('-')),
         tvlUsd: poolData[pool],
-        apy: apy[pool] * 100,
+        apy: poolMeta?.status == 'active' ? apy[pool] * 100: 0,
         poolMeta:
           platformId === undefined ? null : utils.formatChain(platformId),
       });


### PR DESCRIPTION
Correcting APY values for vaults that are paused, below there is an example of a mismatch (527% on DeFiLlama vs 0% on beefy):

**DeFiLlama**: https://defillama.com/yields/pool/0x659418cc3cf755f5367a51adb586a7f770da6d29-polygon
**Beefy**: https://app.beefy.finance/vault/quick-quick

I am setting APY to 0% for non-active assets (asset status can be `active`, `eol` = retired, `paused`)