### PR TITLE
across: Add POOL token

### DIFF
--- a/src/adaptors/across/constants.js
+++ b/src/adaptors/across/constants.js
@@ -42,6 +42,10 @@ const tokens = {
     address: '0xba100000625a3754423978a60c9317c58a424e3d',
     lpAddress: '0xfacd2ec4647df2cb758f684c2aaab56a93288f9e',
   },
+  POOL: {
+    address: '0x0cec1a9154ff802e7934fc916ed7ca50bde6844e',
+    lpAddress: '0xc3f35d90ebce372ded12029b72b22a23a2f637fd',
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
POOL is now supported by Across.