### PR TITLE
Update endpoint decoding for HedgeFarm Alpha 2

### DIFF
--- a/src/adaptors/hedgefarm/index.js
+++ b/src/adaptors/hedgefarm/index.js
@@ -82,7 +82,7 @@ const poolsFunction = async () => {
     project: 'hedgefarm',
     symbol: utils.formatSymbol('BTC.b'),
     tvlUsd: balanceAlpha2 / 1e8 * btcbTokenPrice,
-    apy: alpha2ApyData.historicalPerformance.apy * 100,
+    apy: alpha2ApyData.last24hApy * 100,
   };
 
   return [alpha1, alpha2];


### PR DESCRIPTION
We had to change our API endpoint response for our website which results in this change for our adapter.
It is still the APY generated over the last 24 hours.