### PR TITLE
across: Add ACX as a reward token for LP staking

### DIFF
--- a/src/adaptors/across/abi/AcceleratingDistributor.json
+++ b/src/adaptors/across/abi/AcceleratingDistributor.json
@@ -1,0 +1,503 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_rewardToken", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenCumulativeStaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "Exit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "RecoverErc20",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rewardsToSend",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenLastUpdateTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenRewardPerTokenStored",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "userRewardsOutstanding",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "userRewardsPaidPerToken",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardsWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "averageDepositTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cumulativeBalance",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenCumulativeStaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "Stake",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "baseEmissionRate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxMultiplier",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "secondsToMaxMultiplier",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lastUpdateTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "TokenConfiguredForStaking",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remainingCumulativeBalance",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenCumulativeStaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "Unstake",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" }
+    ],
+    "name": "baseRewardPerToken",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" },
+      { "internalType": "bool", "name": "enabled", "type": "bool" },
+      {
+        "internalType": "uint256",
+        "name": "baseEmissionRate",
+        "type": "uint256"
+      },
+      { "internalType": "uint256", "name": "maxMultiplier", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "secondsToMaxMultiplier",
+        "type": "uint256"
+      }
+    ],
+    "name": "configureStakingToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" }
+    ],
+    "name": "exit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" },
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "getAverageDepositTimePostDeposit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" }
+    ],
+    "name": "getCumulativeStaked",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "getOutstandingRewards",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "getTimeSinceAverageDeposit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "getUserRewardMultiplier",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "getUserStake",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "cumulativeBalance",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "averageDepositTime",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "rewardsAccumulatedPerToken",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "rewardsOutstanding",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct AcceleratingDistributor.UserDeposit",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes[]", "name": "data", "type": "bytes[]" }
+    ],
+    "name": "multicall",
+    "outputs": [
+      { "internalType": "bytes[]", "name": "results", "type": "bytes[]" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "recoverErc20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardToken",
+    "outputs": [
+      { "internalType": "contract IERC20", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "stakingTokens",
+    "outputs": [
+      { "internalType": "bool", "name": "enabled", "type": "bool" },
+      {
+        "internalType": "uint256",
+        "name": "baseEmissionRate",
+        "type": "uint256"
+      },
+      { "internalType": "uint256", "name": "maxMultiplier", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "secondsToMaxMultiplier",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cumulativeStaked",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rewardPerTokenStored",
+        "type": "uint256"
+      },
+      { "internalType": "uint256", "name": "lastUpdateTime", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "unstake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "stakedToken", "type": "address" }
+    ],
+    "name": "withdrawReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/adaptors/across/constants.js
+++ b/src/adaptors/across/constants.js
@@ -1,21 +1,39 @@
-const tokens = {
-  WETH: {
-    address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-  },
-  USDC: {
-    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  },
-  WBTC: {
-    address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-  },
-  DAI: {
-    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
-  },
-  ACX: {
-    address: '0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f',
+const ADContractAbi = require('./abi/AcceleratingDistributor.json');
+
+const SECONDS_PER_YEAR = 31557600; // 365.25 days per year
+
+const contracts = {
+  'AcceleratedDistributor': {
+    address: '0x9040e41ef5e8b281535a96d9a48acb8cfabd9a48',
+    abi: ADContractAbi,
   },
 };
 
+const tokens = {
+  WETH: {
+    address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+    lpAddress: '0x28f77208728b0a45cab24c4868334581fe86f95b',
+  },
+  USDC: {
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    lpAddress: '0xc9b09405959f63f72725828b5d449488b02be1ca',
+  },
+  WBTC: {
+    address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+    lpAddress: '0x59c1427c658e97a7d568541dac780b2e5c8affb4',
+  },
+  DAI: {
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    lpAddress: '0x4fabacac8c41466117d6a38f46d08ddd4948a0cb',
+  },
+  ACX: {
+    address: '0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f',
+    lpAddress: '0xb0c8fef534223b891d4a430e49537143829c4817',
+ },
+};
+
 module.exports = {
+  SECONDS_PER_YEAR,
+  contracts,
   tokens,
 };

--- a/src/adaptors/across/constants.js
+++ b/src/adaptors/across/constants.js
@@ -18,4 +18,4 @@ const tokens = {
 
 module.exports = {
   tokens,
-}
+};

--- a/src/adaptors/across/constants.js
+++ b/src/adaptors/across/constants.js
@@ -3,7 +3,7 @@ const ADContractAbi = require('./abi/AcceleratingDistributor.json');
 const SECONDS_PER_YEAR = 31557600; // 365.25 days per year
 
 const contracts = {
-  'AcceleratedDistributor': {
+  AcceleratedDistributor: {
     address: '0x9040e41ef5e8b281535a96d9a48acb8cfabd9a48',
     abi: ADContractAbi,
   },
@@ -29,7 +29,7 @@ const tokens = {
   ACX: {
     address: '0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f',
     lpAddress: '0xb0c8fef534223b891d4a430e49537143829c4817',
- },
+  },
 };
 
 module.exports = {

--- a/src/adaptors/across/index.js
+++ b/src/adaptors/across/index.js
@@ -1,9 +1,58 @@
-const superagent = require('superagent');
+const { ethers } = require('ethers');
+const { getProvider } = require('@defillama/sdk/build/general');
 const utils = require('../utils');
-const { tokens } = require('./constants');
+const { SECONDS_PER_YEAR, contracts, tokens } = require('./constants');
 
-const buildPool = (token, liquidityPool) => {
-  return {
+const fixedPoint = ethers.utils.parseUnits("1");
+
+const rewardApr = (underlyingToken, stakingPool, rewardToken) => {
+  const { enabled, baseEmissionRate, cumulativeStaked } = stakingPool.stakingTokens;
+
+  if (!enabled) return 0.0;
+
+  // Avoid divide by zero later on.
+  if (cumulativeStaked.eq(0)) return Number.MAX_VALUE;
+
+  const underlyingTokenPrice = ethers.utils.parseUnits(underlyingToken.price.toString());
+  const rewardTokenPrice = ethers.utils.parseUnits(rewardToken.price.toString());
+
+  // Normalise to 18 decimals and convert LP token => underlying token.
+  const cumulativeStakedUsd = cumulativeStaked
+    .mul(ethers.utils.parseUnits("1", 18 - underlyingToken.decimals).toString())
+    .mul(underlyingToken.exchangeRateCurrent)
+    .div(fixedPoint)
+    .mul(underlyingTokenPrice)
+    .div(fixedPoint);
+
+  const rewardsPerYearUsd = baseEmissionRate
+    .mul(ethers.utils.parseUnits("1", 18 - rewardToken.decimals).toString())
+    .mul(SECONDS_PER_YEAR.toString())
+    .mul(rewardTokenPrice)
+    .div(fixedPoint);
+
+  const apr = ethers.utils.formatUnits(
+    rewardsPerYearUsd
+    .mul("100")
+    .mul(fixedPoint)
+    .div(cumulativeStakedUsd)
+  );
+
+  return Number(apr);
+};
+
+const buildPool = (token, tokenPrices, liquidityPool, stakingPool) => {
+  const rewardTokenAddr = stakingPool.rewardToken;
+  const apyReward = rewardApr(
+    {
+      ...token,
+      price: tokenPrices[token.address].price,
+      exchangeRateCurrent: liquidityPool.exchangeRateCurrent
+    },
+    stakingPool,
+    tokenPrices[rewardTokenAddr]
+  ).toFixed(6);
+
+  const poolData = {
     pool: token.address,
     chain: utils.formatChain('ethereum'), // All yield on Mainnet
     project: 'across',
@@ -11,9 +60,16 @@ const buildPool = (token, liquidityPool) => {
     tvlUsd:
       (token.price * Number(liquidityPool.totalPoolSize)) /
       10 ** token.decimals,
-    apyBase: Number(liquidityPool.estimatedApy) * 100,
     underlyingTokens: [token.address],
+    apyBase: Number(liquidityPool.estimatedApy) * 100,
   };
+
+  if (apyReward > 0.0) {
+    poolData["rewardTokens"] = [rewardTokenAddr];
+    poolData["apyReward"] = apyReward;
+  };
+
+  return poolData;
 };
 
 const queryLiquidityPool = async (l1TokenAddr) => {
@@ -33,6 +89,57 @@ const queryLiquidityPools = async (l1TokenAddrs) => {
   );
 };
 
+const queryStakingPool = async (adContract, lpTokenAddr) => {
+  const [
+    baseReward, [
+      enabled,
+      baseEmissionRate,
+      maxMultiplier,
+      secondsToMaxMultiplier,
+      cumulativeStaked,
+      rewardsPerTokenStaked,
+      lastUpdateTime
+    ],
+  ] = await Promise.all([
+    adContract.baseRewardPerToken(lpTokenAddr),
+    adContract.stakingTokens(lpTokenAddr),
+  ]);
+
+  return {
+    baseReward,
+    stakingTokens: {
+      enabled,
+      baseEmissionRate,
+      maxMultiplier,
+      secondsToMaxMultiplier,
+      cumulativeStaked,
+      rewardsPerTokenStaked,
+      lastUpdateTime,
+    },
+  };
+};
+
+const queryStakingPools = async (provider, lpTokenAddrs) => {
+  const { address, abi } = contracts.AcceleratedDistributor
+  const adContract = new ethers.Contract(address, abi, provider);
+  await adContract.connect();
+
+  const rewardToken = (await adContract.rewardToken()).toLowerCase();
+  const pools = Object.fromEntries(
+    await Promise.all(
+      Object.values(lpTokenAddrs).map(async (lpTokenAddr) => {
+        const pool = await queryStakingPool(adContract, lpTokenAddr);
+        return [lpTokenAddr, pool];
+      })
+    )
+  );
+
+  return {
+    rewardToken: rewardToken,
+    pools: pools,
+  };
+};
+
 const l1TokenPrices = async (l1TokenAddrs) => {
   const l1TokenQuery = l1TokenAddrs.map((addr) => `ethereum:${addr}`).join();
   const data = await utils.getData(
@@ -42,18 +149,26 @@ const l1TokenPrices = async (l1TokenAddrs) => {
   return Object.fromEntries(
     l1TokenAddrs.map((addr) => {
       const { decimals, price } = data.coins[`ethereum:${addr}`];
-      return [addr.toLowerCase(), { price, decimals }];
+      return [addr, { price, decimals }];
     })
   );
 };
 
 const main = async () => {
-  const tokenAddrs = Object.values(tokens).map((token) => token.address);
+  const provider = getProvider('ethereum');
 
-  const [liquidityPools, tokenPrices] = await Promise.all([
+  // Note lpTokenAddrs is included in the Across API /pools response. These
+  // LP token addresses are however hardcoded in constants so that the staking
+  // pool lookups can occur in parallel with all other external lookups.
+  const tokenAddrs = Object.values(tokens).map((token) => token.address);
+  const lpTokenAddrs = Object.values(tokens).map((token) => token.lpAddress);
+
+  const [liquidityPools, stakingPools, tokenPrices] = await Promise.all([
     queryLiquidityPools(tokenAddrs),
+    queryStakingPools(provider, lpTokenAddrs),
     l1TokenPrices(tokenAddrs),
   ]);
+
 
   return Object.entries(tokens).map(([symbol, token]) => {
     const { address } = token;
@@ -64,7 +179,12 @@ const main = async () => {
         decimals: tokenPrices[address].decimals,
         price: tokenPrices[address].price,
       },
-      liquidityPools[address]
+      tokenPrices,
+      liquidityPools[address],
+      {
+        rewardToken: stakingPools.rewardToken,
+        ...stakingPools.pools[token.lpAddress],
+      },
     );
   });
 };

--- a/src/adaptors/across/index.js
+++ b/src/adaptors/across/index.js
@@ -2,35 +2,42 @@ const superagent = require('superagent');
 const utils = require('../utils');
 const { tokens } = require('./constants');
 
-const buildPool = (
-  token,
-  liquidityPool,
-) => {
+const buildPool = (token, liquidityPool) => {
   return {
     pool: token.address,
     chain: utils.formatChain('ethereum'), // All yield on Mainnet
     project: 'across',
     symbol: utils.formatSymbol(token.symbol),
-    tvlUsd: (token.price * Number(liquidityPool.totalPoolSize)) / 10 ** token.decimals,
+    tvlUsd:
+      (token.price * Number(liquidityPool.totalPoolSize)) /
+      10 ** token.decimals,
     apyBase: Number(liquidityPool.estimatedApy) * 100,
     underlyingTokens: [token.address],
   };
 };
 
 const queryLiquidityPool = async (l1TokenAddr) => {
-  return await utils.getData(`https://across.to/api/pools?token=${l1TokenAddr}`);
+  return await utils.getData(
+    `https://across.to/api/pools?token=${l1TokenAddr}`
+  );
 };
 
 const queryLiquidityPools = async (l1TokenAddrs) => {
-  const pools = await Promise.all(l1TokenAddrs.map((l1TokenAddr) => queryLiquidityPool(l1TokenAddr)));
+  const pools = await Promise.all(
+    l1TokenAddrs.map((l1TokenAddr) => queryLiquidityPool(l1TokenAddr))
+  );
   return Object.fromEntries(
-    pools.map((pool) => { return [pool.l1Token.toLowerCase(), pool] })
+    pools.map((pool) => {
+      return [pool.l1Token.toLowerCase(), pool];
+    })
   );
 };
 
 const l1TokenPrices = async (l1TokenAddrs) => {
   const l1TokenQuery = l1TokenAddrs.map((addr) => `ethereum:${addr}`).join();
-  const data = await utils.getData(`https://coins.llama.fi/prices/current/${l1TokenQuery}`);
+  const data = await utils.getData(
+    `https://coins.llama.fi/prices/current/${l1TokenQuery}`
+  );
 
   return Object.fromEntries(
     l1TokenAddrs.map((addr) => {
@@ -44,7 +51,8 @@ const main = async () => {
   const tokenAddrs = Object.values(tokens).map((token) => token.address);
 
   const [liquidityPools, tokenPrices] = await Promise.all([
-    queryLiquidityPools(tokenAddrs), l1TokenPrices(tokenAddrs),
+    queryLiquidityPools(tokenAddrs),
+    l1TokenPrices(tokenAddrs),
   ]);
 
   return Object.entries(tokens).map(([symbol, token]) => {
@@ -54,9 +62,9 @@ const main = async () => {
         address,
         symbol,
         decimals: tokenPrices[address].decimals,
-        price: tokenPrices[address].price
+        price: tokenPrices[address].price,
       },
-      liquidityPools[address],
+      liquidityPools[address]
     );
   });
 };

--- a/src/adaptors/across/index.js
+++ b/src/adaptors/across/index.js
@@ -6,8 +6,7 @@ const { SECONDS_PER_YEAR, contracts, tokens } = require('./constants');
 const fixedPoint = ethers.utils.parseUnits('1');
 
 const rewardApr = (underlyingToken, stakingPool, rewardToken) => {
-  const { enabled, baseEmissionRate, cumulativeStaked } =
-    stakingPool.stakingTokens;
+  const { enabled, baseEmissionRate, cumulativeStaked } = stakingPool;
 
   if (!enabled) return 0.0;
 
@@ -91,37 +90,6 @@ const queryLiquidityPools = async (l1TokenAddrs) => {
   );
 };
 
-const queryStakingPool = async (adContract, lpTokenAddr) => {
-  const [
-    baseReward,
-    [
-      enabled,
-      baseEmissionRate,
-      maxMultiplier,
-      secondsToMaxMultiplier,
-      cumulativeStaked,
-      rewardsPerTokenStaked,
-      lastUpdateTime,
-    ],
-  ] = await Promise.all([
-    adContract.baseRewardPerToken(lpTokenAddr),
-    adContract.stakingTokens(lpTokenAddr),
-  ]);
-
-  return {
-    baseReward,
-    stakingTokens: {
-      enabled,
-      baseEmissionRate,
-      maxMultiplier,
-      secondsToMaxMultiplier,
-      cumulativeStaked,
-      rewardsPerTokenStaked,
-      lastUpdateTime,
-    },
-  };
-};
-
 const queryStakingPools = async (provider, lpTokenAddrs) => {
   const { address, abi } = contracts.AcceleratedDistributor;
   const adContract = new ethers.Contract(address, abi, provider);
@@ -131,7 +99,7 @@ const queryStakingPools = async (provider, lpTokenAddrs) => {
   const pools = Object.fromEntries(
     await Promise.all(
       Object.values(lpTokenAddrs).map(async (lpTokenAddr) => {
-        const pool = await queryStakingPool(adContract, lpTokenAddr);
+        const pool = await adContract.stakingTokens(lpTokenAddr);
         return [lpTokenAddr, pool];
       })
     )


### PR DESCRIPTION
Across now offers ACX rewards for ACX, WETH, USDC, DAI and WBTC LPs.

nb. This PR is currently based on https://github.com/DefiLlama/yield-server/pull/468, which only makes changes
to keep prettier happy.