### PR TITLE
feat: update steadefi pool symbol and meta

### DIFF
--- a/src/adaptors/steadefi/index.js
+++ b/src/adaptors/steadefi/index.js
@@ -49,17 +49,13 @@ async function apy() {
 
       const lp = `${p.tokens.map((t) => t.symbol).join('-')}`;
       const symbol = `${p.leverage}x ${p.strategy} ${lp}`;
-      const poolMeta =
-        p.yieldSource === 'Perpetual DEX'
-          ? p.protocol
-          : `${p.protocol} - ${lp}`;
 
       return {
         pool: `${p.address}-${chainString}`.toLowerCase(),
         chain: chainString,
         project,
         symbol,
-        poolMeta,
+        poolMeta: p.protocol,
         tvlUsd: Number(ethers.utils.formatUnits(equityValue)),
         apy: utils.aprToApy(Number(p.data.apr.totalApr * 100)),
       };

--- a/src/adaptors/steadefi/index.js
+++ b/src/adaptors/steadefi/index.js
@@ -47,12 +47,19 @@ async function apy() {
         })
       ).output;
 
+      const lp = `${p.tokens.map((t) => t.symbol).join('-')}`;
+      const symbol = `${p.leverage}x ${p.strategy} ${lp}`;
+      const poolMeta =
+        p.yieldSource === 'Perpetual DEX'
+          ? p.protocol
+          : `${p.protocol} - ${lp}`;
+
       return {
         pool: `${p.address}-${chainString}`.toLowerCase(),
         chain: chainString,
         project,
-        symbol: utils.formatSymbol(p.symbol),
-        poolMeta: p.protocol,
+        symbol,
+        poolMeta,
         tvlUsd: Number(ethers.utils.formatUnits(equityValue)),
         apy: utils.aprToApy(Number(p.data.apr.totalApr * 100)),
       };
@@ -99,11 +106,21 @@ async function apy() {
         })
       ).output;
 
+      const lendingTo = p.name.split(' ')[2];
+
+      const symbol = p.baseToken.symbol;
+
+      const poolMeta =
+        p.lendingTo === 'Perpetual DEX'
+          ? p.protocol
+          : `${p.protocol} - ${lendingTo}`;
+
       return {
         pool: `${p.address}-${chainString}`.toLowerCase(),
         chain: chainString,
         project,
-        symbol: utils.formatSymbol(p.symbol),
+        symbol,
+        poolMeta,
         tvlUsd:
           Number(ethers.utils.formatUnits(totalValue, Number(assetDecimals))) *
           Number(ethers.utils.formatUnits(assetPrice)),
@@ -112,7 +129,7 @@ async function apy() {
     }),
   );
 
-  return [...lendingPools, ...vaults];
+  return [...vaults, ...lendingPools];
 }
 
 const main = async () => {


### PR DESCRIPTION
This PR aims to update Steadefi pool names and meta to provide more clarity

Example:
1. [IBUSDC-GMX](https://defillama.com/yields/pool/dce4e35a-6069-4044-8be0-9f4f6037e704) => USDC (GMX)
2. [IBETH-GRAIL](https://defillama.com/yields/pool/4530d31a-00f9-4aee-a755-83490e99e2e5) => ETH (Camelot ETH-USDC)
3. [3L-GLP-GMX (GMX)](https://defillama.com/yields/pool/b7985457-96d6-49cb-8abc-4487042ad416) => 3x Long GLP (GMX)
4. [3N-ETHUSDC-GRAIL (Camelot)](https://defillama.com/yields/pool/b7fae504-485e-4ddf-9e2b-751ce3e90ae1) => 3x Neutral ETH-USDC (Camelot)

I also have unrelated question: another [PR](https://github.com/DefiLlama/yield-server/pull/787) fixes the chain name from `Avax` to `Avalanche`. Although the PR is closed, the data has been manually updated. For future pools on Avalanche, will it show up as `Avax` or should i implement the update here