### PR TITLE
fix: update balancer-v2 arbitrum + polygon gauge ABIs to use correct ABI

### DIFF
--- a/src/adaptors/balancer-v2/abis/gauge_arbitrum.json
+++ b/src/adaptors/balancer-v2/abis/gauge_arbitrum.json
@@ -1,18 +1,10 @@
 [
   {
-    "name": "Deposit",
+    "name": "Approval",
     "inputs": [
-      { "name": "provider", "type": "address", "indexed": true },
-      { "name": "value", "type": "uint256", "indexed": false }
-    ],
-    "anonymous": false,
-    "type": "event"
-  },
-  {
-    "name": "Withdraw",
-    "inputs": [
-      { "name": "provider", "type": "address", "indexed": true },
-      { "name": "value", "type": "uint256", "indexed": false }
+      { "name": "_owner", "type": "address", "indexed": true },
+      { "name": "_spender", "type": "address", "indexed": true },
+      { "name": "_value", "type": "uint256", "indexed": false }
     ],
     "anonymous": false,
     "type": "event"
@@ -28,11 +20,31 @@
     "type": "event"
   },
   {
-    "name": "Approval",
+    "name": "Deposit",
     "inputs": [
-      { "name": "_owner", "type": "address", "indexed": true },
-      { "name": "_spender", "type": "address", "indexed": true },
+      { "name": "_user", "type": "address", "indexed": true },
       { "name": "_value", "type": "uint256", "indexed": false }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "Withdraw",
+    "inputs": [
+      { "name": "_user", "type": "address", "indexed": true },
+      { "name": "_value", "type": "uint256", "indexed": false }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "UpdateLiquidityLimit",
+    "inputs": [
+      { "name": "_user", "type": "address", "indexed": true },
+      { "name": "_original_balance", "type": "uint256", "indexed": false },
+      { "name": "_original_supply", "type": "uint256", "indexed": false },
+      { "name": "_working_balance", "type": "uint256", "indexed": false },
+      { "name": "_working_supply", "type": "uint256", "indexed": false }
     ],
     "anonymous": false,
     "type": "event"
@@ -41,38 +53,125 @@
     "stateMutability": "nonpayable",
     "type": "constructor",
     "inputs": [
-      { "name": "_bal_token", "type": "address" },
-      { "name": "_vault", "type": "address" },
-      { "name": "_authorizerAdaptor", "type": "address" }
+      { "name": "_voting_escrow_delegation_proxy", "type": "address" },
+      { "name": "_bal_pseudo_minter", "type": "address" },
+      { "name": "_authorizer_adaptor", "type": "address" },
+      { "name": "_version", "type": "string" }
     ],
     "outputs": []
   },
   {
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function",
-    "name": "decimals",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256" }]
+    "name": "deposit",
+    "inputs": [{ "name": "_value", "type": "uint256" }],
+    "outputs": []
   },
   {
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function",
-    "name": "version",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "string" }]
+    "name": "deposit",
+    "inputs": [
+      { "name": "_value", "type": "uint256" },
+      { "name": "_user", "type": "address" }
+    ],
+    "outputs": []
   },
   {
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function",
-    "name": "reward_contract",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "address" }]
+    "name": "withdraw",
+    "inputs": [{ "name": "_value", "type": "uint256" }],
+    "outputs": []
   },
   {
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function",
-    "name": "last_claim",
-    "inputs": [],
+    "name": "withdraw",
+    "inputs": [
+      { "name": "_value", "type": "uint256" },
+      { "name": "_user", "type": "address" }
+    ],
+    "outputs": []
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      { "name": "_from", "type": "address" },
+      { "name": "_to", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "permit",
+    "inputs": [
+      { "name": "_owner", "type": "address" },
+      { "name": "_spender", "type": "address" },
+      { "name": "_value", "type": "uint256" },
+      { "name": "_deadline", "type": "uint256" },
+      { "name": "_v", "type": "uint8" },
+      { "name": "_r", "type": "bytes32" },
+      { "name": "_s", "type": "bytes32" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      { "name": "_to", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "increaseAllowance",
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_added_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "decreaseAllowance",
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_subtracted_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "user_checkpoint",
+    "inputs": [{ "name": "addr", "type": "address" }],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "claimable_tokens",
+    "inputs": [{ "name": "addr", "type": "address" }],
     "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
@@ -90,38 +189,8 @@
     "type": "function",
     "name": "claimable_reward",
     "inputs": [
-      { "name": "_addr", "type": "address" },
-      { "name": "_token", "type": "address" }
-    ],
-    "outputs": [{ "name": "", "type": "uint256" }]
-  },
-  {
-    "stateMutability": "view",
-    "type": "function",
-    "name": "reward_data",
-    "inputs": [{ "name": "_token", "type": "address" }],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "components": [
-          { "name": "token", "type": "address" },
-          { "name": "distributor", "type": "address" },
-          { "name": "period_finish", "type": "uint256" },
-          { "name": "rate", "type": "uint256" },
-          { "name": "last_update", "type": "uint256" },
-          { "name": "integral", "type": "uint256" }
-        ]
-      }
-    ]
-  },
-  {
-    "stateMutability": "nonpayable",
-    "type": "function",
-    "name": "claimable_reward_write",
-    "inputs": [
-      { "name": "_addr", "type": "address" },
-      { "name": "_token", "type": "address" }
+      { "name": "_user", "type": "address" },
+      { "name": "_reward_token", "type": "address" }
     ],
     "outputs": [{ "name": "", "type": "uint256" }]
   },
@@ -159,68 +228,64 @@
   {
     "stateMutability": "nonpayable",
     "type": "function",
-    "name": "deposit",
-    "inputs": [{ "name": "_value", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "stateMutability": "nonpayable",
-    "type": "function",
-    "name": "deposit",
+    "name": "claim_rewards",
     "inputs": [
-      { "name": "_value", "type": "uint256" },
-      { "name": "_addr", "type": "address" }
-    ],
-    "outputs": []
-  },
-  {
-    "stateMutability": "nonpayable",
-    "type": "function",
-    "name": "deposit",
-    "inputs": [
-      { "name": "_value", "type": "uint256" },
       { "name": "_addr", "type": "address" },
-      { "name": "_claim_rewards", "type": "bool" }
+      { "name": "_receiver", "type": "address" },
+      { "name": "_reward_indexes", "type": "uint256[]" }
     ],
     "outputs": []
   },
   {
     "stateMutability": "nonpayable",
     "type": "function",
-    "name": "withdraw",
-    "inputs": [{ "name": "_value", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "stateMutability": "nonpayable",
-    "type": "function",
-    "name": "withdraw",
+    "name": "add_reward",
     "inputs": [
-      { "name": "_value", "type": "uint256" },
-      { "name": "_claim_rewards", "type": "bool" }
+      { "name": "_reward_token", "type": "address" },
+      { "name": "_distributor", "type": "address" }
     ],
     "outputs": []
   },
   {
     "stateMutability": "nonpayable",
     "type": "function",
-    "name": "transfer",
+    "name": "set_reward_distributor",
     "inputs": [
-      { "name": "_to", "type": "address" },
-      { "name": "_value", "type": "uint256" }
+      { "name": "_reward_token", "type": "address" },
+      { "name": "_distributor", "type": "address" }
     ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "outputs": []
   },
   {
     "stateMutability": "nonpayable",
     "type": "function",
-    "name": "transferFrom",
+    "name": "deposit_reward_token",
     "inputs": [
-      { "name": "_from", "type": "address" },
-      { "name": "_to", "type": "address" },
-      { "name": "_value", "type": "uint256" }
+      { "name": "_reward_token", "type": "address" },
+      { "name": "_amount", "type": "uint256" }
     ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "outputs": []
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "killGauge",
+    "inputs": [],
+    "outputs": []
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "unkillGauge",
+    "inputs": [],
+    "outputs": []
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
     "stateMutability": "view",
@@ -233,60 +298,39 @@
     "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "approve",
-    "inputs": [
-      { "name": "_spender", "type": "address" },
-      { "name": "_value", "type": "uint256" }
-    ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "name": "integrate_checkpoint",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "permit",
-    "inputs": [
-      { "name": "_owner", "type": "address" },
-      { "name": "_spender", "type": "address" },
-      { "name": "_value", "type": "uint256" },
-      { "name": "_deadline", "type": "uint256" },
-      { "name": "_v", "type": "uint8" },
-      { "name": "_r", "type": "bytes32" },
-      { "name": "_s", "type": "bytes32" }
-    ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "name": "bal_token",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "increaseAllowance",
-    "inputs": [
-      { "name": "_spender", "type": "address" },
-      { "name": "_added_value", "type": "uint256" }
-    ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "name": "bal_pseudo_minter",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "decreaseAllowance",
-    "inputs": [
-      { "name": "_spender", "type": "address" },
-      { "name": "_subtracted_value", "type": "uint256" }
-    ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "name": "voting_escrow_delegation_proxy",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "set_rewards",
-    "inputs": [
-      { "name": "_reward_contract", "type": "address" },
-      { "name": "_claim_sig", "type": "bytes32" },
-      { "name": "_reward_tokens", "type": "address[8]" }
-    ],
-    "outputs": []
+    "name": "authorizer_adaptor",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
   },
   {
     "stateMutability": "nonpayable",
@@ -294,30 +338,22 @@
     "name": "initialize",
     "inputs": [
       { "name": "_lp_token", "type": "address" },
-      { "name": "_reward_contract", "type": "address" },
-      { "name": "_claim_sig", "type": "bytes32" }
+      { "name": "_version", "type": "string" }
     ],
     "outputs": []
   },
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "lp_token",
+    "name": "DOMAIN_SEPARATOR",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "address" }]
+    "outputs": [{ "name": "", "type": "bytes32" }]
   },
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "balanceOf",
+    "name": "nonces",
     "inputs": [{ "name": "arg0", "type": "address" }],
-    "outputs": [{ "name": "", "type": "uint256" }]
-  },
-  {
-    "stateMutability": "view",
-    "type": "function",
-    "name": "totalSupply",
-    "inputs": [],
     "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
@@ -337,15 +373,99 @@
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "DOMAIN_SEPARATOR",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "bytes32" }]
+    "name": "balanceOf",
+    "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "nonces",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "lp_token",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "version",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "factory",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "working_balances",
     "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "working_supply",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "period",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "period_timestamp",
+    "inputs": [{ "name": "arg0", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "integrate_checkpoint_of",
+    "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "integrate_fraction",
+    "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "integrate_inv_supply",
+    "inputs": [{ "name": "arg0", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "integrate_inv_supply_of",
+    "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "reward_count",
+    "inputs": [],
     "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
@@ -358,9 +478,21 @@
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "reward_balances",
+    "name": "reward_data",
     "inputs": [{ "name": "arg0", "type": "address" }],
-    "outputs": [{ "name": "", "type": "uint256" }]
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "components": [
+          { "name": "distributor", "type": "address" },
+          { "name": "period_finish", "type": "uint256" },
+          { "name": "rate", "type": "uint256" },
+          { "name": "last_update", "type": "uint256" },
+          { "name": "integral", "type": "uint256" }
+        ]
+      }
+    ]
   },
   {
     "stateMutability": "view",
@@ -372,25 +504,25 @@
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "claim_sig",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "bytes" }]
-  },
-  {
-    "stateMutability": "view",
-    "type": "function",
-    "name": "reward_integral",
-    "inputs": [{ "name": "arg0", "type": "address" }],
-    "outputs": [{ "name": "", "type": "uint256" }]
-  },
-  {
-    "stateMutability": "view",
-    "type": "function",
     "name": "reward_integral_for",
     "inputs": [
       { "name": "arg0", "type": "address" },
       { "name": "arg1", "type": "address" }
     ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "is_killed",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "inflation_rate",
+    "inputs": [{ "name": "arg0", "type": "uint256" }],
     "outputs": [{ "name": "", "type": "uint256" }]
   }
 ]

--- a/src/adaptors/balancer-v2/abis/gauge_polygon.json
+++ b/src/adaptors/balancer-v2/abis/gauge_polygon.json
@@ -1,18 +1,10 @@
 [
   {
-    "name": "Deposit",
+    "name": "Approval",
     "inputs": [
-      { "name": "provider", "type": "address", "indexed": true },
-      { "name": "value", "type": "uint256", "indexed": false }
-    ],
-    "anonymous": false,
-    "type": "event"
-  },
-  {
-    "name": "Withdraw",
-    "inputs": [
-      { "name": "provider", "type": "address", "indexed": true },
-      { "name": "value", "type": "uint256", "indexed": false }
+      { "name": "_owner", "type": "address", "indexed": true },
+      { "name": "_spender", "type": "address", "indexed": true },
+      { "name": "_value", "type": "uint256", "indexed": false }
     ],
     "anonymous": false,
     "type": "event"
@@ -28,11 +20,31 @@
     "type": "event"
   },
   {
-    "name": "Approval",
+    "name": "Deposit",
     "inputs": [
-      { "name": "_owner", "type": "address", "indexed": true },
-      { "name": "_spender", "type": "address", "indexed": true },
+      { "name": "_user", "type": "address", "indexed": true },
       { "name": "_value", "type": "uint256", "indexed": false }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "Withdraw",
+    "inputs": [
+      { "name": "_user", "type": "address", "indexed": true },
+      { "name": "_value", "type": "uint256", "indexed": false }
+    ],
+    "anonymous": false,
+    "type": "event"
+  },
+  {
+    "name": "UpdateLiquidityLimit",
+    "inputs": [
+      { "name": "_user", "type": "address", "indexed": true },
+      { "name": "_original_balance", "type": "uint256", "indexed": false },
+      { "name": "_original_supply", "type": "uint256", "indexed": false },
+      { "name": "_working_balance", "type": "uint256", "indexed": false },
+      { "name": "_working_supply", "type": "uint256", "indexed": false }
     ],
     "anonymous": false,
     "type": "event"
@@ -41,38 +53,125 @@
     "stateMutability": "nonpayable",
     "type": "constructor",
     "inputs": [
-      { "name": "_bal_token", "type": "address" },
-      { "name": "_vault", "type": "address" },
-      { "name": "_authorizerAdaptor", "type": "address" }
+      { "name": "_voting_escrow_delegation_proxy", "type": "address" },
+      { "name": "_bal_pseudo_minter", "type": "address" },
+      { "name": "_authorizer_adaptor", "type": "address" },
+      { "name": "_version", "type": "string" }
     ],
     "outputs": []
   },
   {
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function",
-    "name": "decimals",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "uint256" }]
+    "name": "deposit",
+    "inputs": [{ "name": "_value", "type": "uint256" }],
+    "outputs": []
   },
   {
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function",
-    "name": "version",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "string" }]
+    "name": "deposit",
+    "inputs": [
+      { "name": "_value", "type": "uint256" },
+      { "name": "_user", "type": "address" }
+    ],
+    "outputs": []
   },
   {
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function",
-    "name": "reward_contract",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "address" }]
+    "name": "withdraw",
+    "inputs": [{ "name": "_value", "type": "uint256" }],
+    "outputs": []
   },
   {
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function",
-    "name": "last_claim",
-    "inputs": [],
+    "name": "withdraw",
+    "inputs": [
+      { "name": "_value", "type": "uint256" },
+      { "name": "_user", "type": "address" }
+    ],
+    "outputs": []
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      { "name": "_from", "type": "address" },
+      { "name": "_to", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "permit",
+    "inputs": [
+      { "name": "_owner", "type": "address" },
+      { "name": "_spender", "type": "address" },
+      { "name": "_value", "type": "uint256" },
+      { "name": "_deadline", "type": "uint256" },
+      { "name": "_v", "type": "uint8" },
+      { "name": "_r", "type": "bytes32" },
+      { "name": "_s", "type": "bytes32" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      { "name": "_to", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "increaseAllowance",
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_added_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "decreaseAllowance",
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_subtracted_value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "user_checkpoint",
+    "inputs": [{ "name": "addr", "type": "address" }],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "claimable_tokens",
+    "inputs": [{ "name": "addr", "type": "address" }],
     "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
@@ -90,38 +189,8 @@
     "type": "function",
     "name": "claimable_reward",
     "inputs": [
-      { "name": "_addr", "type": "address" },
-      { "name": "_token", "type": "address" }
-    ],
-    "outputs": [{ "name": "", "type": "uint256" }]
-  },
-  {
-    "stateMutability": "view",
-    "type": "function",
-    "name": "reward_data",
-    "inputs": [{ "name": "_token", "type": "address" }],
-    "outputs": [
-      {
-        "name": "",
-        "type": "tuple",
-        "components": [
-          { "name": "token", "type": "address" },
-          { "name": "distributor", "type": "address" },
-          { "name": "period_finish", "type": "uint256" },
-          { "name": "rate", "type": "uint256" },
-          { "name": "last_update", "type": "uint256" },
-          { "name": "integral", "type": "uint256" }
-        ]
-      }
-    ]
-  },
-  {
-    "stateMutability": "nonpayable",
-    "type": "function",
-    "name": "claimable_reward_write",
-    "inputs": [
-      { "name": "_addr", "type": "address" },
-      { "name": "_token", "type": "address" }
+      { "name": "_user", "type": "address" },
+      { "name": "_reward_token", "type": "address" }
     ],
     "outputs": [{ "name": "", "type": "uint256" }]
   },
@@ -159,68 +228,64 @@
   {
     "stateMutability": "nonpayable",
     "type": "function",
-    "name": "deposit",
-    "inputs": [{ "name": "_value", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "stateMutability": "nonpayable",
-    "type": "function",
-    "name": "deposit",
+    "name": "claim_rewards",
     "inputs": [
-      { "name": "_value", "type": "uint256" },
-      { "name": "_addr", "type": "address" }
-    ],
-    "outputs": []
-  },
-  {
-    "stateMutability": "nonpayable",
-    "type": "function",
-    "name": "deposit",
-    "inputs": [
-      { "name": "_value", "type": "uint256" },
       { "name": "_addr", "type": "address" },
-      { "name": "_claim_rewards", "type": "bool" }
+      { "name": "_receiver", "type": "address" },
+      { "name": "_reward_indexes", "type": "uint256[]" }
     ],
     "outputs": []
   },
   {
     "stateMutability": "nonpayable",
     "type": "function",
-    "name": "withdraw",
-    "inputs": [{ "name": "_value", "type": "uint256" }],
-    "outputs": []
-  },
-  {
-    "stateMutability": "nonpayable",
-    "type": "function",
-    "name": "withdraw",
+    "name": "add_reward",
     "inputs": [
-      { "name": "_value", "type": "uint256" },
-      { "name": "_claim_rewards", "type": "bool" }
+      { "name": "_reward_token", "type": "address" },
+      { "name": "_distributor", "type": "address" }
     ],
     "outputs": []
   },
   {
     "stateMutability": "nonpayable",
     "type": "function",
-    "name": "transfer",
+    "name": "set_reward_distributor",
     "inputs": [
-      { "name": "_to", "type": "address" },
-      { "name": "_value", "type": "uint256" }
+      { "name": "_reward_token", "type": "address" },
+      { "name": "_distributor", "type": "address" }
     ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "outputs": []
   },
   {
     "stateMutability": "nonpayable",
     "type": "function",
-    "name": "transferFrom",
+    "name": "deposit_reward_token",
     "inputs": [
-      { "name": "_from", "type": "address" },
-      { "name": "_to", "type": "address" },
-      { "name": "_value", "type": "uint256" }
+      { "name": "_reward_token", "type": "address" },
+      { "name": "_amount", "type": "uint256" }
     ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "outputs": []
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "killGauge",
+    "inputs": [],
+    "outputs": []
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "function",
+    "name": "unkillGauge",
+    "inputs": [],
+    "outputs": []
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
     "stateMutability": "view",
@@ -233,60 +298,39 @@
     "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "approve",
-    "inputs": [
-      { "name": "_spender", "type": "address" },
-      { "name": "_value", "type": "uint256" }
-    ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "name": "integrate_checkpoint",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "permit",
-    "inputs": [
-      { "name": "_owner", "type": "address" },
-      { "name": "_spender", "type": "address" },
-      { "name": "_value", "type": "uint256" },
-      { "name": "_deadline", "type": "uint256" },
-      { "name": "_v", "type": "uint8" },
-      { "name": "_r", "type": "bytes32" },
-      { "name": "_s", "type": "bytes32" }
-    ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "name": "bal_token",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "increaseAllowance",
-    "inputs": [
-      { "name": "_spender", "type": "address" },
-      { "name": "_added_value", "type": "uint256" }
-    ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "name": "bal_pseudo_minter",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "decreaseAllowance",
-    "inputs": [
-      { "name": "_spender", "type": "address" },
-      { "name": "_subtracted_value", "type": "uint256" }
-    ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "name": "voting_escrow_delegation_proxy",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
-    "name": "set_rewards",
-    "inputs": [
-      { "name": "_reward_contract", "type": "address" },
-      { "name": "_claim_sig", "type": "bytes32" },
-      { "name": "_reward_tokens", "type": "address[8]" }
-    ],
-    "outputs": []
+    "name": "authorizer_adaptor",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
   },
   {
     "stateMutability": "nonpayable",
@@ -294,30 +338,22 @@
     "name": "initialize",
     "inputs": [
       { "name": "_lp_token", "type": "address" },
-      { "name": "_reward_contract", "type": "address" },
-      { "name": "_claim_sig", "type": "bytes32" }
+      { "name": "_version", "type": "string" }
     ],
     "outputs": []
   },
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "lp_token",
+    "name": "DOMAIN_SEPARATOR",
     "inputs": [],
-    "outputs": [{ "name": "", "type": "address" }]
+    "outputs": [{ "name": "", "type": "bytes32" }]
   },
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "balanceOf",
+    "name": "nonces",
     "inputs": [{ "name": "arg0", "type": "address" }],
-    "outputs": [{ "name": "", "type": "uint256" }]
-  },
-  {
-    "stateMutability": "view",
-    "type": "function",
-    "name": "totalSupply",
-    "inputs": [],
     "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
@@ -337,15 +373,99 @@
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "DOMAIN_SEPARATOR",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "bytes32" }]
+    "name": "balanceOf",
+    "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "nonces",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "lp_token",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "version",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "string" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "factory",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "address" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "working_balances",
     "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "working_supply",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "period",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "period_timestamp",
+    "inputs": [{ "name": "arg0", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "integrate_checkpoint_of",
+    "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "integrate_fraction",
+    "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "integrate_inv_supply",
+    "inputs": [{ "name": "arg0", "type": "uint256" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "integrate_inv_supply_of",
+    "inputs": [{ "name": "arg0", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "reward_count",
+    "inputs": [],
     "outputs": [{ "name": "", "type": "uint256" }]
   },
   {
@@ -358,9 +478,21 @@
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "reward_balances",
+    "name": "reward_data",
     "inputs": [{ "name": "arg0", "type": "address" }],
-    "outputs": [{ "name": "", "type": "uint256" }]
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "components": [
+          { "name": "distributor", "type": "address" },
+          { "name": "period_finish", "type": "uint256" },
+          { "name": "rate", "type": "uint256" },
+          { "name": "last_update", "type": "uint256" },
+          { "name": "integral", "type": "uint256" }
+        ]
+      }
+    ]
   },
   {
     "stateMutability": "view",
@@ -372,25 +504,25 @@
   {
     "stateMutability": "view",
     "type": "function",
-    "name": "claim_sig",
-    "inputs": [],
-    "outputs": [{ "name": "", "type": "bytes" }]
-  },
-  {
-    "stateMutability": "view",
-    "type": "function",
-    "name": "reward_integral",
-    "inputs": [{ "name": "arg0", "type": "address" }],
-    "outputs": [{ "name": "", "type": "uint256" }]
-  },
-  {
-    "stateMutability": "view",
-    "type": "function",
     "name": "reward_integral_for",
     "inputs": [
       { "name": "arg0", "type": "address" },
       { "name": "arg1", "type": "address" }
     ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "is_killed",
+    "inputs": [],
+    "outputs": [{ "name": "", "type": "bool" }]
+  },
+  {
+    "stateMutability": "view",
+    "type": "function",
+    "name": "inflation_rate",
+    "inputs": [{ "name": "arg0", "type": "uint256" }],
     "outputs": [{ "name": "", "type": "uint256" }]
   }
 ]


### PR DESCRIPTION
Arbitrum + Polygon gauge ABIs were using an incorrect version leading to a lot of reverts in the SDK when trying to decode certain contract calls.

This uses the updated ABI versions and now there are no failures when running ``npm run test --adapter=balancer-v2 ``