### PR TITLE
Fix/actualize toros apy

### DIFF
--- a/src/adaptors/toros/index.js
+++ b/src/adaptors/toros/index.js
@@ -120,11 +120,7 @@ const listTorosYieldProducts = async () => {
         project: 'toros',
         symbol,
         tvlUsd: formatValue(totalValue),
-        apyBase: apy ?? calcApy(blockTime, performanceMetrics),
-        apyReward:
-          rewardIncentivisedPool && rewardData?.rewardApy
-            ? +rewardData.rewardApy * 100
-            : null,
+        apy: apy ?? calcApy(blockTime, performanceMetrics),
         rewardTokens:
           rewardIncentivisedPool && rewardData?.rewardToken
             ? [rewardData.rewardToken]

--- a/src/adaptors/toros/index.js
+++ b/src/adaptors/toros/index.js
@@ -13,6 +13,10 @@ const YIELD_PRODUCTS_QUERY = gql`
     yieldProducts {
       address
     }
+    apyForTorosFunds {
+      fundAddress
+      monthly
+    }
   }
 `;
 
@@ -44,6 +48,7 @@ const formatValue = (value) => new BN(value).shiftedBy(-18).toNumber();
 const getDaysSincePoolCreation = (blockTime) =>
   Math.round((Date.now() / 1000 - +blockTime) / 86400);
 
+// Fallback APY calculation simply based on pool's past performance
 const calcApy = (blockTime, metrics) => {
   const daysActive = getDaysSincePoolCreation(blockTime);
   return daysActive >= 360
@@ -59,13 +64,17 @@ const calcApy = (blockTime, metrics) => {
 
 const fetchTorosYieldProducts = async () => {
   try {
-    const addresses = await request(DHEDGE_API_URL, YIELD_PRODUCTS_QUERY);
+    const response = await request(DHEDGE_API_URL, YIELD_PRODUCTS_QUERY);
+    const apyData = response.apyForTorosFunds;
     const products = await Promise.all(
-      addresses.yieldProducts.map(async ({ address }) => {
-        const poolData = await request(DHEDGE_API_URL, POOL_DATA_QUERY, {
+      response.yieldProducts.map(async ({ address }) => {
+        const { fund } = await request(DHEDGE_API_URL, POOL_DATA_QUERY, {
           address,
         });
-        return poolData.fund;
+        const poolApyData = apyData.find(
+          ({ fundAddress }) => fundAddress === fund.address
+        );
+        return { ...fund, apy: poolApyData?.monthly };
       })
     );
     return products;
@@ -100,6 +109,7 @@ const listTorosYieldProducts = async () => {
       performanceMetrics,
       blockTime,
       fundComposition,
+      apy,
     }) => {
       const rewardIncentivisedPool = rewardData?.poolsWithRewards
         .map((address) => address.toLowerCase())
@@ -110,7 +120,7 @@ const listTorosYieldProducts = async () => {
         project: 'toros',
         symbol,
         tvlUsd: formatValue(totalValue),
-        apyBase: calcApy(blockTime, performanceMetrics),
+        apyBase: apy ?? calcApy(blockTime, performanceMetrics),
         apyReward:
           rewardIncentivisedPool && rewardData?.rewardApy
             ? +rewardData.rewardApy * 100


### PR DESCRIPTION
Hi,

This actualises APY figures for Toros Finance yield vaults. Current figures are overestimated.

Changes made:
* use another source of APY data
* remove `apyBase` and `apyReward` and leave single `apy` field , as requested in doc:

[if you are unsure/your data source doesn't contain a detailed breakdown, then provide an `apy` field indicating the total apy and omit the `apyBase` and `apyReward` fields (or set to null)](https://github.com/dhedge/yield-server/tree/master#adaptors)

Data source for Toros APY values already includes rewards (doesn't contain breakdown).