### PR TITLE
fix: utilize contract checksum addr

### DIFF
--- a/src/adaptors/badger-dao/index.js
+++ b/src/adaptors/badger-dao/index.js
@@ -91,7 +91,7 @@ const SUPPORTED_NETWORKS = [
 
 const project = 'badger-dao';
 
-const influenceVaults = ['0xba485b556399123261a5f9c95d413b4f93107407'];
+const influenceVaults = ['0xBA485b556399123261a5F9c95d413B4f93107407'];
 
 async function queryVaults(chain) {
   try {


### PR DESCRIPTION
# Summary

projections do not work for influence vaults, need to properly check graviauara

- fixes check for graviaura addr (5% proj -> 59% historic) 
