### PR TITLE
AURA adapter should account for wstETH rewards

### DIFF
--- a/src/adaptors/aura/index.js
+++ b/src/adaptors/aura/index.js
@@ -12,6 +12,8 @@ const SWAP_APR_API = 'https://aura-balancer-apr.onrender.com/aprs';
 
 const AURA_ADDRESS = '0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF'.toLowerCase();
 const BAL_ADDRESS = '0xba100000625a3754423978a60c9317c58a424e3D'.toLowerCase();
+const WSTETH_ADDRESS =
+  '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0'.toLowerCase();
 
 const SECONDS_PER_YEAR = 60 * 60 * 24 * 365;
 
@@ -112,6 +114,13 @@ const main = async () => {
         prices[AURA_ADDRESS]
       : 0;
 
+    //make sure to account for stETH rewards on certain pools
+    const wstETHApy = swapApr.poolAprs.tokens.breakdown[WSTETH_ADDRESS] || 0;
+
+    const rewardTokens = wstETHApy
+      ? [BAL_ADDRESS, AURA_ADDRESS, WSTETH_ADDRESS]
+      : [BAL_ADDRESS, AURA_ADDRESS];
+
     return {
       pool: pool.lpToken.id,
       project: 'aura',
@@ -119,9 +128,9 @@ const main = async () => {
       chain: utils.formatChain('ethereum'),
       tvlUsd,
       apyBase: Number(swapApr.poolAprs.swap),
-      apyReward: apyBal + apyAura + auraExtraApy,
+      apyReward: apyBal + apyAura + auraExtraApy + wstETHApy,
       underlyingTokens: balData.tokens.map(({ address }) => address),
-      rewardTokens: [BAL_ADDRESS, AURA_ADDRESS],
+      rewardTokens,
     };
   });
 


### PR DESCRIPTION
This adapter currently doesn't account for wstETH rewards. There are currently 13 pools w/ underreporting APYs

0WSTETH-50LDO
sfrxETH-stETH-rETH-BPT
B-stETH-STABLE
cbETH-wstETH-BPT
wstETH-ACX
B-cbETH-wstETH-Stable
50wstETH-50bb-euler-USD
wstETH-rETH-sfrxETH-BPT
50wstETH-50stk-APE
50wstETH-50ACX
50wstETH-50LDO
OHM-wstETH
50wstETH-50bb-a-USD