### PR TITLE
Fix USDR APY

### DIFF
--- a/src/adaptors/tangible/index.js
+++ b/src/adaptors/tangible/index.js
@@ -19,6 +19,8 @@ const poolsFunction = async () => {
   const apyData = await utils.getData(
     'http://usdr-api.us-east-1.elasticbeanstalk.com/usdr/apy'
   );
+  const usdrAPY = Number(apyData.usdr);
+  const tngblAPY = Number(apyData.tngbl);
 
   const totalSupply = await USDR.totalSupply();
 
@@ -28,8 +30,8 @@ const poolsFunction = async () => {
     project: 'tangible',
     symbol: utils.formatSymbol('USDR'),
     tvlUsd: Number(totalSupply) / 1e9,
-    apy: Number(apyData.usdr),
-    apyReward: Number(apyData.tngbl),
+    apy: usdrAPY + tngblAPY,
+    apyReward: tngblAPY,
     rewardTokens: [TNGBL_ADDRESS],
     underlyingTokens: [USDR_ADDRESS],
   };

--- a/src/adaptors/tangible/index.js
+++ b/src/adaptors/tangible/index.js
@@ -19,8 +19,6 @@ const poolsFunction = async () => {
   const apyData = await utils.getData(
     'http://usdr-api.us-east-1.elasticbeanstalk.com/usdr/apy'
   );
-  const usdrAPY = Number(apyData.usdr);
-  const tngblAPY = Number(apyData.tngbl);
 
   const totalSupply = await USDR.totalSupply();
 
@@ -30,8 +28,8 @@ const poolsFunction = async () => {
     project: 'tangible',
     symbol: utils.formatSymbol('USDR'),
     tvlUsd: Number(totalSupply) / 1e9,
-    apy: usdrAPY + tngblAPY,
-    apyReward: tngblAPY,
+    apyBase: Number(apyData.usdr),
+    apyReward: Number(apyData.tngbl),
     rewardTokens: [TNGBL_ADDRESS],
     underlyingTokens: [USDR_ADDRESS],
   };


### PR DESCRIPTION
The initial commit was using the native token (USDR) APY in the `apy` field. Apparently, this field is supposed to be the total combined APY. This PR fixes that.