### PR TITLE
Sommelier: Update v2 cellar apy calculation to handle launches

### DIFF
--- a/src/adaptors/sommelier/config.js
+++ b/src/adaptors/sommelier/config.js
@@ -1,6 +1,9 @@
 const chain = 'ethereum';
 const project = 'sommelier';
 
+// Addresses
+const realYieldUsd = '0x97e6e0a40a3d02f12d1cec30ebfbae04e37c119e';
+
 // Rewards are paid out in EVM SOMM
 const rewardTokens = ['0xa670d7237398238de01267472c6f13e5b8010fd1'];
 
@@ -20,8 +23,12 @@ const stakingPools = {
     '0x74a9a6fab61e128246a6a5242a3e96e56198cbdd',
   '0x05641a27c82799aaf22b436f20a3110410f29652':
     '0x7da7e27e4bcc6ec8bc06349e1cef6634f6df7c5c',
-  '0x97e6e0a40a3d02f12d1cec30ebfbae04e37c119e':
-    '0x8510f22bd1932afb4753b6b3edf5db00c7e7a748',
+  [realYieldUsd]: '0x8510f22bd1932afb4753b6b3edf5db00c7e7a748',
+};
+
+// Date when cellar was launched
+const launchEpochs = {
+  [realYieldUsd]: 1674604800,
 };
 
 // List of v0815 Cellars
@@ -125,7 +132,7 @@ const v0816Pools = [
 
 const v2Pools = [
   {
-    pool: '0x97e6e0a40a3d02f12d1cec30ebfbae04e37c119e-ethereum',
+    pool: `${realYieldUsd}-ethereum`,
     chain,
     project,
     symbol: 'USDC-USDT-DAI',
@@ -141,6 +148,7 @@ const v2Pools = [
 
 module.exports = {
   chain,
+  launchEpochs,
   project,
   rewardTokens,
   stakingPools,

--- a/src/adaptors/sommelier/config.js
+++ b/src/adaptors/sommelier/config.js
@@ -26,11 +26,6 @@ const stakingPools = {
   [realYieldUsd]: '0x8510f22bd1932afb4753b6b3edf5db00c7e7a748',
 };
 
-// Date when cellar was launched
-const launchEpochs = {
-  [realYieldUsd]: 1674604800,
-};
-
 // List of v0815 Cellars
 const v0815Pools = [
   {
@@ -148,7 +143,6 @@ const v2Pools = [
 
 module.exports = {
   chain,
-  launchEpochs,
   project,
   rewardTokens,
   stakingPools,

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -4,7 +4,6 @@ const utils = require('../utils');
 
 const {
   chain,
-  launchEpochs,
   rewardTokens,
   stakingPools,
   v0815Pools,
@@ -80,7 +79,7 @@ async function handleV2(pool, sommPrice) {
   const underlyingTokens = await v2.getUnderlyingTokens(cellarAddress);
   const asset = await v2.getHoldingPosition(cellarAddress);
   const apyReward = await getRewardApy(stakingPools[cellarAddress], sommPrice);
-  const apyBase = await v2.getApy(cellarAddress, launchEpochs[cellarAddress]);
+  const apyBase = await v2.getApy(cellarAddress);
 
   // getTvlUsd implementation hasn't changed since v1.5 (v0.8.16)
   const tvlUsd = await v0816.getTvlUsd(cellarAddress, asset);

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -4,6 +4,7 @@ const utils = require('../utils');
 
 const {
   chain,
+  launchEpochs,
   rewardTokens,
   stakingPools,
   v0815Pools,
@@ -79,10 +80,10 @@ async function handleV2(pool, sommPrice) {
   const underlyingTokens = await v2.getUnderlyingTokens(cellarAddress);
   const asset = await v2.getHoldingPosition(cellarAddress);
   const apyReward = await getRewardApy(stakingPools[cellarAddress], sommPrice);
+  const apyBase = await v2.getApy(cellarAddress, launchEpochs[cellarAddress]);
 
-  // getTvlUsd and getApy implementation hasn't changed since v1.5 (v0.8.16)
+  // getTvlUsd implementation hasn't changed since v1.5 (v0.8.16)
   const tvlUsd = await v0816.getTvlUsd(cellarAddress, asset);
-  const apyBase = await v0816.getApy(cellarAddress);
 
   return {
     ...pool,

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -80,6 +80,7 @@ async function handleV2(pool, sommPrice) {
   const asset = await v2.getHoldingPosition(cellarAddress);
   const apyReward = await getRewardApy(stakingPools[cellarAddress], sommPrice);
   const apyBase = await v2.getApy(cellarAddress);
+  const apyBase7d = await v2.getApy7d(cellarAddress);
 
   // getTvlUsd implementation hasn't changed since v1.5 (v0.8.16)
   const tvlUsd = await v0816.getTvlUsd(cellarAddress, asset);
@@ -88,6 +89,7 @@ async function handleV2(pool, sommPrice) {
     ...pool,
     tvlUsd,
     apyBase,
+    apyBase7d,
     apyReward,
     underlyingTokens,
     poolMeta:

--- a/src/adaptors/sommelier/queries.js
+++ b/src/adaptors/sommelier/queries.js
@@ -24,6 +24,29 @@ async function getDayData(cellarAddress, numDays) {
   return data.cellarDayDatas;
 }
 
+const hourDataQuery = gql`
+  {
+    cellarHourDatas(
+      where: {cellar: "<CELLAR>" }
+      orderDirection: desc
+      orderBy: date, first: <DAYS>
+    ) {
+      date
+      shareValue
+    }
+  }
+`;
+
+async function getHourData(cellarAddress, numHours) {
+  let query = hourDataQuery.replace('<CELLAR>', cellarAddress);
+  query = query.replace('<DAYS>', numHours);
+
+  const data = await request(url, query);
+
+  return data.cellarHourDatas;
+}
+
 module.exports = {
   getDayData,
+  getHourData,
 };

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -1,3 +1,4 @@
+const { default: BigNumber } = require('bignumber.js');
 const sdk = require('@defillama/sdk');
 const queries = require('./queries');
 const cellarAbi = require('./cellar-v2.json');
@@ -9,6 +10,50 @@ const abiAsset = cellarAbi.find((el) => el.name === 'asset');
 const getPositionAssets = cellarAbi.find(
   (el) => el.name === 'getPositionAssets'
 );
+
+const dayInSecs = 60 * 60 * 24;
+const windowInDays = 7;
+
+// Use the change in price over 7 days to calculate an APR
+// If the cellar has been live for less than 7 days use the
+// number of days since launch.
+async function getApy(cellarAddress, launchEpoch) {
+  // Returns dayData in desc order, today is index 0
+  const dayData = await queries.getDayData(cellarAddress, windowInDays);
+
+  // Need a minimum of 2 days to calculate yield
+  if (dayData.length < 2) {
+    return 0;
+  }
+
+  let numDays = dayData.length;
+  let previousDayIdx = numDays - 1;
+
+  const windowDaysAfterLaunch = dayInSecs * windowInDays + launchEpoch;
+
+  // We are less than a week since launch, calculate APR using
+  // days since launch as the window
+  if (numDays < windowInDays || dayData[0].date < windowDaysAfterLaunch) {
+    const launchDayIdx = dayData.findIndex((data) => data.date === launchEpoch);
+
+    if (launchDayIdx === -1) {
+      // Noop, leaving a comment to describe behavior
+      // We should have found the launch day data, but the epoch must have been configured incorrectly
+      // in src/adaptors/sommelier/config.js. Use window based on number of day datas returned by subgraph.
+    } else {
+      // We found the launch day data. Determine how many days have elapsed.
+      numDays = launchDayIdx + 1;
+      previousDayIdx = launchDayIdx;
+    }
+  }
+
+  const windowsInYear = 365 / numDays; // Normally ~52 unless we are less than a week since launch
+  const price = new BigNumber(dayData[0].shareValue); // Now price
+  const prevPrice = new BigNumber(dayData[previousDayIdx].shareValue); // Comparison price
+  const yieldRatio = price.minus(prevPrice).div(prevPrice);
+
+  return yieldRatio.times(windowsInYear).times(100).toNumber();
+}
 
 // Call getPositionAssets to get all the credit position's underlying assets
 async function getUnderlyingTokens(cellarAddress) {
@@ -37,6 +82,7 @@ async function getHoldingPosition(cellarAddress) {
 }
 
 module.exports = {
-  getUnderlyingTokens,
+  getApy,
   getHoldingPosition,
+  getUnderlyingTokens,
 };

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -43,6 +43,24 @@ async function getApy(cellarAddress) {
   return yieldRatio.times(365).times(100).toNumber();
 }
 
+const windowInDays = 7;
+
+async function getApy7d(cellarAddress) {
+  // Returns dayData in desc order, today is index 0
+  const dayData = await queries.getDayData(cellarAddress, windowInDays);
+
+  // Need a minimum of 7 days to calculate yield
+  if (dayData.length < 7) {
+    return 0;
+  }
+
+  const price = new BigNumber(dayData[0].shareValue); // Now price
+  const prevPrice = new BigNumber(dayData[dayData.length - 1].shareValue); // Comparison price
+  const yieldRatio = price.minus(prevPrice).div(prevPrice);
+
+  return yieldRatio.times(52).times(100).toNumber();
+}
+
 // Call getPositionAssets to get all the credit position's underlying assets
 async function getUnderlyingTokens(cellarAddress) {
   const assets = (
@@ -71,6 +89,7 @@ async function getHoldingPosition(cellarAddress) {
 
 module.exports = {
   getApy,
+  getApy7d,
   getHoldingPosition,
   getUnderlyingTokens,
 };

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -11,48 +11,36 @@ const getPositionAssets = cellarAbi.find(
   (el) => el.name === 'getPositionAssets'
 );
 
-const dayInSecs = 60 * 60 * 24;
-const windowInDays = 7;
+const windowInHrs = 48; // 2 days
 
-// Use the change in price over 7 days to calculate an APR
-// If the cellar has been live for less than 7 days use the
-// number of days since launch.
-async function getApy(cellarAddress, launchEpoch) {
-  // Returns dayData in desc order, today is index 0
-  const dayData = await queries.getDayData(cellarAddress, windowInDays);
+// Use the change in avg daily price between the last 2 days to calculate an APR
+// If there isn't at least 48 hours of hour data then we shold set the pool property
+// `apyBaseInception` to the backtested APY
+async function getApy(cellarAddress) {
+  // Returns hourData in desc order, current hour is index 0
+  const hrData = await queries.getHourData(cellarAddress, windowInHrs);
 
-  // Need a minimum of 2 days to calculate yield
-  if (dayData.length < 2) {
+  // Need a minimum of 2 days of data to calculate yield
+  if (hrData.length < 48) {
     return 0;
   }
 
-  let numDays = dayData.length;
-  let previousDayIdx = numDays - 1;
+  // Sum hourly price of the last 2 days individually
+  let sumPrice = new BigNumber(0);
+  let sumPrevPrice = new BigNumber(0);
+  for (let i = 0; i < 24; i++) {
+    // Current 24hrs
+    sumPrice = sumPrice.plus(hrData[i].shareValue);
 
-  const windowDaysAfterLaunch = dayInSecs * windowInDays + launchEpoch;
-
-  // We are less than a week since launch, calculate APR using
-  // days since launch as the window
-  if (numDays < windowInDays || dayData[0].date < windowDaysAfterLaunch) {
-    const launchDayIdx = dayData.findIndex((data) => data.date === launchEpoch);
-
-    if (launchDayIdx === -1) {
-      // Noop, leaving a comment to describe behavior
-      // We should have found the launch day data, but the epoch must have been configured incorrectly
-      // in src/adaptors/sommelier/config.js. Use window based on number of day datas returned by subgraph.
-    } else {
-      // We found the launch day data. Determine how many days have elapsed.
-      numDays = launchDayIdx + 1;
-      previousDayIdx = launchDayIdx;
-    }
+    // Previous 24hrs
+    sumPrevPrice = sumPrevPrice.plus(hrData[i + 24].shareValue);
   }
 
-  const windowsInYear = 365 / numDays; // Normally ~52 unless we are less than a week since launch
-  const price = new BigNumber(dayData[0].shareValue); // Now price
-  const prevPrice = new BigNumber(dayData[previousDayIdx].shareValue); // Comparison price
+  const price = sumPrice.div(24);
+  const prevPrice = sumPrevPrice.div(24);
   const yieldRatio = price.minus(prevPrice).div(prevPrice);
 
-  return yieldRatio.times(windowsInYear).times(100).toNumber();
+  return yieldRatio.times(365).times(100).toNumber();
 }
 
 // Call getPositionAssets to get all the credit position's underlying assets


### PR DESCRIPTION
Couple of changes and context here:
- Going forward we will only be launching v2 or newer cellars.
- We'd like to calculate the APY for v2 cellars over 7 days
- For newly launched cellars we will use the window since launch day to calculate APY

Previously, we calculated an APY over 30 days but this was incorrect since we did not have 30 days of data. Our APY was under reported. This should fix that as well as report correct APYs for new cellar launches in the future.