### PR TITLE
[FRAXLEND] - Adding Missing Deployers

### DIFF
--- a/src/adaptors/fraxlend/index.js
+++ b/src/adaptors/fraxlend/index.js
@@ -248,9 +248,7 @@ const main = async () => {
       chain: 'ethereum',
       requery: false,
     })
-  ).output.map((x) => {
-    return x.input.target === MKR ? 'MKR' : x.output;
-  });
+  ).output.map((x) => (x.input.target === MKR ? 'MKR' : x.output));
 
   const decimalCollaterals = (
     await sdk.api.abi.multiCall({

--- a/src/adaptors/fraxlend/index.js
+++ b/src/adaptors/fraxlend/index.js
@@ -8,8 +8,13 @@ const DAY = 24 * HOUR;
 const SECONDS_PER_YEAR = 365 * DAY;
 
 const FRAX = '0x853d955aCEf822Db058eb8505911ED77F175b99e';
+const PAIR_DEPLOYERS = [
+  '0x5d6e79bcf90140585ce88c7119b7e43caaa67044',
+  '0x38488dE975B77dc1b0D4B8569f596f6FD6ca0B92',
+  '0x7AB788d0483551428f2291232477F1818952998C',
+];
+const MKR = '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2'; //Not a standard ERC20. symbol and name are base32 encoded
 const HELPER = {
-  address: '0x5d6e79bcf90140585ce88c7119b7e43caaa67044',
   abis: {
     getAllPairAddresses: {
       inputs: [],
@@ -150,12 +155,19 @@ const VAULTS = {
 
 const main = async () => {
   const vaults = (
-    await sdk.api.abi.call({
-      target: HELPER.address,
-      abi: HELPER.abis.getAllPairAddresses,
-      chain: 'ethereum',
-    })
-  ).output;
+    await Promise.all(
+      PAIR_DEPLOYERS.map(
+        async (deployerAddress) =>
+          (
+            await sdk.api.abi.call({
+              target: deployerAddress,
+              abi: HELPER.abis.getAllPairAddresses,
+              chain: 'ethereum',
+            })
+          ).output
+      )
+    )
+  ).flat();
 
   const collateralContracts = (
     await sdk.api.abi.multiCall({
@@ -234,9 +246,11 @@ const main = async () => {
       })),
       abi: 'erc20:symbol',
       chain: 'ethereum',
-      requery: true,
+      requery: false,
     })
-  ).output.map((x) => x.output);
+  ).output.map((x) => {
+    return x.input.target === MKR ? 'MKR' : x.output;
+  });
 
   const decimalCollaterals = (
     await sdk.api.abi.multiCall({


### PR DESCRIPTION
Two pair deployers were missing. 

see: https://app.frax.finance/fraxlend/available-pairs for complete list of available pairs. 

MKR is a nonstandard ERC20, and the name/symbols are base32 encoded. There's a workaround here to allow for the existing logic to still work if any of the pairs contain MKR (one does).