### PR TITLE
Sommelier: Account for Cellar asset price when calculating reward APY

### DIFF
--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -17,30 +17,64 @@ const stakingAbi = require('./staking-v0-8-15.json');
 
 const call = sdk.api.abi.call;
 
+// Get the Cellar address from pool notation
+// <cellar address>:<network>
+function getCellarAddress(pool) {
+  return pool.pool.split('-')[0];
+}
+
+// Get a list of all Cellar holding positions
+async function getHoldingPositions() {
+  const v1Assets = await Promise.all(
+    v0815Pools.map((pool) =>
+      v0815
+        .getUnderlyingTokens(getCellarAddress(pool))
+        .then((tokens) => tokens[0])
+    )
+  );
+
+  const v15Assets = await Promise.all(
+    v0816Pools.map((pool) => v0816.getHoldingPosition(getCellarAddress(pool)))
+  );
+
+  const v2Assets = await Promise.all(
+    v2Pools.map((pool) => v2.getHoldingPosition(getCellarAddress(pool)))
+  );
+
+  return [...v1Assets, ...v15Assets, ...v2Assets];
+}
+
 async function main() {
-  const sommPrice = (await utils.getPrices(['coingecko:sommelier']))
-    .pricesBySymbol.somm;
+  const assets = await getHoldingPositions();
+  const tokens = ['coingecko:sommelier', ...assets.map((a) => `ethereum:${a}`)];
+  const prices = await utils.getPrices(tokens);
+  const sommPrice = prices.pricesBySymbol.somm;
 
   let promises = [];
-  promises = v0815Pools.map((pool) => handleV0815(pool, sommPrice));
+  promises = v0815Pools.map((pool) => handleV0815(pool, prices));
   promises = promises.concat(
-    v0816Pools.map((pool) => handleV0816(pool, sommPrice))
+    v0816Pools.map((pool) => handleV0816(pool, prices))
   );
-  promises = promises.concat(v2Pools.map((pool) => handleV2(pool, sommPrice)));
+  promises = promises.concat(v2Pools.map((pool) => handleV2(pool, prices)));
 
   const pools = await Promise.all(promises);
 
   return pools;
 }
 
-async function handleV0815(pool, sommPrice) {
+async function handleV0815(pool, prices) {
   const cellarAddress = pool.pool.split('-')[0];
 
   const underlyingTokens = await v0815.getUnderlyingTokens(cellarAddress);
   const asset = underlyingTokens[0]; // v0815 Cellar only holds one asset
   const tvlUsd = await v0815.getTvlUsd(cellarAddress, asset);
   const apyBase = await v0815.getApy(cellarAddress);
-  const apyReward = await getRewardApy(stakingPools[cellarAddress], sommPrice);
+  const assetPrice = prices.pricesByAddress[asset.toLowerCase()];
+  const apyReward = await getRewardApy(
+    stakingPools[cellarAddress],
+    prices.pricesBySymbol.somm,
+    assetPrice
+  );
 
   return {
     ...pool,
@@ -53,14 +87,19 @@ async function handleV0815(pool, sommPrice) {
   };
 }
 
-async function handleV0816(pool, sommPrice) {
+async function handleV0816(pool, prices) {
   const cellarAddress = pool.pool.split('-')[0];
 
   const underlyingTokens = await v0816.getUnderlyingTokens(cellarAddress);
   const asset = await v0816.getHoldingPosition(cellarAddress);
   const tvlUsd = await v0816.getTvlUsd(cellarAddress, asset);
   const apyBase = await v0816.getApy(cellarAddress);
-  const apyReward = await getRewardApy(stakingPools[cellarAddress], sommPrice);
+  const assetPrice = prices.pricesByAddress[asset.toLowerCase()];
+  const apyReward = await getRewardApy(
+    stakingPools[cellarAddress],
+    prices.pricesBySymbol.somm,
+    assetPrice
+  );
 
   return {
     ...pool,
@@ -73,12 +112,18 @@ async function handleV0816(pool, sommPrice) {
   };
 }
 
-async function handleV2(pool, sommPrice) {
+async function handleV2(pool, prices) {
   const cellarAddress = pool.pool.split('-')[0];
 
   const underlyingTokens = await v2.getUnderlyingTokens(cellarAddress);
   const asset = await v2.getHoldingPosition(cellarAddress);
-  const apyReward = await getRewardApy(stakingPools[cellarAddress], sommPrice);
+  const assetPrice = prices.pricesByAddress[asset.toLowerCase()];
+
+  const apyReward = await getRewardApy(
+    stakingPools[cellarAddress],
+    prices.pricesBySymbol.somm,
+    assetPrice
+  );
   const apyBase = await v2.getApy(cellarAddress);
   const apyBase7d = await v2.getApy7d(cellarAddress);
 
@@ -98,7 +143,7 @@ async function handleV2(pool, sommPrice) {
 }
 
 // Calculates Staking APY for v0815 staking contract currently used by all pools
-async function getRewardApy(stakingPool, sommPrice) {
+async function getRewardApy(stakingPool, sommPrice, assetPrice) {
   const rewardRateResult = (
     await call({
       target: stakingPool,
@@ -118,11 +163,8 @@ async function getRewardApy(stakingPool, sommPrice) {
   let totalDepositsWithBoost = new BigNumber(totalDepositWithBoostResult).div(
     1e18
   );
-  if(stakingPool === "0x955a31153e6764fe892757ace79123ae996b0afb"){
-    const ethPrice = (await utils.getPrices(['coingecko:ethereum']))
-      .pricesBySymbol.eth;
-    totalDepositsWithBoost = totalDepositsWithBoost.times(ethPrice)
-  }
+
+  totalDepositsWithBoost = totalDepositsWithBoost.times(assetPrice);
 
   const endTimestampResult = (
     await call({


### PR DESCRIPTION
This PR expands on @0xngmi's fix for our Real Yield ETH Reward APY in https://github.com/DefiLlama/yield-server/commit/2ba09525b9e2e90899cc7b181b57890f187082ca.

We now account for each Cellar's underlying asset price when calculating rewards APY by doing the following:
- Fetch a list of underlying assets for all Cellars.
- Get price information upfront
- Update reward APY handler to accept asset price as argument
- Pass price data to each versioned Cellar handler so it can then pass asset price to the reward APY calc