### PR TITLE
Add Across ACX token

### DIFF
--- a/src/adaptors/across/constants.js
+++ b/src/adaptors/across/constants.js
@@ -11,6 +11,9 @@ const tokens = {
   DAI: {
     address: '0x6b175474e89094c44da98b954eedeac495271d0f',
   },
+  ACX: {
+    address: '0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f',
+  },
 };
 
 module.exports = {


### PR DESCRIPTION
The Across ACX token launched yesterday. This PR adds support for displaying the ACX
liquidity pool used for bridging ACX cross-chain. ACX is also used as a reward source for
staking Across LP tokens. A follow-up PR will add support for that.

https://www.coingecko.com/en/coins/across-protocol