### PR TITLE
Update yield APY to be calculated over 30 days

### DIFF
--- a/src/adaptors/strx-finance/index.js
+++ b/src/adaptors/strx-finance/index.js
@@ -5,8 +5,7 @@ const {
 	GraphQLClient
 } = require('graphql-request');
 
-const client = new GraphQL
-('https://graphql.bitquery.io', {
+const client = new GraphQLClient('https://graphql.bitquery.io', {
 	headers: {
 		'X-API-KEY': 'BQYXycn5sT0mgVrAyf0FjAeMwfGeVEia'
 	}

--- a/src/adaptors/strx-finance/index.js
+++ b/src/adaptors/strx-finance/index.js
@@ -1,21 +1,23 @@
 const utils = require('../utils');
 const {
-    request,
-    gql,
-    GraphQLClient
+	request,
+	gql,
+	GraphQLClient
 } = require('graphql-request');
 
-const client = new GraphQLClient('https://graphql.bitquery.io', {
-    headers: {
-      'X-API-KEY': 'BQYXycn5sT0mgVrAyf0FjAeMwfGeVEia'
-    }
+const client = new GraphQL
+('https://graphql.bitquery.io', {
+	headers: {
+		'X-API-KEY': 'BQYXycn5sT0mgVrAyf0FjAeMwfGeVEia'
+	}
 });
 
 const STAKING_ADDRESS = 'TGrdCu9fu8csFmQptVE25fDzFmPU9epamH';
 const FREEZE_ADDRESS = 'TSTrx3UteLMBdeGe9Edwwi2hLeQCmLPZ5g';
+const DAYS = 30;
 
 async function getRevenue() {
-    const query = gql`
+	const query = gql`
   query {
     tron {
       transfers(
@@ -23,7 +25,7 @@ async function getRevenue() {
         receiver: {is: "${STAKING_ADDRESS}"}
         success: true
         external: true
-        date: {since: "${new Date(new Date()-604800*1000).toISOString()}", till: "${new Date().toISOString()}"}
+        date: {since: "${new Date(new Date()-86400*DAYS*1000).toISOString()}", till: "${new Date().toISOString()}"}
       ) {
         amount
         contractType(contractType: {is: Transfer})
@@ -31,47 +33,52 @@ async function getRevenue() {
     }
   }
   `;
-    const data = await client.request(query);
-    return (data.tron.transfers[0].amount * (10 ** 6));
+	const data = await client.request(query);
+	return (data.tron.transfers[0].amount * (10 ** 6));
 }
 
 async function getTrxBalance(address) {
-    const data = await utils.getData('https://apilist.tronscan.org/api/account?address=' + address);
-    return data.balance + (data.totalFrozen || 0)
+	const data = await utils.getData('https://apilist.tronscan.org/api/account?address=' + address);
+	return data.balance + (data.totalFrozen || 0)
 }
 
 async function getCurrentStake() {
-    let stakingBalance = await getTrxBalance(STAKING_ADDRESS);
-    let frozenBalance = await getTrxBalance(FREEZE_ADDRESS);
-    return stakingBalance + frozenBalance;
+	let postdata = {
+		"contract_address": "414b8a2c619bccb710206b3d11e28dce62d8d72a8b",
+		"owner_address": "4128fb7be6c95a27217e0e0bff42ca50cd9461cc9f",
+		"function_selector": "reservedTRX()",
+		"parameter": "",
+		"call_value": 0
+	};
+	let result = await utils.getData('https://api.trongrid.io/wallet/triggerconstantcontract', postdata);
+	let stake = parseInt(result.constant_result[0], 16);
+	return stake;
 }
 
 async function calcAPY(revenue, stake) {
-    return (revenue * 365 / 7 / stake) * 100;
+	return (revenue * 365 / DAYS / stake) * 100;
 }
 
 const poolsFunction = async () => {
-    const revenue = await getRevenue();
-    const totalStake = await getCurrentStake();
-    const weeklyAPY = await calcAPY(revenue, totalStake);
-    const dataTvl = await utils.getData(
-        'https://api.llama.fi/tvl/strx-finance'
-    );
-
-    const StakingPool = {
-        pool: 'TGrdCu9fu8csFmQptVE25fDzFmPU9epamH',
-        chain: utils.formatChain('tron'),
-        project: 'strx-finance',
-        symbol: utils.formatSymbol('TRX'),
-        tvlUsd: dataTvl,
-        apyBase: Number(weeklyAPY)
-    };
-
-    return [StakingPool];
+	const revenue = await getRevenue();
+	const totalStake = await getCurrentStake();
+	const weeklyAPY = await calcAPY(revenue, totalStake);
+	const dataTvl = await utils.getData(
+		'https://api.llama.fi/tvl/strx-finance'
+	);
+	const StakingPool = {
+		pool: 'TGrdCu9fu8csFmQptVE25fDzFmPU9epamH',
+		chain: utils.formatChain('tron'),
+		project: 'strx-finance',
+		symbol: utils.formatSymbol('TRX'),
+		tvlUsd: dataTvl,
+		apyBase: Number(weeklyAPY)
+	};
+	return [StakingPool];
 };
 
 module.exports = {
-    timetravel: false,
-    apy: poolsFunction,
-    url: "https://app.strx.finance",
+	timetravel: false,
+	apy: poolsFunction,
+	url: "https://app.strx.finance",
 };

--- a/src/adaptors/strx-finance/index.js
+++ b/src/adaptors/strx-finance/index.js
@@ -13,25 +13,25 @@ const client = new GraphQLClient('https://graphql.bitquery.io', {
 
 const STAKING_ADDRESS = 'TGrdCu9fu8csFmQptVE25fDzFmPU9epamH';
 const FREEZE_ADDRESS = 'TSTrx3UteLMBdeGe9Edwwi2hLeQCmLPZ5g';
-const DAYS = 30;
+const DAYS = 1;
 
 async function getRevenue() {
 	const query = gql`
-  query {
-    tron {
-      transfers(
-        currency: {is: "TRX"}
-        receiver: {is: "${STAKING_ADDRESS}"}
-        success: true
-        external: true
-        date: {since: "${new Date(new Date()-86400*DAYS*1000).toISOString()}", till: "${new Date().toISOString()}"}
-      ) {
-        amount
-        contractType(contractType: {is: Transfer})
-      }
-    }
-  }
-  `;
+	  query {
+	    tron {
+	      transfers(
+		currency: {is: "TRX"}
+		receiver: {is: "${STAKING_ADDRESS}"}
+		success: true
+		external: true
+		date: {since: "${new Date(new Date()-86400*DAYS*1000).toISOString()}", till: "${new Date().toISOString()}"}
+	      ) {
+		amount
+		contractType(contractType: {is: Transfer})
+	      }
+	    }
+	  }
+	`;
 	const data = await client.request(query);
 	return (data.tron.transfers[0].amount * (10 ** 6));
 }

--- a/src/adaptors/strx-finance/index.js
+++ b/src/adaptors/strx-finance/index.js
@@ -37,11 +37,6 @@ async function getRevenue() {
 	return (data.tron.transfers[0].amount * (10 ** 6));
 }
 
-async function getTrxBalance(address) {
-	const data = await utils.getData('https://apilist.tronscan.org/api/account?address=' + address);
-	return data.balance + (data.totalFrozen || 0)
-}
-
 async function getCurrentStake() {
 	let postdata = {
 		"contract_address": "414b8a2c619bccb710206b3d11e28dce62d8d72a8b",


### PR DESCRIPTION
This pull request updates the yield APY calculation to be based on a 30 day time period rather than just 7 days. This will provide a more stable APY as it will not fluctuate as much on a daily basis.

Additionally, this PR includes a precise calculation of the total value locked (TVL) using a web3 call.

Changes:
- Update yield APY calculation to use a 30 day time period
- Add web3 call to calculate precise TVL

Benefits:
- More stable APY
- Improved accuracy of TVL calculation