### PR TITLE
Add Tortuga protocol on Aptos.

### DIFF
--- a/src/adaptors/tortuga/index.js
+++ b/src/adaptors/tortuga/index.js
@@ -6,11 +6,15 @@ const TGOV_ADDRESS =
   '0x84d7aeef42d38a5ffc3ccef853e1b82e4958659d16a7de736a29c55fbbeb0114';
 const NODE_URL = 'https://fullnode.mainnet.aptoslabs.com/v1';
 const RESOURCE_URL = `${NODE_URL}/accounts/${TGOV_ADDRESS}/resources`;
+const COINS_LLAMA_PRICE_URL = 'https://coins.llama.fi/prices/current/';
+const DECIMALS = 1e8;
+
+const aptosCoinName = 'coingecko:aptos';
 
 async function main() {
   const [resources, aptPrice] = await Promise.all([
     utils.getData(RESOURCE_URL),
-    utils.getData(`https://api.binance.com/api/v3/ticker/price?symbol=APTBUSD`),
+    utils.getData(`${COINS_LLAMA_PRICE_URL}${aptosCoinName}`),
   ]);
 
   const stakingStatus = resources.filter((r) =>
@@ -64,7 +68,10 @@ async function main() {
       chain: utils.formatChain('aptos'),
       project: 'tortuga',
       symbol: utils.formatSymbol('tAPT'),
-      tvlUsd: aptStaked.multipliedBy(aptPrice.price).dividedBy(1e8).toNumber(),
+      tvlUsd: aptStaked
+        .multipliedBy(aptPrice.coins[aptosCoinName].price)
+        .dividedBy(DECIMALS)
+        .toNumber(),
       apy: apy.toNumber(),
     },
   ];

--- a/src/adaptors/tortuga/index.js
+++ b/src/adaptors/tortuga/index.js
@@ -1,0 +1,77 @@
+const { default: BigNumber } = require('bignumber.js');
+
+const utils = require('../utils');
+
+const TGOV_ADDRESS =
+  '0x84d7aeef42d38a5ffc3ccef853e1b82e4958659d16a7de736a29c55fbbeb0114';
+const NODE_URL = 'https://fullnode.mainnet.aptoslabs.com/v1';
+const RESOURCE_URL = `${NODE_URL}/accounts/${TGOV_ADDRESS}/resources`;
+
+async function main() {
+  const [resources, aptPrice] = await Promise.all([
+    utils.getData(RESOURCE_URL),
+    utils.getData(`https://api.binance.com/api/v3/ticker/price?symbol=APTBUSD`),
+  ]);
+
+  const stakingStatus = resources.filter((r) =>
+    r.type.endsWith('StakingStatus')
+  )[0].data;
+
+  const aptosCoinReserve = resources.filter((r) =>
+    r.type.endsWith('AptosCoinReserve')
+  )[0].data;
+
+  const validatorSystem = resources.filter((r) =>
+    r.type.endsWith('ValidatorSystem')
+  )[0].data;
+
+  const tAptCoinInfo = resources.filter((r) =>
+    r.type.endsWith(
+      `CoinInfo<${TGOV_ADDRESS}::staked_aptos_coin::StakedAptosCoin>`
+    )
+  )[0].data;
+
+  const unclaimed_balance = new BigNumber(
+    stakingStatus.total_claims_balance
+  ).minus(BigNumber(stakingStatus.total_claims_balance_cleared));
+
+  const total_balance_with_validators = new BigNumber(
+    validatorSystem.total_balance_with_validators
+  );
+
+  const aptStaked = BigNumber(aptosCoinReserve.coin.value)
+    .plus(total_balance_with_validators)
+    .minus(unclaimed_balance);
+
+  const tAptSupply = new BigNumber(
+    tAptCoinInfo.supply.vec[0].integer.vec[0].value
+  );
+
+  const aptPerTApt = aptStaked.dividedBy(tAptSupply);
+  const secsInYear = 60 * 60 * 24 * 365;
+  const secsSinceDeployment = BigNumber(new Date().valueOf() / 1000).minus(
+    stakingStatus.deployment_time
+  );
+  const apy = aptPerTApt
+    .minus(1)
+    .multipliedBy(secsInYear)
+    .dividedBy(secsSinceDeployment)
+    .multipliedBy(100);
+
+  return [
+    {
+      pool: `${TGOV_ADDRESS}-tortuga`,
+      chain: utils.formatChain('aptos'),
+      project: 'tortuga',
+      symbol: utils.formatSymbol('tAPT'),
+      tvlUsd: aptStaked.multipliedBy(aptPrice.price).dividedBy(1e8).toNumber(),
+      apy: apy.toNumber(),
+    },
+  ];
+}
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+  url: 'https://app.tortuga.finance',
+};


### PR DESCRIPTION
[Tortuga protocol](https://tortuga.finance) is a liquid staking protocol built on Aptos.

The implementation is adapted from the source code from: https://docs.tortuga.finance/product-docs/protocol/reference

Only on-chain data is used, except the price of APT (Aptos chain's native token), which is read from Binance.