### PR TITLE
Update blueshift adapter

### DIFF
--- a/src/adaptors/blueshift/abi.json
+++ b/src/adaptors/blueshift/abi.json
@@ -200,7 +200,7 @@
         },
         {
           "internalType": "uint256",
-          "name": "_block",
+          "name": "_timestamp",
           "type": "uint256"
         }
       ],
@@ -266,7 +266,7 @@
         },
         {
           "internalType": "uint256",
-          "name": "_block",
+          "name": "_timestamp",
           "type": "uint256"
         }
       ],

--- a/src/adaptors/blueshift/index.js
+++ b/src/adaptors/blueshift/index.js
@@ -95,7 +95,7 @@ async function farming(aprWeights, rewardToken, BLUES_PRICE, portfolios) {
     target: MINTER_CONTRACT,
     params: [
       "0x0000000000000000000000000000000000000000",
-      (await sdk.api.util.getLatestBlock("milkomeda")).number
+      (await sdk.api.util.getLatestBlock("milkomeda")).timestamp
     ],
     // block: chainBlocks['milkomeda'],
   })).output;
@@ -192,7 +192,7 @@ async function staking(aprWeights, rewardToken, BLUES_PRICE, portfolios) {
     target: MINTER_CONTRACT,
     params: [
       "0x0000000000000000000000000000000000000000",
-      (await sdk.api.util.getLatestBlock("milkomeda")).number
+      (await sdk.api.util.getLatestBlock("milkomeda")).timestamp
     ],
     // block: chainBlocks['milkomeda'],
   })).output;


### PR DESCRIPTION
Updated Minter smart contract. Some functions now use a timestamp as an argument instead of a block number.