### PR TITLE
fix: arrakis vaults APY calculation

### DIFF
--- a/src/adaptors/arrakis-finance/index.js
+++ b/src/adaptors/arrakis-finance/index.js
@@ -32,6 +32,9 @@ const vaultsQuery = gql`
   {
     vaults {
       id
+      apr {
+        averageApr
+      }
       snapshots(orderBy: startTimestamp, orderDirection: desc, first:1) {
         apr
       }
@@ -118,7 +121,7 @@ const getApy = async () => {
         project: 'arrakis-finance',
         symbol: `${vault.token0.symbol}-${vault.token1.symbol}`,
         tvlUsd: tvl || 0,
-        apy: Number(vault.snapshots[0]?.apr),
+        apy: vault.snapshots[0]? Number(vault.snapshots[0].apr) : Number(vault.apr.averageApr),
         url: `https://beta.arrakis.finance/vaults/${CHAIN_IDS[chain]}/${vault.id}`,
         underlyingTokens: [vault.token0.address, vault.token1.address],
       };

--- a/src/adaptors/arrakis-finance/index.js
+++ b/src/adaptors/arrakis-finance/index.js
@@ -32,8 +32,8 @@ const vaultsQuery = gql`
   {
     vaults {
       id
-      apr {
-        averageApr
+      snapshots(orderBy: startTimestamp, orderDirection: desc, first:1) {
+        apr
       }
       token0 {
         symbol
@@ -118,7 +118,7 @@ const getApy = async () => {
         project: 'arrakis-finance',
         symbol: `${vault.token0.symbol}-${vault.token1.symbol}`,
         tvlUsd: tvl || 0,
-        apy: Number(vault.apr.averageApr),
+        apy: Number(vault.snapshots[0].apr),
         url: `https://beta.arrakis.finance/vaults/${CHAIN_IDS[chain]}/${vault.id}`,
         underlyingTokens: [vault.token0.address, vault.token1.address],
       };

--- a/src/adaptors/arrakis-finance/index.js
+++ b/src/adaptors/arrakis-finance/index.js
@@ -118,7 +118,7 @@ const getApy = async () => {
         project: 'arrakis-finance',
         symbol: `${vault.token0.symbol}-${vault.token1.symbol}`,
         tvlUsd: tvl || 0,
-        apy: Number(vault.snapshots[0].apr),
+        apy: Number(vault.snapshots[0]?.apr),
         url: `https://beta.arrakis.finance/vaults/${CHAIN_IDS[chain]}/${vault.id}`,
         underlyingTokens: [vault.token0.address, vault.token1.address],
       };


### PR DESCRIPTION
this PR replaces the `averageApr` queried for the `apr` of the last snapshot took to the pool