### PR TITLE
Sommelier: Remove subgraph dependency + Add TurboSWETH cellar

### DIFF
--- a/src/adaptors/sommelier/apy.js
+++ b/src/adaptors/sommelier/apy.js
@@ -1,0 +1,115 @@
+const { default: BigNumber } = require('bignumber.js');
+const sdk = require('@defillama/sdk');
+const cellarAbi = require('./cellar-v2.json');
+const { chain } = require('./config');
+const { endOfYesterday, subDays } = require('date-fns');
+const utils = require('../utils');
+
+const call = sdk.api.abi.call;
+
+const abiDecimals = cellarAbi.find((el) => el.name === 'decimals');
+const abiConvertToAssets = cellarAbi.find(
+  (el) => el.name === 'convertToAssets'
+);
+
+const getPositionAssets = cellarAbi.find(
+  (el) => el.name === 'getPositionAssets'
+);
+
+async function getBlockByEpoch(epochSecs) {
+  if (!Number.isInteger) {
+    throw new Error('getBlockByEpoch was not passed an integer');
+  }
+
+  const data = await utils.getData(
+    `https://coins.llama.fi/block/ethereum/${epochSecs}`
+  );
+
+  return data.height;
+}
+
+async function getShareValueAtBlock(cellarAddress, block) {
+  const decimals = (
+    await call({
+      target: cellarAddress,
+      abi: abiDecimals,
+      chain,
+    })
+  ).output;
+
+  const share = new BigNumber(10).pow(decimals);
+
+  const shareValue = (
+    await call({
+      target: cellarAddress,
+      abi: abiConvertToAssets,
+      params: [share.toString()],
+      block,
+      chain,
+    })
+  ).output;
+
+  return new BigNumber(shareValue);
+}
+
+async function calcApy(
+  cellarAddress,
+  startEpochSecs,
+  endEpochSecs,
+  intervalDays
+) {
+  const startBlock = await getBlockByEpoch(startEpochSecs);
+  const endBlock = await getBlockByEpoch(endEpochSecs);
+
+  const startValue = await getShareValueAtBlock(cellarAddress, startBlock);
+  const endValue = await getShareValueAtBlock(cellarAddress, endBlock);
+
+  const yieldRatio = endValue.minus(startValue).div(startValue);
+  const result = yieldRatio
+    .times(365 / intervalDays)
+    .times(100)
+    .toNumber();
+
+  return Number.isNaN(result) ? 0 : result;
+}
+
+function utcToday() {
+  const dateString = new Date().toISOString().split('T')[0];
+  return new Date(`${dateString}T00:00:00.000Z`);
+}
+
+function utcEndOfYesterday() {
+  const today = utcToday();
+  return new Date(today.getTime() - 1000);
+}
+
+async function getApy(cellarAddress) {
+  const yesterday = utcEndOfYesterday();
+  const start = subDays(yesterday, 1);
+
+  const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
+  const startEpoch = Math.floor(start.getTime() / 1000);
+
+  return calcApy(cellarAddress, startEpoch, yesterdayEpoch, 1);
+}
+
+async function getApy7d(cellarAddress) {
+  const interval = 7; // days
+  const yesterday = utcEndOfYesterday();
+
+  // Subtract 6 days because we are including yesterday
+  const start = subDays(yesterday, interval - 1);
+
+  const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
+  const startEpoch = Math.floor(start.getTime() / 1000);
+
+  return calcApy(cellarAddress, startEpoch, yesterdayEpoch, interval);
+}
+
+module.exports = {
+  getBlockByEpoch,
+  getShareValueAtBlock,
+  calcApy,
+  getApy,
+  getApy7d,
+};

--- a/src/adaptors/sommelier/cellar-v2p5.json
+++ b/src/adaptors/sommelier/cellar-v2p5.json
@@ -1,0 +1,2173 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "contract Registry",
+        "name": "_registry",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ERC20",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_symbol",
+        "type": "string"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_holdingPosition",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_holdingPositionConfig",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_initialDeposit",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_strategistPlatformCut",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint192",
+        "name": "_shareSupplyCap",
+        "type": "uint192"
+      },
+      {
+        "internalType": "address",
+        "name": "_balancerVault",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "expectedAsset",
+        "type": "address"
+      }
+    ],
+    "name": "Cellar__AssetMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adaptor",
+        "type": "address"
+      }
+    ],
+    "name": "Cellar__CallToAdaptorNotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__CallerNotApprovedToRebalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__CallerNotBalancerVault",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__ContractNotShutdown",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__ContractShutdown",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "position",
+        "type": "uint32"
+      }
+    ],
+    "name": "Cellar__DebtMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__ExpectedAddressDoesNotMatchActual",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__ExternalInitiator",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__FailedToForceOutPosition",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "illiquidPosition",
+        "type": "address"
+      }
+    ],
+    "name": "Cellar__IlliquidWithdraw",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assetsOwed",
+        "type": "uint256"
+      }
+    ],
+    "name": "Cellar__IncompleteWithdraw",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__InvalidFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__InvalidFeeCut",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "positionId",
+        "type": "uint32"
+      }
+    ],
+    "name": "Cellar__InvalidHoldingPosition",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "Cellar__InvalidRebalanceDeviation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__InvalidShareSupplyCap",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__MinimumConstructorMintNotMet",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__OracleFailure",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__Paused",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "position",
+        "type": "uint32"
+      }
+    ],
+    "name": "Cellar__PositionAlreadyUsed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxPositions",
+        "type": "uint256"
+      }
+    ],
+    "name": "Cellar__PositionArrayFull",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "position",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "sharesRemaining",
+        "type": "uint256"
+      }
+    ],
+    "name": "Cellar__PositionNotEmpty",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "position",
+        "type": "uint32"
+      }
+    ],
+    "name": "Cellar__PositionNotInCatalogue",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "position",
+        "type": "uint32"
+      }
+    ],
+    "name": "Cellar__PositionNotUsed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__RemovingHoldingPosition",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__SettingValueToRegistryIdZeroIsProhibited",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__ShareSupplyCapExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "min",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "Cellar__TotalAssetDeviatedOutsideRange",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "current",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expected",
+        "type": "uint256"
+      }
+    ],
+    "name": "Cellar__TotalSharesMustRemainConstant",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__ZeroAssets",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Cellar__ZeroShares",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "adaptor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "AdaptorCalled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "adaptor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "inCatalogue",
+        "type": "bool"
+      }
+    ],
+    "name": "AdaptorCatalogueAltered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAutomationActions",
+        "type": "address"
+      }
+    ],
+    "name": "Cellar__AutomationActionsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "position",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "PositionAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "positionId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "inCatalogue",
+        "type": "bool"
+      }
+    ],
+    "name": "PositionCatalogueAltered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "position",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "PositionRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newPosition1",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newPosition2",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index2",
+        "type": "uint256"
+      }
+    ],
+    "name": "PositionSwapped",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldDeviation",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newDeviation",
+        "type": "uint256"
+      }
+    ],
+    "name": "RebalanceDeviationChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOracle",
+        "type": "address"
+      }
+    ],
+    "name": "SharePriceOracleUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isShutdown",
+        "type": "bool"
+      }
+    ],
+    "name": "ShutdownChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldPayoutAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newPayoutAddress",
+        "type": "address"
+      }
+    ],
+    "name": "StrategistPayoutAddressChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "oldPlatformCut",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "newPlatformCut",
+        "type": "uint64"
+      }
+    ],
+    "name": "StrategistPlatformCutChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "GRAVITY_BRIDGE_REGISTRY_SLOT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_FEE_CUT",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_PLATFORM_FEE",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_POSITIONS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_REBALANCE_DEVIATION",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ORACLE_DECIMALS",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_ROUTER_REGISTRY_SLOT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "adaptorCatalogue",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adaptor",
+        "type": "address"
+      }
+    ],
+    "name": "addAdaptorToCatalogue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "index",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "positionId",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "configurationData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bool",
+        "name": "inDebtArray",
+        "type": "bool"
+      }
+    ],
+    "name": "addPosition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "positionId",
+        "type": "uint32"
+      }
+    ],
+    "name": "addPositionToCatalogue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "allowedRebalanceDeviation",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "asset",
+    "outputs": [
+      {
+        "internalType": "contract ERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "automationActions",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "balancerVault",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "blockExternalReceiver",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "checkTotalAssets",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint16",
+        "name": "allowableRange",
+        "type": "uint16"
+      },
+      {
+        "internalType": "address",
+        "name": "expectedPriceRouter",
+        "type": "address"
+      }
+    ],
+    "name": "cachePriceRouter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "adaptor",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes[]",
+            "name": "callData",
+            "type": "bytes[]"
+          }
+        ],
+        "internalType": "struct Cellar.AdaptorCall[]",
+        "name": "data",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "callOnAdaptor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToShares",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "creditPositions",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "debtPositions",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint192",
+        "name": "_newShareSupplyCap",
+        "type": "uint192"
+      }
+    ],
+    "name": "decreaseShareSupplyCap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeData",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "strategistPlatformCut",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "platformFee",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "lastAccrual",
+        "type": "uint64"
+      },
+      {
+        "internalType": "address",
+        "name": "strategistPayoutAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "index",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "positionId",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bool",
+        "name": "inDebtArray",
+        "type": "bool"
+      }
+    ],
+    "name": "forcePositionOut",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCreditPositions",
+    "outputs": [
+      {
+        "internalType": "uint32[]",
+        "name": "",
+        "type": "uint32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDebtPositions",
+    "outputs": [
+      {
+        "internalType": "uint32[]",
+        "name": "",
+        "type": "uint32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "name": "getPositionData",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "adaptor",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "isDebt",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "adaptorData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "configurationData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "holdingPosition",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ignorePause",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint192",
+        "name": "_newShareSupplyCap",
+        "type": "uint192"
+      }
+    ],
+    "name": "increaseShareSupplyCap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initiateShutdown",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "isPositionUsed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isShutdown",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "liftShutdown",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "locked",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxDeposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxMint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "maxRedeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "maxWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "multicall",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "name": "positionCatalogue",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewDeposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewMint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewRedeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceRouter",
+    "outputs": [
+      {
+        "internalType": "contract PriceRouter",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "feeAmounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "receiveFlashLoan",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "redeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "registry",
+    "outputs": [
+      {
+        "internalType": "contract Registry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "adaptor",
+        "type": "address"
+      }
+    ],
+    "name": "removeAdaptorFromCatalogue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "index",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bool",
+        "name": "inDebtArray",
+        "type": "bool"
+      }
+    ],
+    "name": "removePosition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "positionId",
+        "type": "uint32"
+      }
+    ],
+    "name": "removePositionFromCatalogue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_registryId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_expectedAutomationActions",
+        "type": "address"
+      }
+    ],
+    "name": "setAutomationActions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "positionId",
+        "type": "uint32"
+      }
+    ],
+    "name": "setHoldingPosition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newDeviation",
+        "type": "uint256"
+      }
+    ],
+    "name": "setRebalanceDeviation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_registryId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract ERC4626SharePriceOracle",
+        "name": "_sharePriceOracle",
+        "type": "address"
+      }
+    ],
+    "name": "setSharePriceOracle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "payout",
+        "type": "address"
+      }
+    ],
+    "name": "setStrategistPayoutAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "cut",
+        "type": "uint64"
+      }
+    ],
+    "name": "setStrategistPlatformCut",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sharePriceOracle",
+    "outputs": [
+      {
+        "internalType": "contract ERC4626SharePriceOracle",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "shareSupplyCap",
+    "outputs": [
+      {
+        "internalType": "uint192",
+        "name": "",
+        "type": "uint192"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "index1",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "index2",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bool",
+        "name": "inDebtArray",
+        "type": "bool"
+      }
+    ],
+    "name": "swapPositions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "toggleIgnorePause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAssetsWithdrawable",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "viewPositionBalances",
+    "outputs": [
+      {
+        "internalType": "contract ERC20[]",
+        "name": "assets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "balances",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bool[]",
+        "name": "isDebt",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]
+

--- a/src/adaptors/sommelier/config.js
+++ b/src/adaptors/sommelier/config.js
@@ -38,7 +38,7 @@ const stakingPools = {
   [realYieldBtc]: '0x1eff374fd9aa7266504144da861fff9bbd31828e',
   [defiStars]: '0x0349b3c56adb9e39b5d75fc1df52eee313dd80d1',
   [fraximal]: '0x290a42e913083edf5aefb241f8a12b306c19f8f9',
-  [turbosweth]: '0x8930ad2b661a3192d4b88f8bd02870a1db035589',
+  [turbosweth]: '0x69374d81fdc42add0fe1dc655705e40b51b6681b',
 };
 
 // List of v0815 Cellars

--- a/src/adaptors/sommelier/config.js
+++ b/src/adaptors/sommelier/config.js
@@ -12,6 +12,7 @@ const realYieldSNX = '0xcbf2250f33c4161e18d4a2fa47464520af5216b5';
 const realYieldENS = '0x18ea937aba6053bc232d9ae2c42abe7a8a2be440';
 const fraximal = '0xdbe19d1c3f21b1bb250ca7bdae0687a97b5f77e6';
 const realYieldBtc = '0x0274a704a6d9129f90a62ddc6f6024b33ecdad36';
+const turbosweth = '0xd33dad974b938744dac81fe00ac67cb5aa13958e';
 
 // Rewards are paid out in EVM SOMM
 const rewardTokens = ['0xa670d7237398238de01267472c6f13e5b8010fd1'];
@@ -37,6 +38,7 @@ const stakingPools = {
   [realYieldBtc]: '0x1eff374fd9aa7266504144da861fff9bbd31828e',
   [defiStars]: '0x0349b3c56adb9e39b5d75fc1df52eee313dd80d1',
   [fraximal]: '0x290a42e913083edf5aefb241f8a12b306c19f8f9',
+  [turbosweth]: '0x8930ad2b661a3192d4b88f8bd02870a1db035589',
 };
 
 // List of v0815 Cellars
@@ -261,6 +263,23 @@ const v2Pools = [
   },
 ];
 
+const v2p5Pools = [
+  {
+    pool: `${turbosweth}-ethereum`,
+    chain,
+    project,
+    symbol: 'WETH-SWETH',
+    poolMeta: 'TurboSWETH',
+    tvlUsd: 0,
+    apyBase: 0,
+    apyReward: 0,
+    rewardTokens,
+    underlyingTokens: [],
+    // FIXME: Double check url on launch
+    url: 'https://app.sommelier.finance/strategies/Turbo-SWETH',
+  },
+];
+
 module.exports = {
   chain,
   project,
@@ -269,5 +288,6 @@ module.exports = {
   v0815Pools,
   v0816Pools,
   v2Pools,
+  v2p5Pools,
   realYieldEth,
 };

--- a/src/adaptors/sommelier/config.js
+++ b/src/adaptors/sommelier/config.js
@@ -275,7 +275,6 @@ const v2p5Pools = [
     apyReward: 0,
     rewardTokens,
     underlyingTokens: [],
-    // FIXME: Double check url on launch
     url: 'https://app.sommelier.finance/strategies/Turbo-SWETH',
   },
 ];

--- a/src/adaptors/sommelier/config.js
+++ b/src/adaptors/sommelier/config.js
@@ -269,4 +269,5 @@ module.exports = {
   v0815Pools,
   v0816Pools,
   v2Pools,
+  realYieldEth,
 };

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -9,6 +9,7 @@ const {
   v0815Pools,
   v0816Pools,
   v2Pools,
+  v2p5Pools,
 } = require('./config');
 const v0815 = require('./v0-8-15');
 const v0816 = require('./v0-8-16');
@@ -67,6 +68,10 @@ async function main() {
 
   // V2
   promises = promises.concat(v2Pools.map((pool) => handleV2(pool, prices)));
+
+  // V2.5
+  // no change in implementation from v2 -> v2.5
+  promises = promises.concat(v2p5Pools.map((pool) => handleV2(pool, prices)));
 
   const pools = await Promise.all(promises);
 

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -61,12 +61,12 @@ async function main() {
   let promises = [];
   // Calculate TVL, APRs (with rewards if applicable) for each cellar version
   // V1
-  // promises = v0815Pools.map((pool) => handleV0815(pool, prices));
+  promises = v0815Pools.map((pool) => handleV0815(pool, prices));
 
   // V1.5
-  // promises = promises.concat(
-  //   v0816Pools.map((pool) => handleV0816(pool, prices))
-  // );
+  promises = promises.concat(
+    v0816Pools.map((pool) => handleV0816(pool, prices))
+  );
 
   // V2
   promises = promises.concat(v2Pools.map((pool) => handleV2(pool, prices)));
@@ -74,7 +74,7 @@ async function main() {
   // V2.5
   // no change in implementation from v2 -> v2.5
   // TODO: fix getPositionAssets
-  // promises = promises.concat(v2p5Pools.map((pool) => handleV2(pool, prices)));
+  promises = promises.concat(v2p5Pools.map((pool) => handleV2(pool, prices)));
 
   const pools = await Promise.all(promises);
 

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -45,16 +45,27 @@ async function getHoldingPositions() {
 }
 
 async function main() {
+  // Grab all holding positions across all cellars
   const assets = await getHoldingPositions();
+
+  // List of holding position tokens and sommelier token
   const tokens = ['coingecko:sommelier', ...assets.map((a) => `ethereum:${a}`)];
+
+  // Fetch prices for all assets upfront
   const prices = await utils.getPrices(tokens);
   const sommPrice = prices.pricesBySymbol.somm;
 
   let promises = [];
+  // Calculate TVL, APRs (with rewards if applicable) for each cellar version
+  // V1
   promises = v0815Pools.map((pool) => handleV0815(pool, prices));
+
+  // V1.5
   promises = promises.concat(
     v0816Pools.map((pool) => handleV0816(pool, prices))
   );
+
+  // V2
   promises = promises.concat(v2Pools.map((pool) => handleV2(pool, prices)));
 
   const pools = await Promise.all(promises);

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -45,6 +45,8 @@ async function getHoldingPositions() {
   return [...v1Assets, ...v15Assets, ...v2Assets];
 }
 
+const { getShareValueAtBlock, getBlockByEpoch } = require('./v2');
+
 async function main() {
   // Grab all holding positions across all cellars
   const assets = await getHoldingPositions();
@@ -59,19 +61,20 @@ async function main() {
   let promises = [];
   // Calculate TVL, APRs (with rewards if applicable) for each cellar version
   // V1
-  promises = v0815Pools.map((pool) => handleV0815(pool, prices));
+  // promises = v0815Pools.map((pool) => handleV0815(pool, prices));
 
   // V1.5
-  promises = promises.concat(
-    v0816Pools.map((pool) => handleV0816(pool, prices))
-  );
+  // promises = promises.concat(
+  //   v0816Pools.map((pool) => handleV0816(pool, prices))
+  // );
 
   // V2
   promises = promises.concat(v2Pools.map((pool) => handleV2(pool, prices)));
 
   // V2.5
   // no change in implementation from v2 -> v2.5
-  promises = promises.concat(v2p5Pools.map((pool) => handleV2(pool, prices)));
+  // TODO: fix getPositionAssets
+  // promises = promises.concat(v2p5Pools.map((pool) => handleV2(pool, prices)));
 
   const pools = await Promise.all(promises);
 
@@ -136,7 +139,7 @@ async function handleV2(pool, prices) {
   const assetPrice = prices.pricesByAddress[asset.toLowerCase()];
 
   const apyBase = await v2.getApy(cellarAddress);
-  const apyBase7d = await v2.getApy7d(cellarAddress);
+  // const apyBase7d = await v2.getApy7d(cellarAddress);
 
   // getTvlUsd implementation hasn't changed since v1.5 (v0.8.16)
   const tvlUsd = await v0816.getTvlUsd(cellarAddress, asset);
@@ -145,7 +148,7 @@ async function handleV2(pool, prices) {
     ...pool,
     tvlUsd,
     apyBase,
-    apyBase7d,
+    // apyBase7d,
     underlyingTokens,
   };
 

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -84,7 +84,6 @@ async function main() {
   promises = promises.concat(v2Pools.map((pool) => handleV2(pool, prices)));
 
   // V2.5
-  // no change in implementation from v2 -> v2.5
   promises = promises.concat(v2p5Pools.map((pool) => handleV2p5(pool, prices)));
 
   const pools = await Promise.all(promises);

--- a/src/adaptors/sommelier/index.js
+++ b/src/adaptors/sommelier/index.js
@@ -163,7 +163,7 @@ async function handleV2plus(pool, prices, underlyingTokens) {
   const assetPrice = prices.pricesByAddress[asset.toLowerCase()];
 
   const apyBase = await v2.getApy(cellarAddress);
-  // const apyBase7d = await v2.getApy7d(cellarAddress);
+  const apyBase7d = await v2.getApy7d(cellarAddress);
 
   // getTvlUsd implementation hasn't changed since v1.5 (v0.8.16)
   const tvlUsd = await v0816.getTvlUsd(cellarAddress, asset);
@@ -172,7 +172,7 @@ async function handleV2plus(pool, prices, underlyingTokens) {
     ...pool,
     tvlUsd,
     apyBase,
-    // apyBase7d,
+    apyBase7d,
     underlyingTokens,
   };
 

--- a/src/adaptors/sommelier/v0-8-15.js
+++ b/src/adaptors/sommelier/v0-8-15.js
@@ -1,35 +1,11 @@
 const { default: BigNumber } = require('bignumber.js');
-const { request, gql } = require('graphql-request');
 const sdk = require('@defillama/sdk');
 const utils = require('../utils');
-const queries = require('./queries');
 const cellarAbi = require('./cellar-v0-8-15.json');
 const { chain } = require('./config');
+const { getApy } = require('./apy');
 
 const call = sdk.api.abi.call;
-
-async function getApy(cellarAddress) {
-  const dayData = await queries.getDayData(cellarAddress, 30);
-
-  // Find the most recent accural event (the date shareValue changed)
-  // Use the yield / loss to extrapolate APR
-  const idx = dayData.findIndex((el, idx, arr) => {
-    if (idx === dayData.length - 1) return false;
-
-    const price = el.shareValue;
-    const prevPrice = arr[idx + 1].shareValue;
-
-    return prevPrice !== price;
-  });
-
-  if (idx < 0) return 0;
-
-  const price = new BigNumber(dayData[idx].shareValue);
-  const prevPrice = new BigNumber(dayData[idx + 1].shareValue);
-  const yieldRatio = price.minus(prevPrice).div(prevPrice);
-
-  return yieldRatio.times(52).times(100).toNumber();
-}
 
 async function getUnderlyingTokens(cellarAddress) {
   const asset = (

--- a/src/adaptors/sommelier/v0-8-16.js
+++ b/src/adaptors/sommelier/v0-8-16.js
@@ -1,23 +1,11 @@
 const { default: BigNumber } = require('bignumber.js');
-const { request, gql } = require('graphql-request');
 const sdk = require('@defillama/sdk');
 const utils = require('../utils');
-const queries = require('./queries');
 const cellarAbi = require('./cellar-v0-8-16.json');
 const { chain } = require('./config');
+const { getApy } = require('./apy');
 
 const call = sdk.api.abi.call;
-
-// Use the change in price over 30 days to extrapolate an APR
-async function getApy(cellarAddress) {
-  const dayData = await queries.getDayData(cellarAddress, 30);
-
-  const price = new BigNumber(dayData[0].shareValue);
-  const prevPrice = new BigNumber(dayData[dayData.length - 1].shareValue);
-  const yieldRatio = price.minus(prevPrice).div(prevPrice);
-
-  return yieldRatio.times(12).times(100).toNumber();
-}
 
 // Call getPositions() to get a list of assets held by the Cellar
 async function getUnderlyingTokens(cellarAddress) {

--- a/src/adaptors/sommelier/v2-subgraph.js
+++ b/src/adaptors/sommelier/v2-subgraph.js
@@ -1,0 +1,70 @@
+// deprecated v2 apy implementations using subgraph
+
+// Calculate daily APY given a start and end time in seconds since epoch
+// APY should only be calculated with data from a full day. To calculate today's
+// APY, use the complete data from the previous 2 days.
+async function calcApy2(cellarAddress, startEpochSecs, endEpochSecs) {
+  // Returns hourData in desc order, current hour is index 0
+  const hrData = await queries.getHourData(
+    cellarAddress,
+    startEpochSecs,
+    endEpochSecs
+  );
+
+  // How many seconds have elapsed today
+  const remainder = endEpochSecs % dayInSec;
+  // Start of the 2nd day
+  const startOfEnd =
+    remainder === 0 ? endEpochSecs - dayInSec : endEpochSecs - remainder;
+
+  // Bucket hr datas by date
+  const dayBefore = hrData.filter((data) => data.date >= startOfEnd);
+  const twoDaysBefore = hrData.filter((data) => data.date < startOfEnd);
+
+  // Sum hourly price of the last 2 days individually
+  let sumPrice = dayBefore.reduce((memo, data) => {
+    return memo.plus(data.shareValue);
+  }, new BigNumber(0));
+
+  let sumPrevPrice = twoDaysBefore.reduce((memo, data) => {
+    return memo.plus(data.shareValue);
+  }, new BigNumber(0));
+
+  // Calculate yesterday's yield
+  const price = sumPrice.div(dayBefore.length);
+  const prevPrice = sumPrevPrice.div(twoDaysBefore.length);
+  const yieldRatio = price.minus(prevPrice).div(prevPrice);
+
+  const result = yieldRatio.times(365).times(100).toNumber();
+
+  return Number.isNaN(result) ? 0 : result;
+}
+
+// Use the change in avg daily price between the last 2 days to calculate an APR
+async function getApy2(cellarAddress) {
+  const now = Math.floor(Date.now() / 1000);
+  const remainder = now % dayInSec;
+  const end = now - remainder - 1;
+  const start = end - dayInSec - dayInSec + 1;
+
+  return calcApy(cellarAddress, start, end);
+}
+
+const windowInDays = 7;
+
+async function getApy7d2(cellarAddress) {
+  // Returns dayData in desc order, today is index 0
+  const dayData = await queries.getDayData(cellarAddress, windowInDays);
+
+  // Need a minimum of 7 days to calculate yield
+  if (dayData.length < 7) {
+    return 0;
+  }
+
+  const price = new BigNumber(dayData[0].shareValue); // Now price
+  const prevPrice = new BigNumber(dayData[dayData.length - 1].shareValue); // Comparison price
+  const yieldRatio = price.minus(prevPrice).div(prevPrice);
+
+  const result = yieldRatio.times(52).times(100).toNumber();
+  return Number.isNaN(result) ? 0 : result;
+}

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -10,7 +10,9 @@ const call = sdk.api.abi.call;
 
 const abiAsset = cellarAbi.find((el) => el.name === 'asset');
 const abiDecimals = cellarAbi.find((el) => el.name === 'decimals');
-const abiConverToAssets = cellarAbi.find((el) => el.name === 'convertToAssets');
+const abiConvertToAssets = cellarAbi.find(
+  (el) => el.name === 'convertToAssets'
+);
 
 const getPositionAssets = cellarAbi.find(
   (el) => el.name === 'getPositionAssets'
@@ -45,7 +47,7 @@ async function getShareValueAtBlock(cellarAddress, block) {
   const shareValue = (
     await call({
       target: cellarAddress,
-      abi: abiConverToAssets,
+      abi: abiConvertToAssets,
       params: [share.toString()],
       block,
       chain,

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -2,7 +2,7 @@ const { default: BigNumber } = require('bignumber.js');
 const sdk = require('@defillama/sdk');
 const queries = require('./queries');
 const cellarAbi = require('./cellar-v2.json');
-const { chain } = require('./config');
+const { chain, realYieldEth } = require('./config');
 
 const call = sdk.api.abi.call;
 
@@ -98,6 +98,14 @@ async function getUnderlyingTokens(cellarAddress) {
 }
 
 async function getHoldingPosition(cellarAddress) {
+  if (cellarAddress === realYieldEth) {
+    // WETH
+    // We need to hardcode this temporarily since the holding position was changed
+    // to the vesting position in order to block deposits. Otherwise, the call below
+    // will revert and it will break.
+    return '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+  }
+
   const asset = (
     await call({
       target: cellarAddress,

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -3,10 +3,15 @@ const sdk = require('@defillama/sdk');
 const queries = require('./queries');
 const cellarAbi = require('./cellar-v2.json');
 const { chain, realYieldEth } = require('./config');
+const { endOfYesterday, subDays } = require('date-fns');
+const utils = require('../utils');
 
 const call = sdk.api.abi.call;
 
 const abiAsset = cellarAbi.find((el) => el.name === 'asset');
+const abiDecimals = cellarAbi.find((el) => el.name === 'decimals');
+const abiConverToAssets = cellarAbi.find((el) => el.name === 'convertToAssets');
+
 const getPositionAssets = cellarAbi.find(
   (el) => el.name === 'getPositionAssets'
 );
@@ -14,73 +19,83 @@ const getPositionAssets = cellarAbi.find(
 const windowInHrs = 48; // 2 days
 const dayInSec = 60 * 60 * 24; // 1 day in seconds
 
-// Calculate daily APY given a start and end time in seconds since epoch
-// APY should only be calculated with data from a full day. To calculate today's
-// APY, use the complete data from the previous 2 days.
-async function calcApy(cellarAddress, startEpochSecs, endEpochSecs) {
-  // Returns hourData in desc order, current hour is index 0
-  const hrData = await queries.getHourData(
-    cellarAddress,
-    startEpochSecs,
-    endEpochSecs
+async function getBlockByEpoch(epochSecs) {
+  if (!Number.isInteger) {
+    throw new Error('getBlockByEpoch was not passed an integer');
+  }
+
+  const data = await utils.getData(
+    `https://coins.llama.fi/block/ethereum/${epochSecs}`
   );
 
-  // How many seconds have elapsed today
-  const remainder = endEpochSecs % dayInSec;
-  // Start of the 2nd day
-  const startOfEnd =
-    remainder === 0 ? endEpochSecs - dayInSec : endEpochSecs - remainder;
+  return data.height;
+}
 
-  // Bucket hr datas by date
-  const dayBefore = hrData.filter((data) => data.date >= startOfEnd);
-  const twoDaysBefore = hrData.filter((data) => data.date < startOfEnd);
+async function getShareValueAtBlock(cellarAddress, block) {
+  const decimals = (
+    await call({
+      target: cellarAddress,
+      abi: abiDecimals,
+      chain,
+    })
+  ).output;
 
-  // Sum hourly price of the last 2 days individually
-  let sumPrice = dayBefore.reduce((memo, data) => {
-    return memo.plus(data.shareValue);
-  }, new BigNumber(0));
+  const share = new BigNumber(10).pow(decimals);
 
-  let sumPrevPrice = twoDaysBefore.reduce((memo, data) => {
-    return memo.plus(data.shareValue);
-  }, new BigNumber(0));
+  const shareValue = (
+    await call({
+      target: cellarAddress,
+      abi: abiConverToAssets,
+      params: [share.toString()],
+      block,
+      chain,
+    })
+  ).output;
 
-  // Calculate yesterday's yield
-  const price = sumPrice.div(dayBefore.length);
-  const prevPrice = sumPrevPrice.div(twoDaysBefore.length);
-  const yieldRatio = price.minus(prevPrice).div(prevPrice);
+  return new BigNumber(shareValue);
+}
 
+async function calcApy(cellarAddress, startEpochSecs, endEpochSecs) {
+  const startBlock = await getBlockByEpoch(startEpochSecs);
+  const endBlock = await getBlockByEpoch(endEpochSecs);
+
+  const startValue = await getShareValueAtBlock(cellarAddress, startBlock);
+  const endValue = await getShareValueAtBlock(cellarAddress, endBlock);
+
+  const yieldRatio = endValue.minus(startValue).div(startValue);
   const result = yieldRatio.times(365).times(100).toNumber();
 
   return Number.isNaN(result) ? 0 : result;
 }
 
-// Use the change in avg daily price between the last 2 days to calculate an APR
-async function getApy(cellarAddress) {
-  const now = Math.floor(Date.now() / 1000);
-  const remainder = now % dayInSec;
-  const end = now - remainder - 1;
-  const start = end - dayInSec - dayInSec + 1;
-
-  return calcApy(cellarAddress, start, end);
+function utcToday() {
+  const dateString = new Date().toISOString().split('T')[0];
+  return new Date(`${dateString}T00:00:00.000Z`);
 }
 
-const windowInDays = 7;
+function utcEndOfYesterday() {
+  const today = utcToday();
+  return new Date(today.getTime() - 1000);
+}
+
+async function getApy(cellarAddress) {
+  const yesterday = utcEndOfYesterday();
+  const start = subDays(yesterday, 1);
+
+  const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
+  const startEpoch = Math.floor(start.getTime() / 1000);
+
+  return calcApy(cellarAddress, startEpoch, yesterdayEpoch);
+}
 
 async function getApy7d(cellarAddress) {
-  // Returns dayData in desc order, today is index 0
-  const dayData = await queries.getDayData(cellarAddress, windowInDays);
+  const yesterday = utcEndOfYesterday();
+  const start = subDays(yesterday, 7);
 
-  // Need a minimum of 7 days to calculate yield
-  if (dayData.length < 7) {
-    return 0;
-  }
+  const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
+  const startEpoch = Math.floor(start.getTime() / 1000);
 
-  const price = new BigNumber(dayData[0].shareValue); // Now price
-  const prevPrice = new BigNumber(dayData[dayData.length - 1].shareValue); // Comparison price
-  const yieldRatio = price.minus(prevPrice).div(prevPrice);
-
-  const result = yieldRatio.times(52).times(100).toNumber();
-  return Number.isNaN(result) ? 0 : result;
+  return calcApy(cellarAddress, startEpoch, yesterdayEpoch);
 }
 
 // Call getPositionAssets to get all the credit position's underlying assets
@@ -123,4 +138,6 @@ module.exports = {
   getApy7d,
   getHoldingPosition,
   getUnderlyingTokens,
+  getBlockByEpoch,
+  getShareValueAtBlock,
 };

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -99,9 +99,9 @@ async function getApy(cellarAddress) {
 async function getApy7d(cellarAddress) {
   const interval = 7; // days
   const yesterday = utcEndOfYesterday();
-  const start = subDays(yesterday, interval);
-  console.log(yesterday.toISOString());
-  console.log(start.toISOString());
+
+  // Subtract 6 days because we are including yesterday
+  const start = subDays(yesterday, interval - 1);
 
   const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
   const startEpoch = Math.floor(start.getTime() / 1000);

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -3,113 +3,16 @@ const sdk = require('@defillama/sdk');
 const queries = require('./queries');
 const cellarAbi = require('./cellar-v2.json');
 const { chain, realYieldEth } = require('./config');
-const { endOfYesterday, subDays } = require('date-fns');
 const utils = require('../utils');
+const { getApy, getApy7d } = require('./apy');
 
 const call = sdk.api.abi.call;
 
 const abiAsset = cellarAbi.find((el) => el.name === 'asset');
-const abiDecimals = cellarAbi.find((el) => el.name === 'decimals');
-const abiConvertToAssets = cellarAbi.find(
-  (el) => el.name === 'convertToAssets'
-);
 
 const getPositionAssets = cellarAbi.find(
   (el) => el.name === 'getPositionAssets'
 );
-
-const windowInHrs = 48; // 2 days
-const dayInSec = 60 * 60 * 24; // 1 day in seconds
-
-async function getBlockByEpoch(epochSecs) {
-  if (!Number.isInteger) {
-    throw new Error('getBlockByEpoch was not passed an integer');
-  }
-
-  const data = await utils.getData(
-    `https://coins.llama.fi/block/ethereum/${epochSecs}`
-  );
-
-  return data.height;
-}
-
-async function getShareValueAtBlock(cellarAddress, block) {
-  const decimals = (
-    await call({
-      target: cellarAddress,
-      abi: abiDecimals,
-      chain,
-    })
-  ).output;
-
-  const share = new BigNumber(10).pow(decimals);
-
-  const shareValue = (
-    await call({
-      target: cellarAddress,
-      abi: abiConvertToAssets,
-      params: [share.toString()],
-      block,
-      chain,
-    })
-  ).output;
-
-  return new BigNumber(shareValue);
-}
-
-async function calcApy(
-  cellarAddress,
-  startEpochSecs,
-  endEpochSecs,
-  intervalDays
-) {
-  const startBlock = await getBlockByEpoch(startEpochSecs);
-  const endBlock = await getBlockByEpoch(endEpochSecs);
-
-  const startValue = await getShareValueAtBlock(cellarAddress, startBlock);
-  const endValue = await getShareValueAtBlock(cellarAddress, endBlock);
-
-  const yieldRatio = endValue.minus(startValue).div(startValue);
-  const result = yieldRatio
-    .times(365 / intervalDays)
-    .times(100)
-    .toNumber();
-
-  return Number.isNaN(result) ? 0 : result;
-}
-
-function utcToday() {
-  const dateString = new Date().toISOString().split('T')[0];
-  return new Date(`${dateString}T00:00:00.000Z`);
-}
-
-function utcEndOfYesterday() {
-  const today = utcToday();
-  return new Date(today.getTime() - 1000);
-}
-
-async function getApy(cellarAddress) {
-  const yesterday = utcEndOfYesterday();
-  const start = subDays(yesterday, 1);
-
-  const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
-  const startEpoch = Math.floor(start.getTime() / 1000);
-
-  return calcApy(cellarAddress, startEpoch, yesterdayEpoch, 1);
-}
-
-async function getApy7d(cellarAddress) {
-  const interval = 7; // days
-  const yesterday = utcEndOfYesterday();
-
-  // Subtract 6 days because we are including yesterday
-  const start = subDays(yesterday, interval - 1);
-
-  const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
-  const startEpoch = Math.floor(start.getTime() / 1000);
-
-  return calcApy(cellarAddress, startEpoch, yesterdayEpoch, interval);
-}
 
 // Call getPositionAssets to get all the credit position's underlying assets
 async function getUnderlyingTokens(cellarAddress) {
@@ -146,11 +49,8 @@ async function getHoldingPosition(cellarAddress) {
 }
 
 module.exports = {
-  calcApy,
   getApy,
   getApy7d,
   getHoldingPosition,
   getUnderlyingTokens,
-  getBlockByEpoch,
-  getShareValueAtBlock,
 };

--- a/src/adaptors/sommelier/v2.js
+++ b/src/adaptors/sommelier/v2.js
@@ -55,7 +55,12 @@ async function getShareValueAtBlock(cellarAddress, block) {
   return new BigNumber(shareValue);
 }
 
-async function calcApy(cellarAddress, startEpochSecs, endEpochSecs) {
+async function calcApy(
+  cellarAddress,
+  startEpochSecs,
+  endEpochSecs,
+  intervalDays
+) {
   const startBlock = await getBlockByEpoch(startEpochSecs);
   const endBlock = await getBlockByEpoch(endEpochSecs);
 
@@ -63,7 +68,10 @@ async function calcApy(cellarAddress, startEpochSecs, endEpochSecs) {
   const endValue = await getShareValueAtBlock(cellarAddress, endBlock);
 
   const yieldRatio = endValue.minus(startValue).div(startValue);
-  const result = yieldRatio.times(365).times(100).toNumber();
+  const result = yieldRatio
+    .times(365 / intervalDays)
+    .times(100)
+    .toNumber();
 
   return Number.isNaN(result) ? 0 : result;
 }
@@ -85,17 +93,20 @@ async function getApy(cellarAddress) {
   const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
   const startEpoch = Math.floor(start.getTime() / 1000);
 
-  return calcApy(cellarAddress, startEpoch, yesterdayEpoch);
+  return calcApy(cellarAddress, startEpoch, yesterdayEpoch, 1);
 }
 
 async function getApy7d(cellarAddress) {
+  const interval = 7; // days
   const yesterday = utcEndOfYesterday();
-  const start = subDays(yesterday, 7);
+  const start = subDays(yesterday, interval);
+  console.log(yesterday.toISOString());
+  console.log(start.toISOString());
 
   const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
   const startEpoch = Math.floor(start.getTime() / 1000);
 
-  return calcApy(cellarAddress, startEpoch, yesterdayEpoch);
+  return calcApy(cellarAddress, startEpoch, yesterdayEpoch, interval);
 }
 
 // Call getPositionAssets to get all the credit position's underlying assets

--- a/src/adaptors/sommelier/v2p5.js
+++ b/src/adaptors/sommelier/v2p5.js
@@ -1,0 +1,31 @@
+const sdk = require('@defillama/sdk');
+const { chain } = require('./config');
+const cellarAbi = require('./cellar-v2p5.json');
+const v2 = require('./v2');
+
+const call = sdk.api.abi.call;
+
+const abiViewPositionBalances = cellarAbi.find(
+  (el) => el.name === 'viewPositionBalances'
+);
+
+async function getUnderlyingTokens(cellarAddress) {
+  const result = (
+    await call({
+      target: cellarAddress,
+      abi: abiViewPositionBalances,
+      chain,
+    })
+  ).output;
+
+  // dedupe, different positions may have the same underlying
+  return [...new Set(result.assets)];
+}
+
+module.exports = {
+  calcApy: v2.calcApy,
+  getApy: v2.getApy,
+  getApy7d: v2.getApy7d,
+  getHoldingPosition: v2.getHoldingPosition,
+  getUnderlyingTokens,
+};


### PR DESCRIPTION
# Ready for merge

## Description
This PR removes dependence on our subgraphs for calculating APY. We now get data directly from the RPC with the following flow:
- Determine block height for our daily and 7d APY intervals.
- Fetch share price @ those specified block heights.
- Use share price to calculate a daily and 7d APY.

Previously, we used hour snapshots of the share price when calculating daily APY in order to smooth out volatility. This method goes back to end of day snapshots so those APYs may be slightly different. We have double checked the 7d APYs and those are the same up to 3 decimal places. We feel this is a fair trade off since getting hourly snapshots would require 46 more RPC calls per Cellar.