### PR TITLE
[Convex Adapter] Update to latest curve gauge api endpoint

### DIFF
--- a/src/adaptors/convex-finance/index.js
+++ b/src/adaptors/convex-finance/index.js
@@ -46,9 +46,9 @@ const main = async () => {
     .map(({ data }) => data.poolData)
     .flat();
 
-  const {
-    data: { gauges },
-  } = await utils.getData('https://api.curve.fi/api/getGauges');
+  const { data: gauges } = await utils.getData(
+    'https://api.curve.fi/api/getAllGauges'
+  );
 
   const mappedGauges = Object.entries(gauges).reduce(
     (acc, [name, gauge]) => ({


### PR DESCRIPTION
**The current API endpoint used in the convex adapter does not include all gauges on curve. When the adapter attempts to map to convex gauges it results in missing convex pools.**

For example: 
https://curve.fi/#/ethereum/pools/factory-crypto-158/deposit - references `0x06f691180f643b35e3644a2296a4097e1f577d0d` as its gauge. 

https://api.curve.fi/api/getGauges does not include `0x06f691180f643b35e3644a2296a4097e1f577d0d` in the response, but https://api.curve.fi/api/getAllGauges does include it. 

`/getAllGauges` is what's queried from the curve frontend and represents an all-inclusive list of gauges.

Replacing the endpoint with this `/getAllGauges` endpoint results in an additional 30 pools being returned. 
All tests are passing locally. 

