### PR TITLE
multiply Liqwid APYs by 100

### DIFF
--- a/src/adaptors/liqwid/index.js
+++ b/src/adaptors/liqwid/index.js
@@ -38,13 +38,13 @@ const apy = async () => {
       project: "liqwid",
       symbol: market.asset.name,
       tvlUsd: market.state.totalSupply / Math.pow(10, market.decimals) * market.price.price,
-      apyBase: Number(market.state.supplyApy),
-      apyReward: Number(market.state.supplyLqDistributionApy),
+      apyBase: Number(market.state.supplyApy) * 100,
+      apyReward: Number(market.state.supplyLqDistributionApy) * 100,
       rewardTokens: [tokenName, "LQ"],
       underlyingTokens: [tokenName],
       // lending protocol fields
-      apyBaseBorrow: Number(market.state.borrowApy),
-      apyRewardBorrow: Number(market.state.borrowLqDistributionApy),
+      apyBaseBorrow: Number(market.state.borrowApy) * 100,
+      apyRewardBorrow: Number(market.state.borrowLqDistributionApy) * 100,
       totalSupplyUsd: market.state.totalSupply / (1 - market.state.utilization) / Math.pow(10, market.decimals) * market.price.price,
       totalBorrowUsd: market.state.totalSupply / (1 - market.state.utilization) / Math.pow(10, market.decimals) * market.state.utilization * market.price.price,
       ltv: Number(market.state.maxLoanToValue)


### PR DESCRIPTION
### Summary
Fix Liqwid APYs displaying as 100x smaller than expected (reason is that DefiLlama percentualizes the APYs for display).