### PR TITLE
Use data from completed day to calculate daily APY

### DIFF
--- a/src/adaptors/sommelier/backfill.js
+++ b/src/adaptors/sommelier/backfill.js
@@ -1,0 +1,44 @@
+const { calcApy } = require('./v2.js');
+const { v2Pools } = require('./config.js');
+
+const cellarAddress = v2Pools[0].pool.split('-')[0];
+
+const launchDate = new Date('2023-01-27T00:00:00.000Z');
+
+const dayInSec = 60 * 60 * 24;
+const dayInMs = dayInSec * 1000;
+
+const days = [];
+
+// Generate days
+let day = new Date();
+while (day > launchDate) {
+  const epochSec = day.getTime();
+  const remainder = epochSec % dayInMs;
+  const start = new Date(
+    remainder === 0 ? epochSec - dayInMs : epochSec - remainder
+  );
+
+  days.push(start);
+  day = start;
+}
+
+// Convert to epoch seconds
+const epochs = days.map((day) => Math.floor(day.getTime() / 1000));
+
+// Get apys
+const promises = epochs.map((epoch) => {
+  // Today's APY is calculated from yesterday's gains
+  const end = epoch - 1;
+  const start = epoch - dayInSec - dayInSec;
+
+  return calcApy(cellarAddress, start, end);
+});
+
+(async function () {
+  const apys = await Promise.all(promises);
+
+  for (let i = days.length - 1; i >= 0; i--) {
+    console.log(days[i].toISOString(), apys[i]);
+  }
+})();

--- a/src/adaptors/sommelier/backfill.js
+++ b/src/adaptors/sommelier/backfill.js
@@ -29,8 +29,8 @@ const epochs = days.map((day) => Math.floor(day.getTime() / 1000));
 // Get apys
 const promises = epochs.map((epoch) => {
   // Today's APY is calculated from yesterday's gains
-  const end = epoch - 1;
-  const start = epoch - dayInSec - dayInSec;
+  const end = epoch - 1; // <date>T11:59:99.000
+  const start = epoch - dayInSec - dayInSec; // <date -1>T00:00:00.000
 
   return calcApy(cellarAddress, start, end);
 });

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -22,10 +22,10 @@ async function main() {
     .pricesBySymbol.somm;
 
   let promises = [];
-  promises = v0815Pools.map((pool) => handleV0815(pool, sommPrice));
-  promises = promises.concat(
-    v0816Pools.map((pool) => handleV0816(pool, sommPrice))
-  );
+  // promises = v0815Pools.map((pool) => handleV0815(pool, sommPrice));
+  // promises = promises.concat(
+  //   v0816Pools.map((pool) => handleV0816(pool, sommPrice))
+  // );
   promises = promises.concat(v2Pools.map((pool) => handleV2(pool, sommPrice)));
 
   const pools = await Promise.all(promises);

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -22,10 +22,10 @@ async function main() {
     .pricesBySymbol.somm;
 
   let promises = [];
-  // promises = v0815Pools.map((pool) => handleV0815(pool, sommPrice));
-  // promises = promises.concat(
-  //   v0816Pools.map((pool) => handleV0816(pool, sommPrice))
-  // );
+  promises = v0815Pools.map((pool) => handleV0815(pool, sommPrice));
+  promises = promises.concat(
+    v0816Pools.map((pool) => handleV0816(pool, sommPrice))
+  );
   promises = promises.concat(v2Pools.map((pool) => handleV2(pool, sommPrice)));
 
   const pools = await Promise.all(promises);

--- a/src/adaptors/sommelier/queries.js
+++ b/src/adaptors/sommelier/queries.js
@@ -27,9 +27,9 @@ async function getDayData(cellarAddress, numDays) {
 const hourDataQuery = gql`
   {
     cellarHourDatas(
-      where: {cellar: "<CELLAR>" }
+      where: {cellar: "<CELLAR>", date_gte: <START>, date_lte: <END> }
       orderDirection: desc
-      orderBy: date, first: <DAYS>
+      orderBy: date
     ) {
       date
       shareValue
@@ -37,9 +37,10 @@ const hourDataQuery = gql`
   }
 `;
 
-async function getHourData(cellarAddress, numHours) {
+async function getHourData(cellarAddress, startDate, endDate) {
   let query = hourDataQuery.replace('<CELLAR>', cellarAddress);
-  query = query.replace('<DAYS>', numHours);
+  query = query.replace('<START>', startDate);
+  query = query.replace('<END>', endDate);
 
   const data = await request(url, query);
 

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -59,7 +59,7 @@ async function getApy(cellarAddress) {
   const end = now - remainder - 1;
   const start = end - dayInSec - dayInSec + 1;
 
-  return calcApy(start, end);
+  return calcApy(cellarAddress, start, end);
 }
 
 const windowInDays = 7;


### PR DESCRIPTION
Previously we were using the last 48 hours of data to calculate the daily APY. The team would like to only use data from a fully completed day, aka using the yield from the previous day.

There is also a `backfill.js` script that utilizes the fn that implements this methodology. I can remove it once you are done with the data fix. @slasher125. Just run `node src/adapters/sommelier/backfill.js` to get an output of all the APYs of the Real Yield USD cellar since inception.

Here are the dates we'd like to correct:
```bash
2023-01-27T00:00:00.000Z 6.993695306389211
2023-01-28T00:00:00.000Z 6.811426985205848
2023-01-29T00:00:00.000Z 14.587111171508859
2023-01-30T00:00:00.000Z 5.748332288613453
2023-01-31T00:00:00.000Z 5.249104084084564
2023-02-01T00:00:00.000Z 9.714383171887867
```