### PR TITLE
use oracle pricing when token is not available on coingecko

### DIFF
--- a/src/adaptors/nitron/helper.js
+++ b/src/adaptors/nitron/helper.js
@@ -175,13 +175,14 @@ module.exports.getUSDValues = async (assets, denomToGeckoIdMap) => {
     )
   ).data.coins;
 
+  const pricingsFromOracle = (await axios.get('https://api.carbon.network/carbon/pricing/v1/token_price')).data?.token_prices
+
   let result = {};
   assets.forEach((asset) => {
     const denomtInGeckoId = denomToGeckoIdMap[asset.denom];
-    if (denomtInGeckoId) {
-      const usd = prices[`coingecko:${denomtInGeckoId}`]?.price;
-      result[asset.denom] = { ...asset, usd };
-    }
+    let usd = prices[`coingecko:${denomtInGeckoId}`]?.price;
+    if (!usd) usd = Number(pricingsFromOracle.find((o) => o.denom === asset.denom)?.twap)
+    result[asset.denom] = { ...asset, usd };
   });
   return result;
 };


### PR DESCRIPTION
Hello, I've noticed that some of the Nitron tokens are not appearing on DefiLlama because their prices cannot be found. This pull request proposes using the Nitron oracle TWAP price when a token is unavailable on CoinGecko. For example, popular tokens like GLP and RealYieldUSD are not listed on CoinGecko but are available on Nitron for lending and borrowing.

we have also noticed that Nitron is not included in the "Leveraged Lending" section. How can we add Nitron to that section?

Thank you!