### PR TITLE
add support for olympus boosted liquidity engine

### DIFF
--- a/src/adaptors/olympus-dao/abis/liquidityRegistryAbi.json
+++ b/src/adaptors/olympus-dao/abis/liquidityRegistryAbi.json
@@ -1,0 +1,193 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract Kernel",
+        "name": "kernel_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller_",
+        "type": "address"
+      }
+    ],
+    "name": "KernelAdapter_OnlyKernel",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LQREG_RemovalMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "policy_",
+        "type": "address"
+      }
+    ],
+    "name": "Module_PolicyNotPermitted",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      }
+    ],
+    "name": "VaultAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      }
+    ],
+    "name": "VaultRemoved",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "INIT",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "KEYCODE",
+    "outputs": [
+      {
+        "internalType": "Keycode",
+        "name": "",
+        "type": "bytes5"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "VERSION",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "major",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "minor",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "activeVaultCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "activeVaults",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vault_",
+        "type": "address"
+      }
+    ],
+    "name": "addVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract Kernel",
+        "name": "newKernel_",
+        "type": "address"
+      }
+    ],
+    "name": "changeKernel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "kernel",
+    "outputs": [
+      {
+        "internalType": "contract Kernel",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "vault_",
+        "type": "address"
+      }
+    ],
+    "name": "removeVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/adaptors/olympus-dao/abis/vaultManagerAbi.json
+++ b/src/adaptors/olympus-dao/abis/vaultManagerAbi.json
@@ -1,0 +1,748 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract Kernel",
+        "name": "kernel_",
+        "type": "address"
+      },
+      {
+        "components": [
+          { "internalType": "address", "name": "ohm", "type": "address" },
+          { "internalType": "address", "name": "pairToken", "type": "address" },
+          { "internalType": "address", "name": "aura", "type": "address" },
+          { "internalType": "address", "name": "bal", "type": "address" }
+        ],
+        "internalType": "struct IBLVaultManagerLido.TokenData",
+        "name": "tokenData_",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          { "internalType": "address", "name": "vault", "type": "address" },
+          {
+            "internalType": "address",
+            "name": "liquidityPool",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "balancerHelper",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct IBLVaultManagerLido.BalancerData",
+        "name": "balancerData_",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          { "internalType": "uint256", "name": "pid", "type": "uint256" },
+          {
+            "internalType": "address",
+            "name": "auraBooster",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "auraRewardPool",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct IBLVaultManagerLido.AuraData",
+        "name": "auraData_",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "auraMiningLib_",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract AggregatorV3Interface",
+            "name": "feed",
+            "type": "address"
+          },
+          {
+            "internalType": "uint48",
+            "name": "updateThreshold",
+            "type": "uint48"
+          }
+        ],
+        "internalType": "struct IBLVaultManagerLido.OracleFeed",
+        "name": "ohmEthPriceFeed_",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract AggregatorV3Interface",
+            "name": "feed",
+            "type": "address"
+          },
+          {
+            "internalType": "uint48",
+            "name": "updateThreshold",
+            "type": "uint48"
+          }
+        ],
+        "internalType": "struct IBLVaultManagerLido.OracleFeed",
+        "name": "ethUsdPriceFeed_",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract AggregatorV3Interface",
+            "name": "feed",
+            "type": "address"
+          },
+          {
+            "internalType": "uint48",
+            "name": "updateThreshold",
+            "type": "uint48"
+          }
+        ],
+        "internalType": "struct IBLVaultManagerLido.OracleFeed",
+        "name": "stethUsdPriceFeed_",
+        "type": "tuple"
+      },
+      {
+        "internalType": "address",
+        "name": "implementation_",
+        "type": "address"
+      },
+      { "internalType": "uint256", "name": "ohmLimit_", "type": "uint256" },
+      { "internalType": "uint64", "name": "fee_", "type": "uint64" },
+      {
+        "internalType": "uint48",
+        "name": "minWithdrawalDelay_",
+        "type": "uint48"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "BLManagerLido_AlreadyActive", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_AlreadyInactive", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_BadPriceFeed", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_Inactive", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_InvalidFee", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_InvalidLimit", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_InvalidLpAmount", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_InvalidVault", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_LimitViolation", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_NoUserVault", "type": "error" },
+  { "inputs": [], "name": "BLManagerLido_VaultAlreadyExists", "type": "error" },
+  { "inputs": [], "name": "CreateFail", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "caller_", "type": "address" }
+    ],
+    "name": "KernelAdapter_OnlyKernel",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "Keycode", "name": "keycode_", "type": "bytes5" }
+    ],
+    "name": "Policy_ModuleDoesNotExist",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "fee",
+        "type": "uint64"
+      }
+    ],
+    "name": "VaultDeployed",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BLREG",
+    "outputs": [
+      { "internalType": "contract BLREGv1", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_FEE",
+    "outputs": [{ "internalType": "uint32", "name": "", "type": "uint32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MINTR",
+    "outputs": [
+      { "internalType": "contract MINTRv1", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ROLES",
+    "outputs": [
+      { "internalType": "contract ROLESv1", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "TRSRY",
+    "outputs": [
+      { "internalType": "contract TRSRYv1", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "activate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "aura",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "auraData",
+    "outputs": [
+      { "internalType": "uint256", "name": "pid", "type": "uint256" },
+      { "internalType": "address", "name": "auraBooster", "type": "address" },
+      { "internalType": "address", "name": "auraRewardPool", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "auraMiningLib",
+    "outputs": [
+      {
+        "internalType": "contract IAuraMiningLib",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bal",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "balancerData",
+    "outputs": [
+      { "internalType": "address", "name": "vault", "type": "address" },
+      { "internalType": "address", "name": "liquidityPool", "type": "address" },
+      { "internalType": "address", "name": "balancerHelper", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount_", "type": "uint256" }
+    ],
+    "name": "burnOhmFromVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user_", "type": "address" }
+    ],
+    "name": "canWithdraw",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract Kernel",
+        "name": "newKernel_",
+        "type": "address"
+      }
+    ],
+    "name": "changeKernel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint48",
+        "name": "ohmEthUpdateThreshold_",
+        "type": "uint48"
+      },
+      {
+        "internalType": "uint48",
+        "name": "ethUsdUpdateThreshold_",
+        "type": "uint48"
+      },
+      {
+        "internalType": "uint48",
+        "name": "stethUsdUpdateThreshold_",
+        "type": "uint48"
+      }
+    ],
+    "name": "changeUpdateThresholds",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "circulatingOhmBurned",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "configureDependencies",
+    "outputs": [
+      {
+        "internalType": "Keycode[]",
+        "name": "dependencies",
+        "type": "bytes5[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentFee",
+    "outputs": [{ "internalType": "uint64", "name": "", "type": "uint64" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "deactivate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount_", "type": "uint256" }
+    ],
+    "name": "decreaseTotalLp",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "deployVault",
+    "outputs": [
+      { "internalType": "address", "name": "vault", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "deployedOhm",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount_", "type": "uint256" }
+    ],
+    "name": "emergencyBurnOhm",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ethUsdPriceFeed",
+    "outputs": [
+      {
+        "internalType": "contract AggregatorV3Interface",
+        "name": "feed",
+        "type": "address"
+      },
+      { "internalType": "uint48", "name": "updateThreshold", "type": "uint48" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeName",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount_", "type": "uint256" }
+    ],
+    "name": "getExpectedLpAmount",
+    "outputs": [
+      { "internalType": "uint256", "name": "bptAmount", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "lpAmount_", "type": "uint256" }
+    ],
+    "name": "getExpectedPairTokenOutUser",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "expectedTknAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "lpAmount_", "type": "uint256" }
+    ],
+    "name": "getExpectedTokensOutProtocol",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "expectedTokenAmounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user_", "type": "address" }
+    ],
+    "name": "getLpBalance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMaxDeposit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOhmSupplyChangeData",
+    "outputs": [
+      { "internalType": "uint256", "name": "poolOhmShare", "type": "uint256" },
+      { "internalType": "uint256", "name": "mintedOhm", "type": "uint256" },
+      { "internalType": "uint256", "name": "netBurnedOhm", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOhmTknPoolPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOhmTknPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user_", "type": "address" }
+    ],
+    "name": "getOutstandingRewards",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "rewardToken",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "outstandingRewards",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct RewardsData[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolOhmShare",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "rewardToken_", "type": "address" }
+    ],
+    "name": "getRewardRate",
+    "outputs": [
+      { "internalType": "uint256", "name": "rewardRate", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRewardTokens",
+    "outputs": [
+      { "internalType": "address[]", "name": "", "type": "address[]" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTknOhmPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user_", "type": "address" }
+    ],
+    "name": "getUserPairShare",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "implementation",
+    "outputs": [
+      { "internalType": "contract BLVaultLido", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount_", "type": "uint256" }
+    ],
+    "name": "increaseTotalLp",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isActive",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isLidoBLVaultActive",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "kernel",
+    "outputs": [
+      { "internalType": "contract Kernel", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minWithdrawalDelay",
+    "outputs": [{ "internalType": "uint48", "name": "", "type": "uint48" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount_", "type": "uint256" }
+    ],
+    "name": "mintOhmToVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ohm",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ohmEthPriceFeed",
+    "outputs": [
+      {
+        "internalType": "contract AggregatorV3Interface",
+        "name": "feed",
+        "type": "address"
+      },
+      { "internalType": "uint48", "name": "updateThreshold", "type": "uint48" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ohmLimit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pairToken",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "requestPermissions",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "Keycode", "name": "keycode", "type": "bytes5" },
+          { "internalType": "bytes4", "name": "funcSelector", "type": "bytes4" }
+        ],
+        "internalType": "struct Permissions[]",
+        "name": "permissions",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint64", "name": "newFee_", "type": "uint64" }
+    ],
+    "name": "setFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "newLimit_", "type": "uint256" }
+    ],
+    "name": "setLimit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint48", "name": "newDelay_", "type": "uint48" }
+    ],
+    "name": "setWithdrawalDelay",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stethUsdPriceFeed",
+    "outputs": [
+      {
+        "internalType": "contract AggregatorV3Interface",
+        "name": "feed",
+        "type": "address"
+      },
+      { "internalType": "uint48", "name": "updateThreshold", "type": "uint48" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalLp",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "userVaults",
+    "outputs": [
+      { "internalType": "contract BLVaultLido", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "contract BLVaultLido", "name": "", "type": "address" }
+    ],
+    "name": "vaultOwners",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/adaptors/olympus-dao/index.js
+++ b/src/adaptors/olympus-dao/index.js
@@ -1,0 +1,267 @@
+const { gql, default: request } = require('graphql-request');
+const sdk = require('@defillama/sdk');
+const liquidityRegistry = require('./abis/liquidityRegistryAbi.json');
+const vaultManager = require('./abis/vaultManagerAbi.json');
+const utils = require('../utils');
+
+const OLYMPUS_LIQUIDITY_REGISTRY = '0x375E06C694B5E50aF8be8FB03495A612eA3e2275';
+const OHM_WSTETH_VAULT =
+  '0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23'.toLowerCase();
+const AURA_ADDRESS = '0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF'.toLowerCase();
+const BAL_ADDRESS = '0xba100000625a3754423978a60c9317c58a424e3D'.toLowerCase();
+const WSTETH_ADDRESS =
+  '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0'.toLowerCase();
+const OHM_ADDRESS = '0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5';
+
+const AURA_API =
+  'https://graph.aura.finance/subgraphs/name/aura/aura-mainnet-v2';
+const BAL_API =
+  'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2';
+const SWAP_APR_API = 'https://aura-balancer-apr.onrender.com/aprs';
+const AURA_TVL_API = 'https://aura-metrics.onrender.com/tvl';
+
+const balBoolsQuery = gql`
+  query Pools($address_in: [Bytes!] = "") {
+    pools(where: { address_in: $address_in }) {
+      id
+      symbol
+      address
+      tokens {
+        address
+        token {
+          symbol
+        }
+        cashBalance
+        balance
+        decimals
+        symbol
+      }
+    }
+  }
+`;
+
+const auraPoolsQuery = gql`
+  query Pools($id: Int = 0) {
+    pools(where: { id: $id }) {
+      id
+      lpToken {
+        name
+        symbol
+        id
+      }
+      rewardData {
+        rewardRate
+        token {
+          name
+          id
+        }
+      }
+      totalSupply
+      totalStaked
+      gauge {
+        balance
+        totalSupply
+        workingSupply
+      }
+    }
+  }
+`;
+
+const SECONDS_PER_YEAR = 60 * 60 * 24 * 365;
+
+const getAuraMintAmount = (balEarned, auraSupply) => {
+  const auraUnitsMinted =
+    (((500 - (auraSupply - 50000000) / 100000) * 2.5 + 700) / 500) * balEarned;
+  return auraUnitsMinted;
+};
+
+/**
+ * Return an array of active vault addresses
+ */
+const getActiveVaults = async () => {
+  const activeVaultsCount = (
+    await sdk.api.abi.call({
+      target: OLYMPUS_LIQUIDITY_REGISTRY,
+      abi: liquidityRegistry.find((n) => n.name === 'activeVaultCount'),
+      chain: 'ethereum',
+    })
+  ).output;
+
+  /* we only care about the count, so we can fill an array with 0s and map over it */
+  const countArray = Array(activeVaultsCount).fill(0);
+
+  const addresses = await Promise.all(
+    countArray.map(async (value, position) => {
+      const address = (
+        await sdk.api.abi.call({
+          target: OLYMPUS_LIQUIDITY_REGISTRY,
+          abi: liquidityRegistry.find((n) => n.name === 'activeVaults'),
+          params: position,
+          chain: 'ethereum',
+        })
+      ).output;
+      return address;
+    })
+  );
+  return addresses;
+};
+
+const getAuraVaultTVL = async (vaultAddress, pairToken) => {
+  const pricePerDepositToken =
+    (
+      await sdk.api.abi.call({
+        target: vaultAddress,
+        abi: vaultManager.find((n) => n.name === 'getExpectedLpAmount'),
+        params: '1000000000000000000',
+        chain: 'ethereum',
+      })
+    ).output / 1e18;
+
+  const totalLp =
+    (
+      await sdk.api.abi.call({
+        target: vaultAddress,
+        abi: vaultManager.find((n) => n.name === 'totalLp'),
+        chain: 'ethereum',
+      })
+    ).output / 1e18;
+
+  const { pricesByAddress: prices } = await utils.getPrices(
+    [pairToken, OHM_ADDRESS],
+    'ethereum'
+  );
+
+  //Price for 1 LP Token in deposit token (converted to USD)
+  const usdPricePerDepositToken =
+    prices[pairToken.toLowerCase()] / pricePerDepositToken;
+
+  //Price for 1 Deposit Token in OHM
+  const ohmPricePerDepositToken =
+    usdPricePerDepositToken / prices[OHM_ADDRESS.toLowerCase()];
+
+  //Price for 1 OHM Deposit Token in USD
+  const usdPricePerOhm =
+    prices[OHM_ADDRESS.toLowerCase()] * ohmPricePerDepositToken;
+
+  const lpTokenPrice = usdPricePerDepositToken + usdPricePerOhm;
+  const tvlUsd = lpTokenPrice * totalLp;
+
+  return tvlUsd;
+};
+
+/**
+ * Use the same method as Aura to calculate the APY.
+ * Return TVL of the Vault.
+ * Boost the reward APY by 2 to account for single sided deposit.
+ */
+const getAuraAPY = async (address, swapAprs, prices, auraSupply) => {
+  const auraPool = (
+    await sdk.api.abi.call({
+      target: address,
+      abi: vaultManager.find((n) => n.name === 'auraData'),
+      chain: 'ethereum',
+    })
+  ).output;
+
+  const pairToken = (
+    await sdk.api.abi.call({
+      target: address,
+      abi: vaultManager.find((n) => n.name === 'pairToken'),
+      chain: 'ethereum',
+    })
+  ).output;
+
+  const { pools } = await request(AURA_API, auraPoolsQuery, {
+    id: +auraPool.pid,
+  });
+
+  const pool = pools[0];
+
+  const { pools: balPools } = await request(BAL_API, balBoolsQuery, {
+    address_in: [pool.lpToken.id],
+  });
+
+  const balPool = balPools[0];
+  if (!balPool) return;
+
+  const swapApr = swapAprs.find(({ id }) => id === balPool.id);
+  if (!swapApr?.poolAprs) return;
+
+  const vaultTvlUsd = await getAuraVaultTVL(address, pairToken);
+
+  const balRewards = pool.rewardData.find(
+    ({ token }) => token.id === BAL_ADDRESS
+  );
+
+  const auraExtraRewards = pool.rewardData.find(
+    ({ token }) => token.id === AURA_ADDRESS
+  );
+  const {
+    balancer: { breakdown: auraTvl },
+  } = await utils.getData(AURA_TVL_API);
+  const tvlUsd = auraTvl[pool.lpToken.id] || 0;
+  const balPerYear = (balRewards.rewardRate / 1e18) * SECONDS_PER_YEAR;
+  const apyBal = (balPerYear / tvlUsd) * 100 * prices[BAL_ADDRESS] || 0;
+  const auraPerYear = getAuraMintAmount(balPerYear, auraSupply);
+  const apyAura = (auraPerYear / tvlUsd) * 100 * prices[AURA_ADDRESS] || 0;
+  const auraExtraApy = auraExtraRewards
+    ? (((auraExtraRewards.rewardRate / 1e18) * SECONDS_PER_YEAR) / tvlUsd) *
+      100 *
+      prices[AURA_ADDRESS]
+    : 0;
+  //make sure to account for stETH rewards on certain pools
+  const wstETHApy = swapApr.poolAprs.tokens.breakdown[WSTETH_ADDRESS] || 0;
+
+  const rewardTokens = [BAL_ADDRESS, AURA_ADDRESS];
+
+  return {
+    pool: address,
+    symbol: balPool.tokens.map(({ symbol }) => symbol).join('-'),
+    chain: utils.formatChain('ethereum'),
+    tvlUsd: vaultTvlUsd,
+    apyBase: Number(swapApr.poolAprs.swap) + wstETHApy * 2, //boosted
+    apyReward: (apyBal + apyAura + auraExtraApy) * 2, //boosted
+    underlyingTokens: balPool.tokens.map(({ address }) => address),
+    rewardTokens,
+  };
+};
+
+/**
+ * Olympus Boosted Liquidity Pools are single sided deposit pools.
+ * Depositor deposits deposit token, Olympus matches deposit with OHM.
+ * Rewards from underlying pool are 2x, due to the single sided deposit and match.
+ */
+const main = async () => {
+  const addresses = await getActiveVaults();
+  const { pools: swapAprs } = await utils.getData(SWAP_APR_API);
+  const auraSupply =
+    (
+      await sdk.api.abi.call({
+        target: AURA_ADDRESS,
+        abi: 'erc20:totalSupply',
+        chain: 'ethereum',
+      })
+    ).output / 1e18;
+  const { pricesByAddress: prices } = await utils.getPrices(
+    [AURA_ADDRESS, BAL_ADDRESS],
+    'ethereum'
+  );
+  const apyInfo = await Promise.all(
+    addresses.map(async (address) => {
+      switch (address.toLowerCase()) {
+        case OHM_WSTETH_VAULT:
+          const info = await getAuraAPY(address, swapAprs, prices, auraSupply);
+          return { project: 'olympus-dao', ...info };
+        default:
+          return null;
+      }
+    })
+  );
+  return apyInfo;
+};
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+  url: 'https://app.olympusdao.finance/',
+};


### PR DESCRIPTION
Olympus Boosted Liquidity Engine Launched today. 
Add support for Olympus BLE and the OHM-wstETH vault. 

BLE is a single asset deposit vault strategy. Deposit wstETH, and olympus matches the deposit with OHM, allowing for 2x boosted return on the rewards from the underlying pool for the depositor. 

Based on feedback from other PR for Aura, i moved the wstETH reward calc into the base APY. 

Will update this adapter to be more robust as more vaults are added in the future.

see more here: https://app.olympusdao.finance/#/liquidity/vaults
