### PR TITLE
Use 7day APY for Robo Vault

### DIFF
--- a/src/adaptors/robo-vault/index.js
+++ b/src/adaptors/robo-vault/index.js
@@ -11,7 +11,7 @@ const poolsFunction = async () => {
       project: 'robo-vault',
       symbol: utils.formatSymbol(item.symbol).replace('sAMM-', ''),
       tvlUsd: item.tvlUsd,
-      apy: item.apy3d * 100,
+      apy: item.apy7d * 100,
     }));
 };
 


### PR DESCRIPTION
Change from the 3 day to the 7 day APY for Robo Vault. 

Justification: 
We employ a delta-neutral farming strategy and the returns can be volatile. Most of our users deposit for weeks so the 3 day APY is misleading as it often pumps but doesn't sustain. The 7 day is a good balance of volatility and responsiveness. 