### PR TITLE
Fixing bifi-gov APY

### DIFF
--- a/src/adaptors/beefy/index.js
+++ b/src/adaptors/beefy/index.js
@@ -64,6 +64,8 @@ const main = async () => {
           ? bifiMapping[chain]
           : poolMeta.earnedTokenAddress;
 
+      const isActive = poolMeta === undefined || poolMeta.status == 'active';
+
       if (!poolId) continue;
 
       data.push({
@@ -72,7 +74,7 @@ const main = async () => {
         project: 'beefy',
         symbol: utils.formatSymbol(pool.split('-').slice(1).join('-')),
         tvlUsd: poolData[pool],
-        apy: poolMeta?.status == 'active' ? apy[pool] * 100 : 0,
+        apy: isActive ? apy[pool] * 100 : 0,
         poolMeta:
           platformId === undefined ? null : utils.formatChain(platformId),
       });


### PR DESCRIPTION
Hey, sorry but I missed out on the `bifi-gov` pools on my last PR to set beefy APYs=0 when pools are paused/retired. 

There is a special case that when `poolMeta === undefined` it means the pool is active.

This PR will fix APY differences here:
**Beefy**: https://app.beefy.com/vault/polygon-bifi-gov
**DefiLlama**: https://defillama.com/yields/pool/6a352398-0e6a-488a-be15-22b56323601a