### PR TITLE
Add BSC chain to SwapFish adaptor

### DIFF
--- a/src/adaptors/swapfish/index.js
+++ b/src/adaptors/swapfish/index.js
@@ -6,9 +6,16 @@ const masterChefABI = require('./abis/masterchef.json');
 const lpABI = require('./abis/lp.json');
 
 const FISH_TOKEN = '0xb348B87b23D5977E2948E6f36ca07E1EC94d7328';
-const MASTERCHEF_ADDRESS = '0x33141e87ad2DFae5FBd12Ed6e61Fa2374aAeD029';
+const CHAINS = {
+    'arbitrum': {
+        'masterchef': '0x33141e87ad2DFae5FBd12Ed6e61Fa2374aAeD029',
+    },
+    'bsc': {
+        'masterchef': '0x671eFBa3F6874485cC39535fa7b525fe764985e9',
+    },
+};
 
-const getPairInfo = async (pair, tokenAddress) => {
+const getPairInfo = async (pair, tokenAddress, chain) => {
   const [tokenSymbol, tokenDecimals] = await Promise.all(
     ['erc20:symbol', 'erc20:decimals'].map((method) =>
       sdk.api.abi.multiCall({
@@ -16,7 +23,7 @@ const getPairInfo = async (pair, tokenAddress) => {
         calls: tokenAddress.map((address) => ({
           target: address,
         })),
-        chain: 'arbitrum',
+        chain: chain,
         requery: true,
       })
     )
@@ -38,10 +45,14 @@ const getPairInfo = async (pair, tokenAddress) => {
   };
 };
 
-const getPrices = async (addresses) => {
+const getPrices = async (addresses, chain) => {
   const prices = (
     await superagent.post('https://coins.llama.fi/prices').send({
-      coins: addresses.map((address) => `arbitrum:${address}`),
+      coins: addresses.map((address) => {
+        // FISH is bridgeable, take price from the main chain
+        const priceChain = (address == FISH_TOKEN)? 'arbitrum' : chain
+        return `${priceChain}:${address}`
+      }),
     })
   ).body.coins;
 
@@ -92,122 +103,127 @@ const calculateReservesUSD = (
 };
 
 const getApy = async () => {
-  const poolLength = await sdk.api.abi.call({
-    target: MASTERCHEF_ADDRESS,
-    chain: 'arbitrum',
-    abi: masterChefABI.find((e) => e.name === 'poolLength'),
-  });
-  const totalAllocPoint = await sdk.api.abi.call({
-    target: MASTERCHEF_ADDRESS,
-    chain: 'arbitrum',
-    abi: masterChefABI.find((e) => e.name === 'totalAllocPoint'),
-  });
-  const FishPerSecond = await sdk.api.abi.call({
-    target: MASTERCHEF_ADDRESS,
-    chain: 'arbitrum',
-    abi: masterChefABI.find((e) => e.name === 'cakePerSecond'),
-  });
-  const normalizedFishPerSecond = FishPerSecond.output / 1e18;
-
-  const poolsRes = await sdk.api.abi.multiCall({
-    abi: masterChefABI.filter(({ name }) => name === 'poolInfo')[0],
-    calls: [...Array(Number(poolLength.output)).keys()].map((i) => ({
-      target: MASTERCHEF_ADDRESS,
-      params: i,
-    })),
-    chain: 'arbitrum',
-    requery: true,
-  });
-
-  const pools = poolsRes.output
-    .map(({ output }, i) => ({ ...output, i }))
-    .filter((e) => e.allocPoint !== '0')
-    .filter(
-      (k) =>
-        ![
-          '0xb348B87b23D5977E2948E6f36ca07E1EC94d7328',
-          '0x666F4429681BeAfE36208FF9D0d16665755f488a',
-        ].includes(k.lpToken)
-    );
-  const lpTokens = pools.map(({ lpToken }) => lpToken);
-
-  const [reservesRes, supplyRes, masterChefBalancesRes] = await Promise.all(
-    ['getReserves', 'totalSupply', 'balanceOf'].map((method) =>
-      sdk.api.abi.multiCall({
-        abi: lpABI.filter(({ name }) => name === method)[0],
-        calls: lpTokens.map((address) => ({
-          target: address,
-          params: method === 'balanceOf' ? [MASTERCHEF_ADDRESS] : null,
-        })),
-        chain: 'arbitrum',
-        requery: true,
-      })
-    )
-  );
-
-  const [underlyingToken0, underlyingToken1] = await Promise.all(
-    ['token0', 'token1'].map((method) =>
-      sdk.api.abi.multiCall({
-        abi: lpABI.filter(({ name }) => name === method)[0],
-        calls: lpTokens.map((address) => ({
-          target: address,
-        })),
-        chain: 'arbitrum',
-        requery: true,
-      })
-    )
-  );
-
-  const reservesData = reservesRes.output.map((res) => res.output);
-  const supplyData = supplyRes.output.map((res) => res.output);
-  const masterChefBalData = masterChefBalancesRes.output.map(
-    (res, i) => res.output
-  );
-  const tokens0 = underlyingToken0.output.map((res) => res.output);
-  const tokens1 = underlyingToken1.output.map((res) => res.output);
-  const tokensPrices = await getPrices([...tokens0, ...tokens1]);
-  const pairInfos = await Promise.all(
-    pools.map((_, index) =>
-      getPairInfo(lpTokens[index], [tokens0[index], tokens1[index]])
-    )
-  );
   const poolsApy = [];
 
-  for (const [i, pool] of pools.entries()) {
-    const pairInfo = pairInfos[i];
-    const poolInfo = pool;
-    const reserves = reservesData[i];
-    const supply = supplyData[i];
-    const masterChefBalance = masterChefBalData[i];
+  for (chain in CHAINS) {
+    masterchefAddress = CHAINS[chain]["masterchef"];
 
-    const masterChefReservesUsd = calculateReservesUSD(
-      reserves,
-      masterChefBalance / supply,
-      pairInfo.token0,
-      pairInfo.token1,
-      tokensPrices
-    )
-      .div(1e18)
-      .toString();
+    const poolLength = await sdk.api.abi.call({
+      target: masterchefAddress,
+      chain: chain,
+      abi: masterChefABI.find((e) => e.name === 'poolLength'),
+    });
+    const totalAllocPoint = await sdk.api.abi.call({
+      target: masterchefAddress,
+      chain: chain,
+      abi: masterChefABI.find((e) => e.name === 'totalAllocPoint'),
+    });
+    const FishPerSecond = await sdk.api.abi.call({
+      target: masterchefAddress,
+      chain: chain,
+      abi: masterChefABI.find((e) => e.name === 'cakePerSecond'),
+    });
+    const normalizedFishPerSecond = FishPerSecond.output / 1e18;
 
-    const apy = calculateApy(
-      poolInfo,
-      totalAllocPoint,
-      normalizedFishPerSecond,
-      tokensPrices[FISH_TOKEN.toLowerCase()],
-      masterChefReservesUsd
+    const poolsRes = await sdk.api.abi.multiCall({
+      abi: masterChefABI.filter(({ name }) => name === 'poolInfo')[0],
+      calls: [...Array(Number(poolLength.output)).keys()].map((i) => ({
+        target: masterchefAddress,
+        params: i,
+      })),
+      chain: chain,
+      requery: true,
+    });
+
+    const pools = poolsRes.output
+      .map(({ output }, i) => ({ ...output, i }))
+      .filter((e) => e.allocPoint !== '0')
+      .filter(
+        (k) =>
+          ![
+            '0xb348B87b23D5977E2948E6f36ca07E1EC94d7328',
+            '0x666F4429681BeAfE36208FF9D0d16665755f488a',
+          ].includes(k.lpToken)
+      );
+    const lpTokens = pools.map(({ lpToken }) => lpToken);
+
+    const [reservesRes, supplyRes, masterChefBalancesRes] = await Promise.all(
+      ['getReserves', 'totalSupply', 'balanceOf'].map((method) =>
+        sdk.api.abi.multiCall({
+          abi: lpABI.filter(({ name }) => name === method)[0],
+          calls: lpTokens.map((address) => ({
+            target: address,
+            params: method === 'balanceOf' ? [masterchefAddress] : null,
+          })),
+          chain: chain,
+          requery: true,
+        })
+      )
     );
 
-    poolsApy.push({
-      pool: pool.lpToken,
-      chain: utils.formatChain('arbitrum'),
-      project: 'swapfish',
-      symbol: `${pairInfo.token0.symbol}-${pairInfo.token1.symbol}`,
-      tvlUsd: Number(masterChefReservesUsd),
-      apyReward: apy,
-      underlyingTokens: [tokens0[i], tokens1[i]],
-      rewardTokens: [FISH_TOKEN],
-    });
+    const [underlyingToken0, underlyingToken1] = await Promise.all(
+      ['token0', 'token1'].map((method) =>
+        sdk.api.abi.multiCall({
+          abi: lpABI.filter(({ name }) => name === method)[0],
+          calls: lpTokens.map((address) => ({
+            target: address,
+          })),
+          chain: chain,
+          requery: true,
+        })
+      )
+    );
+
+    const reservesData = reservesRes.output.map((res) => res.output);
+    const supplyData = supplyRes.output.map((res) => res.output);
+    const masterChefBalData = masterChefBalancesRes.output.map(
+      (res, i) => res.output
+    );
+    const tokens0 = underlyingToken0.output.map((res) => res.output);
+    const tokens1 = underlyingToken1.output.map((res) => res.output);
+    const tokensPrices = await getPrices([...tokens0, ...tokens1], chain);
+    const pairInfos = await Promise.all(
+      pools.map((_, index) =>
+        getPairInfo(lpTokens[index], [tokens0[index], tokens1[index]], chain)
+      )
+    );
+
+    for (const [i, pool] of pools.entries()) {
+      const pairInfo = pairInfos[i];
+      const poolInfo = pool;
+      const reserves = reservesData[i];
+      const supply = supplyData[i];
+      const masterChefBalance = masterChefBalData[i];
+
+      const masterChefReservesUsd = calculateReservesUSD(
+        reserves,
+        masterChefBalance / supply,
+        pairInfo.token0,
+        pairInfo.token1,
+        tokensPrices
+      )
+        .div(1e18)
+        .toString();
+
+      const apy = calculateApy(
+        poolInfo,
+        totalAllocPoint,
+        normalizedFishPerSecond,
+        tokensPrices[FISH_TOKEN.toLowerCase()],
+        masterChefReservesUsd
+      );
+
+      poolsApy.push({
+        pool: pool.lpToken,
+        chain: utils.formatChain(chain),
+        project: 'swapfish',
+        symbol: `${pairInfo.token0.symbol}-${pairInfo.token1.symbol}`,
+        tvlUsd: Number(masterChefReservesUsd),
+        apyReward: apy,
+        underlyingTokens: [tokens0[i], tokens1[i]],
+        rewardTokens: [FISH_TOKEN],
+      });
+    }
   }
 
   return poolsApy;


### PR DESCRIPTION
SwapFish adaptor returns data for Arbitrum chain. This PR adds data for BSC chain.

Website: https://swapfish.fi/
Docs: https://docs.swapfish.fi/swapfish-protocol/protocol-overview
Contract addresses: https://docs.swapfish.fi/security/contracts
Contract code: https://github.com/swapfish/contracts