### PR TITLE
[Midas Capital] add arbitrum and ftm support

### DIFF
--- a/src/adaptors/midas-capital/abiFlywheelLensRouterV2.js
+++ b/src/adaptors/midas-capital/abiFlywheelLensRouterV2.js
@@ -1,0 +1,335 @@
+module.exports = [
+  {
+    inputs: [
+      {
+        internalType: 'contract FusePoolDirectory',
+        name: '_fpd',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'user',
+        type: 'address',
+      },
+    ],
+    name: 'claimAllRewardTokens',
+    outputs: [
+      {
+        internalType: 'address[]',
+        name: '',
+        type: 'address[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: '',
+        type: 'uint256[]',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'user',
+        type: 'address',
+      },
+      {
+        internalType: 'contract ERC20',
+        name: 'market',
+        type: 'address',
+      },
+      {
+        internalType: 'contract MidasFlywheelCore[]',
+        name: 'flywheels',
+        type: 'address[]',
+      },
+      {
+        internalType: 'bool[]',
+        name: 'accrue',
+        type: 'bool[]',
+      },
+    ],
+    name: 'claimRewardsForMarket',
+    outputs: [
+      {
+        internalType: 'contract MidasFlywheelCore[]',
+        name: '',
+        type: 'address[]',
+      },
+      {
+        internalType: 'address[]',
+        name: 'rewardTokens',
+        type: 'address[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'rewards',
+        type: 'uint256[]',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'user',
+        type: 'address',
+      },
+      {
+        internalType: 'contract ERC20[]',
+        name: 'markets',
+        type: 'address[]',
+      },
+      {
+        internalType: 'contract MidasFlywheelCore[]',
+        name: 'flywheels',
+        type: 'address[]',
+      },
+      {
+        internalType: 'bool[]',
+        name: 'accrue',
+        type: 'bool[]',
+      },
+    ],
+    name: 'claimRewardsForMarkets',
+    outputs: [
+      {
+        internalType: 'contract MidasFlywheelCore[]',
+        name: '',
+        type: 'address[]',
+      },
+      {
+        internalType: 'address[]',
+        name: 'rewardTokens',
+        type: 'address[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'rewards',
+        type: 'uint256[]',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'user',
+        type: 'address',
+      },
+      {
+        internalType: 'contract IComptroller',
+        name: 'comptroller',
+        type: 'address',
+      },
+    ],
+    name: 'claimRewardsForPool',
+    outputs: [
+      {
+        internalType: 'contract MidasFlywheelCore[]',
+        name: '',
+        type: 'address[]',
+      },
+      {
+        internalType: 'address[]',
+        name: '',
+        type: 'address[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: '',
+        type: 'uint256[]',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'user',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'rewardToken',
+        type: 'address',
+      },
+    ],
+    name: 'claimRewardsOfRewardToken',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'rewardsClaimed',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'fpd',
+    outputs: [
+      {
+        internalType: 'contract FusePoolDirectory',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getAllRewardTokens',
+    outputs: [
+      {
+        internalType: 'address[]',
+        name: 'uniqueRewardTokens',
+        type: 'address[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract ICErc20[]',
+        name: 'markets',
+        type: 'address[]',
+      },
+    ],
+    name: 'getMarketRewardsInfo',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'underlyingPrice',
+            type: 'uint256',
+          },
+          {
+            internalType: 'contract ICErc20',
+            name: 'market',
+            type: 'address',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint256',
+                name: 'rewardSpeedPerSecondPerToken',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'rewardTokenPrice',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'formattedAPR',
+                type: 'uint256',
+              },
+              {
+                internalType: 'address',
+                name: 'flywheel',
+                type: 'address',
+              },
+              {
+                internalType: 'address',
+                name: 'rewardToken',
+                type: 'address',
+              },
+            ],
+            internalType: 'struct MidasFlywheelLensRouter.RewardsInfo[]',
+            name: 'rewardsInfo',
+            type: 'tuple[]',
+          },
+        ],
+        internalType: 'struct MidasFlywheelLensRouter.MarketRewardsInfo[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IComptroller',
+        name: 'comptroller',
+        type: 'address',
+      },
+    ],
+    name: 'getPoolMarketRewardsInfo',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'underlyingPrice',
+            type: 'uint256',
+          },
+          {
+            internalType: 'contract ICErc20',
+            name: 'market',
+            type: 'address',
+          },
+          {
+            components: [
+              {
+                internalType: 'uint256',
+                name: 'rewardSpeedPerSecondPerToken',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'rewardTokenPrice',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'formattedAPR',
+                type: 'uint256',
+              },
+              {
+                internalType: 'address',
+                name: 'flywheel',
+                type: 'address',
+              },
+              {
+                internalType: 'address',
+                name: 'rewardToken',
+                type: 'address',
+              },
+            ],
+            internalType: 'struct MidasFlywheelLensRouter.RewardsInfo[]',
+            name: 'rewardsInfo',
+            type: 'tuple[]',
+          },
+        ],
+        internalType: 'struct MidasFlywheelLensRouter.MarketRewardsInfo[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];

--- a/src/adaptors/midas-capital/index.js
+++ b/src/adaptors/midas-capital/index.js
@@ -5,7 +5,8 @@ const { ethers } = require('ethers');
 const utils = require('../utils');
 const poolDirectoryAbi = require('../midas-capital/abiPoolDirectory');
 const poolLensAbi = require('../midas-capital/abiPoolLens');
-const flywheelLensRouterAbi = require('../midas-capital/abiFlywheelLensRouter');
+const flywheelLensRouterAbiV1 = require('../midas-capital/abiFlywheelLensRouter');
+const flywheelLensRouterAbiV2 = require('../midas-capital/abiFlywheelLensRouterV2');
 
 const CHAINS = {
   arbitrum: 'arbitrum',
@@ -59,6 +60,7 @@ const GET_ACTIVE_POOLS = 'getActivePools';
 const POOLS = 'pools';
 const GET_POOL_ASSETS_WITH_DATA = 'getPoolAssetsWithData';
 const GET_MARKET_REWARDS_INFO = 'getMarketRewardsInfo';
+const GET_MARKET_REWARDS_INFO_ARBITRUM = 'getPoolMarketRewardsInfo';
 
 const PROJECT_NAME = 'midas-capital';
 const PROJECT_URL = 'https://development.midascapital.xyz';
@@ -109,6 +111,10 @@ const main = async () => {
             params: [Number(poolId)],
           })
         ).output;
+        const flywheelLensRouterAbi =
+          chain === 'arbitrum'
+            ? flywheelLensRouterAbiV2
+            : flywheelLensRouterAbiV1;
 
         const marketRewards = (
           await sdk.api.abi
@@ -116,7 +122,11 @@ const main = async () => {
               target: MIDAS_FLYWHEEL_LENS_ROUTER[chain],
               chain: chain,
               abi: flywheelLensRouterAbi.find(
-                ({ name }) => name === GET_MARKET_REWARDS_INFO
+                ({ name }) =>
+                  name ===
+                  (chain === 'arbitrum'
+                    ? GET_MARKET_REWARDS_INFO_ARBITRUM
+                    : GET_MARKET_REWARDS_INFO)
               ),
               params: [comptroller],
             })


### PR DESCRIPTION
Arbitrum and fantom were missing from the adapter. 
Add new lens router abi for arbitrum and logic for handling new reward function.
Arbitrum is using ETH for its underlying price, hence when coingecko:ethereum is referenced under CG_key

contracts pulled from here: 
https://github.com/Midas-Protocol/monorepo/tree/development/packages/chains/deployments

app: https://app.midascapital.xyz/

