### PR TITLE
Add FiRM protocol

### DIFF
--- a/src/adaptors/inverse-finance-firm/abi.ts
+++ b/src/adaptors/inverse-finance-firm/abi.ts
@@ -1,0 +1,79 @@
+module.exports = {
+  "balance": {
+    "inputs": [
+    ],
+    "name": "balance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "totalDebt": {
+    "inputs": [
+    ],
+    "name": "totalDebt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "collateralFactorBps": {
+    "inputs": [
+    ],
+    "name": "collateralFactorBps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "borrowPaused": {
+    "inputs": [
+    ],
+    "name": "borrowPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "collateral": {
+    "inputs": [
+    ],
+    "name": "collateral",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "market": [
+    "function totalDebt() public view returns (uint)",
+    "event CreateEscrow(address indexed user, address escrow)",
+  ],
+  "dbr": [
+    "event AddMarket(address indexed market)"
+  ]
+}

--- a/src/adaptors/inverse-finance-firm/index.js
+++ b/src/adaptors/inverse-finance-firm/index.js
@@ -1,0 +1,177 @@
+const ethers = require('ethers');
+const ethersProviders = require('@ethersproject/providers');
+const sdk = require('@defillama/sdk');
+const { providers } = require('@defillama/sdk/build/general');
+const superagent = require('superagent');
+const BigNumber = require("bignumber.js");
+const utils = require('../utils');
+const abi = require('./abi');
+
+const firmStart = 16159015;
+const DBR = '0xAD038Eb671c44b853887A7E32528FaB35dC5D710';
+
+const l1TokenPrices = async (l1TokenAddrs) => {
+  const l1TokenQuery = l1TokenAddrs.map((addr) => `ethereum:${addr}`).join();
+  const data = await utils.getData(
+    `https://coins.llama.fi/prices/current/${l1TokenQuery}`
+  );
+
+  return Object.fromEntries(
+    l1TokenAddrs.map((addr) => {
+      const { decimals, price, symbol } = data.coins[`ethereum:${addr}`];
+      return [addr, { price, decimals, symbol }];
+    })
+  );
+};
+
+const getFirmMarkets = async (dbrContract) => {
+  const logs = await dbrContract.queryFilter(dbrContract.filters.AddMarket());
+  return logs.map(l => l.args.market);
+}
+
+const getFirmEscrowsWithMarket = async (markets, provider) => {
+  const escrowCreations = await Promise.all(
+    markets.map(m => {
+      const market = new ethers.Contract(m, abi.market, provider);
+      return market.queryFilter(market.filters.CreateEscrow(), firmStart);
+    })
+  );
+
+  const escrowsWithMarkets = escrowCreations.map((marketEscrows, marketIndex) => {
+    const market = markets[marketIndex];
+    return marketEscrows.map(escrowCreationEvent => {
+      return { escrow: escrowCreationEvent.args[1], market }
+    })
+  }).flat();
+
+  return escrowsWithMarkets;
+}
+
+const main = async () => {
+  const balances = {};
+
+  const provider = providers.ethereum;
+
+  const dbrContract = new ethers.Contract(DBR, abi.dbr, provider);
+  const markets = await getFirmMarkets(dbrContract);
+
+  const escrowsWithMarkets = await getFirmEscrowsWithMarket(markets, provider);
+
+  const allBalances = (
+    await sdk.api.abi.multiCall({
+      chain: 'ethereum',
+      calls: escrowsWithMarkets.map(
+        (em) => ({
+          target: em.escrow,
+          params: [],
+        })
+      ),
+      abi: abi.balance,
+    })
+  ).output;
+
+  const allUnderlying = (
+    await sdk.api.abi.multiCall({
+      chain: 'ethereum',
+      calls: markets.map(
+        (m) => ({
+          target: m,
+          params: [],
+        })
+      ),
+      abi: abi.collateral,
+    })
+  ).output;
+
+  const underlyings = allUnderlying.map(u => u.output);
+
+  const allDebt = (
+    await sdk.api.abi.multiCall({
+      chain: 'ethereum',
+      calls: markets.map(
+        (m) => ({
+          target: m,
+          params: [],
+        })
+      ),
+      abi: abi.totalDebt,
+    })
+  ).output;
+
+  const allCfs = (
+    await sdk.api.abi.multiCall({
+      chain: 'ethereum',
+      calls: markets.map(
+        (m) => ({
+          target: m,
+          params: [],
+        })
+      ),
+      abi: abi.collateralFactorBps,
+    })
+  ).output;  
+  
+  const allBorrowPaused = (
+    await sdk.api.abi.multiCall({
+      chain: 'ethereum',
+      calls: markets.map(
+        (m) => ({
+          target: m,
+          params: [],
+        })
+      ),
+      abi: abi.borrowPaused,
+    })
+  ).output;
+
+  const addressesToPrice = underlyings.concat([DBR]);
+  const prices = await l1TokenPrices(addressesToPrice);
+
+  allBalances.map((b, i) => {
+    const market = escrowsWithMarkets[i].market;
+    if (!balances[market]) {
+      balances[market] = BigNumber(0);
+    }
+    balances[market] = balances[market].plus(b.output);
+  });
+
+  // the current fixed borrow rate is always directly related to DBR's current price
+  // (1 DBR allows to borrow 1 DOLA for one year)
+  const currentFixedRate = prices[DBR].price * 100;
+
+  const pools = markets.map((m, marketIndex) => {
+    const underlying = allUnderlying.find(u => u.input.target === m).output;
+    const decimals = prices[underlying].decimals;
+    const symbol = prices[underlying].symbol;
+    const totalSupplyUsd = (Number(balances[m]) / (10 ** decimals)) * prices[underlying].price;
+    const totalBorrowUsd = Number(allDebt[marketIndex].output) / 1e18;
+    return {
+      pool: `firm-${m}`,
+      chain: 'Ethereum',
+      project: 'inverse-finance-firm',
+      symbol,
+      tvlUsd: totalSupplyUsd - totalBorrowUsd,
+      apyBase: 0,
+      apyReward: 0,
+      rewardTokens: [],
+      underlyingTokens: [underlying],
+      poolMeta: 'Fixed Borrow Rate',
+      url: 'https://inverse.finance/firm/'+symbol,
+      apyBaseBorrow: currentFixedRate,
+      apyRewardBorrow: 0,      
+      // === new attribute request: isFixedBorrowRate to then be able to filter by fixed-rate in the borrow aggregator ===
+      isFixedBorrowRate: true,      
+      totalSupplyUsd,
+      totalBorrowUsd,
+      borrowable: !allBorrowPaused[marketIndex].output,
+      ltv: Number(allCfs[marketIndex].output) / 1e4,
+    }
+  })
+  
+  return pools
+};
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+};

--- a/src/adaptors/inverse-finance-firm/index.js
+++ b/src/adaptors/inverse-finance-firm/index.js
@@ -138,7 +138,7 @@ const main = async () => {
     })
   ).output;
 
-  const addressesToPrice = underlyings.concat([DBR]);
+  const addressesToPrice = underlyings.concat([DBR, DOLA]);
   const prices = await l1TokenPrices(addressesToPrice);
 
   allBalances.map((b, i) => {
@@ -159,7 +159,7 @@ const main = async () => {
     const symbol = prices[underlying].symbol;
     const totalSupplyUsd = (Number(balances[m]) / (10 ** decimals)) * prices[underlying].price;
     const totalBorrowUsd = Number(allDebt[marketIndex].output) / 1e18;
-    const debtCeilingUsd = Number(allLiquidity[marketIndex].output) / 1e18;
+    const debtCeilingUsd = Number(allLiquidity[marketIndex].output) / 1e18 * prices[DOLA].price;
     return {
       pool: `firm-${m}`,
       chain: 'Ethereum',


### PR DESCRIPTION
Related to:
https://github.com/DefiLlama/DefiLlama-Adapters/pull/5045
https://github.com/DefiLlama/defillama-server/pull/1905

Adds FiRM's markets

I added a new attribute regarding lending: `isFixedBorrowRate`, hopefully we can then use this later on in the frontend to filter by "fixed-rate only", in the borrow aggregator for example, let me know what you think, the attribute name can be different ofc.

Code is using `queryFilter` which requires a provider supporting past events like alchemy, I didn't see a way to customize the provider in the env files, for my local tests I used a custom `AlchemyProvider` instead of the`providers.ethereum` you can see in the PR.
