### PR TITLE
fix Stake DAO Liquid Lockers breakdown APRs

### DIFF
--- a/src/adaptors/stakedao/index.js
+++ b/src/adaptors/stakedao/index.js
@@ -92,7 +92,6 @@ const poolsFunction = async () => {
 
         if (strat?.aprBreakdown[2]?.isBribe) {
           apyBase += strat.aprBreakdown[2]?.minApr *100;
-          apyReward += (strat.aprBreakdown[2]?.maxApr - strat.aprBreakdown[2]?.minApr)*100;
         }
       } 
       // calcul for strategies APR


### PR DESCRIPTION
Last push for the Stake DAO Liquid Lockers doesn't have a good breakdown between baseAPR and rewardAPR. This PR fix this.