### PR TITLE
Add support for new pool types on Curve and Convex

### DIFF
--- a/src/adaptors/convex-finance/index.js
+++ b/src/adaptors/convex-finance/index.js
@@ -38,7 +38,7 @@ const main = async () => {
 
   const poolsList = (
     await Promise.all(
-      ['factory', 'main', 'crypto', 'factory-crypto'].map((registry) =>
+      ['factory', 'main', 'crypto', 'factory-crypto', 'factory-crvusd'].map((registry) =>
         utils.getData(`https://api.curve.fi/api/getPools/ethereum/${registry}`)
       )
     )

--- a/src/adaptors/convex-finance/index.js
+++ b/src/adaptors/convex-finance/index.js
@@ -38,7 +38,7 @@ const main = async () => {
 
   const poolsList = (
     await Promise.all(
-      ['factory', 'main', 'crypto', 'factory-crypto', 'factory-crvusd'].map((registry) =>
+      ['factory', 'main', 'crypto', 'factory-crypto', 'factory-crvusd', 'factory-tricrypto'].map((registry) =>
         utils.getData(`https://api.curve.fi/api/getPools/ethereum/${registry}`)
       )
     )

--- a/src/adaptors/curve-dex/config.js
+++ b/src/adaptors/curve-dex/config.js
@@ -11,7 +11,7 @@ exports.BLOCKCHAINIDS = [
   // 'celo',
 ];
 // https://github.com/curvefi/curve-api/blob/main/endpoints.md#getpools
-REGISTRY_TYPES = ['main', 'crypto', 'factory', 'factory-crypto', 'optimism'];
+REGISTRY_TYPES = ['main', 'crypto', 'factory', 'factory-crypto', 'optimism', 'factory-crvusd', 'factory-tricrypto'];
 exports.BLOCKCHAINID_TO_REGISTRIES = {};
 exports.BLOCKCHAINIDS.forEach((blockchainId) => {
   switch (blockchainId) {


### PR DESCRIPTION
There are new pool types on Curve and Convex (crvusd & tricrypto factory pools) which uses a new prefix in the platforms API and this isn't currently parsed by the adapter. The PR just adds the new prefix so the pools can be properly handled by the current adapter.