### PR TITLE
[OLYMPUS] update to support all balancer/aura vaults from Olympus BLV

### DIFF
--- a/src/adaptors/olympus-dao/index.js
+++ b/src/adaptors/olympus-dao/index.js
@@ -5,8 +5,6 @@ const vaultManager = require('./abis/vaultManagerAbi.json');
 const utils = require('../utils');
 
 const OLYMPUS_LIQUIDITY_REGISTRY = '0x375E06C694B5E50aF8be8FB03495A612eA3e2275';
-const OHM_WSTETH_VAULT =
-  '0xafe729d57d2CC58978C2e01b4EC39C47FB7C4b23'.toLowerCase();
 const AURA_ADDRESS = '0xC0c293ce456fF0ED870ADd98a0828Dd4d2903DBF'.toLowerCase();
 const BAL_ADDRESS = '0xba100000625a3754423978a60c9317c58a424e3D'.toLowerCase();
 const WSTETH_ADDRESS =

--- a/src/adaptors/olympus-dao/index.js
+++ b/src/adaptors/olympus-dao/index.js
@@ -174,7 +174,7 @@ const getAuraAPY = async (address, swapAprs, prices, auraSupply) => {
       await sdk.api.abi
         .call({
           target: address,
-          abi: vaultManager.find((n) => n.name === 'fee'),
+          abi: vaultManager.find((n) => n.name === 'currentFee'),
           chain: 'ethereum',
         })
         .catch(() => {
@@ -218,7 +218,6 @@ const getAuraAPY = async (address, swapAprs, prices, auraSupply) => {
       ((balPerYear - balFee) / tvlUsd) * 100 * prices[BAL_ADDRESS] || 0;
     const auraPerYear = getAuraMintAmount(balPerYear, auraSupply);
     const auraFee = auraPerYear * fee;
-    console.log(auraPerYear, auraFee);
     const apyAura =
       ((auraPerYear - auraFee) / tvlUsd) * 100 * prices[AURA_ADDRESS] || 0;
     const auraExtraApy = auraExtraRewards


### PR DESCRIPTION
This update makes the Olympus Yield Adapter more robust and will support any Vaults that use Balancer and AURA under the hood. 
We're deploying a new LUSD/OHM Vault this week and this update will allow support for this.

In the event additional vault types outside of Balancer/AURA are added in the future, this adapter will drop those gracefully, until the adapter updated.

Changes:
- Remove now unused OHM_WSTETH address variable
- Remove switch statement
- Add a try/catch to getAuraAPY function. return undefined if invalid pool. 
- Filter out any undefined pools from getAuraAPY (a case that shouldn't happen unless a new vault type is eventually deployed)
- Add support for BLV Fees

 