### PR TITLE
improve: Refactor across adapter

### DIFF
--- a/src/adaptors/across/constants.js
+++ b/src/adaptors/across/constants.js
@@ -1,0 +1,18 @@
+const tokens = {
+  WETH: {
+    address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+  },
+  USDC: {
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  },
+  WBTC: {
+    address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+  },
+  DAI: {
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  },
+};
+
+module.exports = {
+  tokens,
+}


### PR DESCRIPTION
No real functional change here - this is mostly just a streamlining of the existing logic. It paves the way for follow-up changes to introduce the Across ACX token as both a direct yield source, as well as a reward token for other Across-supported L1 tokens.

- Factor out constants to constants.js.
- Batch token price requests (n price lookups => 1 price lookup).
- Consolidate arguments to buildPool().
- Reduce duplication and hardcoded response generation in main().