### PR TITLE
feat: yield-protocol adaptor

### DIFF
--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -169,12 +169,8 @@ const getPools = async (chain) => {
             );
       const apy = sharesTokenAPY + +fyTokenInterestAPR + +feeAPR;
 
-      // extra data
-      const maturityFormatted = formatMaturity(maturity);
-      const name = `${poolAddr}-${chain}`.toLowerCase();
-
       return {
-        pool: name,
+        pool: `${poolAddr}-${chain}`.toLowerCase(),
         chain: formatChain(chain),
         project: 'yield-protocol',
         symbol: formatSymbol(`${fyTokenSymbol}LP`),
@@ -187,7 +183,7 @@ const getPools = async (chain) => {
         totalSupplyUsd,
         totalBorrowUsd,
         url: `https://app.yieldprotocol.com/`,
-        poolMeta: maturityFormatted,
+        poolMeta: formatMaturity(maturity),
       };
     })
   );

--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -167,7 +167,7 @@ const getPools = async (chain) => {
               baseReserves, // when pool is tv, this is actually shares
               currentSharePrice
             );
-      const apy = sharesTokenAPY + fyTokenInterestAPR + feeAPR;
+      const apy = sharesTokenAPY + +fyTokenInterestAPR + +feeAPR;
 
       // extra data
       const maturityFormatted = formatMaturity(maturity);

--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -173,7 +173,7 @@ const getPools = async (chain) => {
         pool: `${poolAddr}-${chain}`.toLowerCase(),
         chain: formatChain(chain),
         project: 'yield-protocol',
-        symbol: formatSymbol(`${fyTokenSymbol}LP`),
+        symbol: baseSymbol,
         underlyingTokens: [baseAddr, fyTokenAddr],
         apy, // liquidity providing apy estimate
         apyReward: 0, // TODO: pool/strategy reward apy estimate

--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -1,0 +1,125 @@
+const { request, gql } = require('graphql-request');
+const { formatChain, formatSymbol } = require('../utils');
+const superagent = require('superagent');
+const { format } = require('date-fns');
+const { compact } = require('lodash');
+
+// TODO
+// add symbol, totalBorrowed on pool in subgraph
+
+const SUBGRAPH_BASE = 'https://api.thegraph.com/subgraphs/name/yieldprotocol/';
+
+const SUBGRAPHS = {
+  ethereum: `${SUBGRAPH_BASE}v2-mainnet`,
+  arbitrum: `${SUBGRAPH_BASE}v2-arbitrum`,
+};
+
+const formatMaturity = (maturity) => {
+  return format(new Date(maturity * 1000), 'dd MMM yyyy');
+};
+
+const getPools = async (chain) => {
+  const url = SUBGRAPHS[chain];
+  const query = gql`
+    {
+      pools {
+        id
+        base
+        fyToken {
+          id
+          totalSupply
+          maturity
+        }
+        currentFYTokenPriceInBase
+        tvlInBase
+      }
+      _meta {
+        block {
+          timestamp
+        }
+      }
+    }
+  `;
+
+  const {
+    pools: subgraphPools,
+    _meta: {
+      block: { timestamp },
+    },
+  } = await request(url, query);
+
+  const pools = await Promise.all(
+    subgraphPools.map(async (pool) => {
+      const {
+        id: poolAddress,
+        // symbol: poolSymbol,
+        base: baseAddr,
+        fyToken: { id: fyTokenAddr, totalSupply: fyTokenTotalSupply, maturity },
+        tvlInBase,
+        currentFYTokenPriceInBase,
+        // apy,
+        // borrowAPY,
+        // lendAPY,
+      } = pool;
+
+      // don't grab matured pool data
+      if (maturity < timestamp) return;
+
+      // price of base token in USD terms
+      const key = `${chain}:${baseAddr}`;
+      const priceRes = await superagent.get(
+        `https://coins.llama.fi/prices/current/${key}`
+      );
+      const price = priceRes.body.coins[key];
+      const priceBaseUsd = price ? price.price : 0;
+
+      // total borrow/lend calculations
+      const tvlUsd = tvlInBase * priceBaseUsd;
+      const totalSupplyUsd =
+        currentFYTokenPriceInBase * fyTokenTotalSupply * priceBaseUsd; // total fyTokens in circulation converted to base, then to USD;
+      const totalBorrowUsd = tvlUsd - totalSupplyUsd; // TODO check if true
+
+      // apy calculations
+      const apyBase = 0; // TODO: calculate/estimate lp token return
+      const apyBaseBorrow = 0; // TODO: calculate/estimate apr borrow
+      const apyBaseSupply = 0; // TODO: calculate/estimate apr borrow
+
+      const maturityFormatted = formatMaturity(maturity);
+      const name = `${poolAddress}-${chain}`.toLowerCase();
+      const poolSymbol = `${price.symbol}-${maturityFormatted}`;
+      const poolMeta =
+        `Yield Protocol ${price.symbol} ${maturityFormatted}`.trim();
+
+      return {
+        pool: name,
+        chain: formatChain(chain),
+        project: 'yield-protocol',
+        symbol: formatSymbol(poolSymbol),
+        tvlUsd,
+        apy: 0, // pool apy estimate
+        apyReward: 0, // pool reward apy estimate
+        apyBase, // lend apy estimate
+        underlyingTokens: [baseAddr, fyTokenAddr],
+        apyBaseBorrow, // borow apy estimate
+        totalSupplyUsd,
+        totalBorrowUsd,
+        url: `https://app.yieldprotocol.com/`,
+        poolMeta,
+      };
+    })
+  );
+
+  return compact(pools);
+};
+
+const main = async () => {
+  return Object.keys(SUBGRAPHS).reduce(async (acc, chain) => {
+    return [...(await acc), ...(await getPools(chain))];
+  }, Promise.resolve([]));
+};
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+  url: 'https://app.yieldprotocol.com/',
+};

--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -200,6 +200,7 @@ const getPools = async (chain) => {
           totalBorrowUsd,
           url: `https://app.yieldprotocol.com/`,
           poolMeta: `fixed rate ${formatMaturity(maturity)}`,
+          ltv: 0.7, // using 70% ltv, which is close to an eth/stable borrow, but the ltv differs between each collateral/base pair (there are many collateral assets available for each base)
         },
       ];
     })

--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -44,8 +44,7 @@ const getBlendedSharesTokenAPY = async (
     const sharesAPY = (+markets[0].supplyAPY * 100) / 1e27;
 
     // convert shares to base
-    const sharesBaseVal = getBase(sharesReserves);
-    const sharesValRatio = (sharesBaseVal * currentSharePrice) / poolBaseValue;
+    const sharesValRatio = (sharesReserves * currentSharePrice) / poolBaseValue;
     return sharesAPY * sharesValRatio;
   } catch (e) {
     return 0;
@@ -165,7 +164,7 @@ const getPools = async (chain) => {
               sharesToken,
               chain,
               tvlInBase,
-              sharesReserves,
+              baseReserves, // when pool is tv, this is actually shares
               currentSharePrice
             );
       const apy = sharesTokenAPY + fyTokenInterestAPR + feeAPR;

--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -172,9 +172,6 @@ const getPools = async (chain) => {
       // extra data
       const maturityFormatted = formatMaturity(maturity);
       const name = `${poolAddr}-${chain}`.toLowerCase();
-      const poolMeta = `Yield Protocol ${formatSymbol(
-        baseSymbol
-      )} ${maturityFormatted}`.trim();
 
       return {
         pool: name,
@@ -190,7 +187,7 @@ const getPools = async (chain) => {
         totalSupplyUsd,
         totalBorrowUsd,
         url: `https://app.yieldprotocol.com/`,
-        poolMeta,
+        poolMeta: maturityFormatted,
       };
     })
   );

--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -4,9 +4,6 @@ const superagent = require('superagent');
 const { format } = require('date-fns');
 const { compact } = require('lodash');
 
-// TODO
-// add symbol, totalBorrowed on pool in subgraph
-
 const SUBGRAPH_BASE = 'https://api.thegraph.com/subgraphs/name/yieldprotocol/';
 
 const SUBGRAPHS = {
@@ -18,57 +15,74 @@ const formatMaturity = (maturity) => {
   return format(new Date(maturity * 1000), 'dd MMM yyyy');
 };
 
-const getPools = async (chain) => {
+// get the total base borrowed for a specific seriesEntity
+const getTotalBorrow = async (seriesEntityId, chain) => {
   const url = SUBGRAPHS[chain];
   const query = gql`
     {
-      pools {
-        id
-        base
-        fyToken {
-          id
-          totalSupply
-          maturity
-          symbol
-        }
-        currentFYTokenPriceInBase
-        tvlInBase
-      }
-      _meta {
-        block {
-          timestamp
-        }
+      vaults(where: { series: "${seriesEntityId}", debtAmount_gt: "0" }) {
+        debtAmount
       }
     }
   `;
 
-  const {
-    pools: subgraphPools,
-    _meta: {
-      block: { timestamp },
-    },
-  } = await request(url, query);
+  const { vaults: subgraphVaults } = await request(url, query);
+
+  const totalBorrow = subgraphVaults.reduce((acc, vault) => {
+    return acc + +vault.debtAmount;
+  }, 0);
+
+  return totalBorrow;
+};
+
+const getPools = async (chain) => {
+  const url = SUBGRAPHS[chain];
+  const query = gql`
+    {
+      seriesEntities(where: { matured: false }) {
+        id
+        fyToken {
+          id
+          pools {
+            apr
+            id
+            currentFYTokenPriceInBase
+            tvlInBase
+          }
+          totalSupply
+          symbol
+        }
+        maturity
+        baseAsset {
+          id
+          symbol
+        }
+      }
+    }
+  `;
+  const { seriesEntities } = await request(url, query);
 
   const pools = await Promise.all(
-    subgraphPools.map(async (pool) => {
+    seriesEntities.map(async (seriesEntity) => {
       const {
-        id: poolAddress,
-        base: baseAddr,
+        id: seriesEntityId,
         fyToken: {
           id: fyTokenAddr,
+          pools,
           totalSupply: fyTokenTotalSupply,
-          maturity,
-          symbol,
+          symbol: fyTokenSymbol,
         },
-        tvlInBase,
-        currentFYTokenPriceInBase,
-        // apy,
-        // borrowAPY,
-        // lendAPY,
-      } = pool;
+        maturity,
+        baseAsset: { id: baseAddr, symbol: baseSymbol },
+      } = seriesEntity;
 
-      // don't grab matured pool data
-      if (maturity < timestamp) return;
+      const pool = pools[0]; // grab the first pool since there should be only one pool per seriesEntity
+      const {
+        id: poolAddr,
+        currentFYTokenPriceInBase,
+        tvlInBase,
+        // borrowApy, lendApy, poolApy,
+      } = pool;
 
       // price of base token in USD terms
       const key = `${chain}:${baseAddr}`;
@@ -78,34 +92,40 @@ const getPools = async (chain) => {
       const price = priceRes.body.coins[key];
       const priceBaseUsd = price ? price.price : 0;
 
-      // total borrow/lend calculations
+      // total base value in pool plus total fyToken value (in base) in pool, converted to USD
       const tvlUsd = tvlInBase * priceBaseUsd;
+      // total fyTokens in circulation converted to base, then to USD
       const totalSupplyUsd =
-        currentFYTokenPriceInBase * fyTokenTotalSupply * priceBaseUsd; // total fyTokens in circulation converted to base, then to USD;
-      const totalBorrowUsd = tvlUsd - totalSupplyUsd; // TODO check if true
+        currentFYTokenPriceInBase * fyTokenTotalSupply * priceBaseUsd;
+      // total borrowed in USD for this specific pool/series
+      const totalBorrowUsd =
+        (await getTotalBorrow(seriesEntityId, chain)) * priceBaseUsd;
 
-      // apy calculations
-      const apyBase = 0; // TODO: calculate/estimate lp token return
-      const apyBaseBorrow = 0; // TODO: calculate/estimate apr borrow
-      const apyBaseSupply = 0; // TODO: calculate/estimate apr borrow
+      // apy estimate when providing liquidity
+      const apy = 0; // TODO: calculate/estimate lp token return
+      // apy estimate when lending (buying fyToken)
+      const apyBase = 0; // TODO: calculate/estimate apy lend
+      // apy estimate when borrowing from the pool
+      const apyBaseBorrow = 0; // TODO: calculate/estimate apy borrow
 
       // extra data
       const maturityFormatted = formatMaturity(maturity);
-      const name = `${poolAddress}-${chain}`.toLowerCase();
-      const poolMeta =
-        `Yield Protocol ${price.symbol} ${maturityFormatted}`.trim();
+      const name = `${poolAddr}-${chain}`.toLowerCase();
+      const poolMeta = `Yield Protocol ${formatSymbol(
+        baseSymbol
+      )} ${maturityFormatted}`.trim();
 
       return {
         pool: name,
         chain: formatChain(chain),
         project: 'yield-protocol',
-        symbol: formatSymbol(`${symbol}LP`),
-        tvlUsd,
-        apy: 0, // pool apy estimate
+        symbol: formatSymbol(`${fyTokenSymbol}LP`),
+        underlyingTokens: [baseAddr, fyTokenAddr],
+        apy, // liquidity providing apy estimate
         apyReward: 0, // pool reward apy estimate
         apyBase, // lend apy estimate
-        underlyingTokens: [baseAddr, fyTokenAddr],
         apyBaseBorrow, // borow apy estimate
+        tvlUsd,
         totalSupplyUsd,
         totalBorrowUsd,
         url: `https://app.yieldprotocol.com/`,

--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -29,6 +29,7 @@ const getPools = async (chain) => {
           id
           totalSupply
           maturity
+          symbol
         }
         currentFYTokenPriceInBase
         tvlInBase
@@ -52,9 +53,13 @@ const getPools = async (chain) => {
     subgraphPools.map(async (pool) => {
       const {
         id: poolAddress,
-        // symbol: poolSymbol,
         base: baseAddr,
-        fyToken: { id: fyTokenAddr, totalSupply: fyTokenTotalSupply, maturity },
+        fyToken: {
+          id: fyTokenAddr,
+          totalSupply: fyTokenTotalSupply,
+          maturity,
+          symbol,
+        },
         tvlInBase,
         currentFYTokenPriceInBase,
         // apy,
@@ -84,9 +89,9 @@ const getPools = async (chain) => {
       const apyBaseBorrow = 0; // TODO: calculate/estimate apr borrow
       const apyBaseSupply = 0; // TODO: calculate/estimate apr borrow
 
+      // extra data
       const maturityFormatted = formatMaturity(maturity);
       const name = `${poolAddress}-${chain}`.toLowerCase();
-      const poolSymbol = `${price.symbol}-${maturityFormatted}`;
       const poolMeta =
         `Yield Protocol ${price.symbol} ${maturityFormatted}`.trim();
 
@@ -94,7 +99,7 @@ const getPools = async (chain) => {
         pool: name,
         chain: formatChain(chain),
         project: 'yield-protocol',
-        symbol: formatSymbol(poolSymbol),
+        symbol: formatSymbol(`${symbol}LP`),
         tvlUsd,
         apy: 0, // pool apy estimate
         apyReward: 0, // pool reward apy estimate

--- a/src/adaptors/yield-protocol/index.js
+++ b/src/adaptors/yield-protocol/index.js
@@ -184,8 +184,6 @@ const getPools = async (chain) => {
           apyReward: poolRewardsAPY, // TODO: pool/strategy reward apy estimate
           apyBase: poolAPY, // variable apy estimate for providing liquidity
           tvlUsd,
-          totalSupplyUsd,
-          totalBorrowUsd,
           url: `https://app.yieldprotocol.com/`,
           poolMeta: `variable rate ${formatMaturity(maturity)}`,
         },


### PR DESCRIPTION
## Description

Yield Protocol is a fixed-rate borrowing and lending protocol. Users can borrow and lend at a fixed rate via interactions with a pool (an AMM). Each pool is comprised of an underlying (base) and an associated `fyToken` (USDC and fyUSDC, respectively); the fyToken and associated pool have a maturity (date of expiration), in which the fyToken trades one-to-one with the underlying. Each user can interact as such:

Borrowers: Get underlying for fyTokens they immediately sell, thus incurring debt to repay at maturity.

Lenders: Buy fyTokens, which trade at a discount before maturity, but can be redeemed at maturity one-to-one with the underlying; in this way they are "lending" there underlying.

Liquidity Providers: add liquidity (base and fyToken) in proportion to the pool. They derive a variable rate of return from the interest of the fyToken, plus any fees accrued, plus (if the pool is configured as such) an interest earned from depositing the base pooled into a money-market (some pools on mainnet deposit into Euler). In the future, there could be a rewards return implemented as well (logic not included here).

**This pr implements a yield-protocol adaptor to showcase borrower, lender, and liquidity provider apy estimates associated with pools.** A subsequent pr will add pool rewards apy logic.

Since there is some nuance with how the pool's apy estimates are calculated and not exactly the same as a traditional money-market/borrowing/lending protocol (i.e. Compound/Aave), please let me know if you have any questions.