### PR TITLE
feat: add support for Balancer L2 BAL rewards

### DIFF
--- a/src/adaptors/balancer-v2/abis/balancer_token_admin.json
+++ b/src/adaptors/balancer-v2/abis/balancer_token_admin.json
@@ -1,0 +1,243 @@
+[
+  {
+    "inputs": [
+      { "internalType": "contract IVault", "name": "vault", "type": "address" },
+      {
+        "internalType": "contract IBalancerToken",
+        "name": "balancerToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "supply",
+        "type": "uint256"
+      }
+    ],
+    "name": "MiningParametersUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "INITIAL_RATE",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RATE_DENOMINATOR",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RATE_REDUCTION_COEFFICIENT",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "RATE_REDUCTION_TIME",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "activate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "available_supply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "futureEpochTimeWrite",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "future_epoch_time_write",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes4", "name": "selector", "type": "bytes4" }
+    ],
+    "name": "getActionId",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAuthorizer",
+    "outputs": [
+      { "internalType": "contract IAuthorizer", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAvailableSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBalancerToken",
+    "outputs": [
+      {
+        "internalType": "contract IBalancerToken",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getFutureEpochTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getInflationRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMiningEpoch",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStartEpochSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStartEpochTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVault",
+    "outputs": [
+      { "internalType": "contract IVault", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "start", "type": "uint256" },
+      { "internalType": "uint256", "name": "end", "type": "uint256" }
+    ],
+    "name": "mintableInTimeframe",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "start", "type": "uint256" },
+      { "internalType": "uint256", "name": "end", "type": "uint256" }
+    ],
+    "name": "mintable_in_timeframe",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "snapshot",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startEpochTimeWrite",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "start_epoch_time_write",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "updateMiningParameters",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "update_mining_parameters",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/adaptors/balancer-v2/childChainGauges.js
+++ b/src/adaptors/balancer-v2/childChainGauges.js
@@ -4,15 +4,16 @@ const { capitalizeFirstLetter } = require('../utils');
 const urlBase = 'https://api.thegraph.com/subgraphs/name/balancer-labs';
 const urlGaugesEthereum = `${urlBase}/balancer-gauges`;
 
-const chainToEnum = {
-  arbitrum: 0,
-  xdai: 1,
-  polygon: 2,
-  optimism: 3,
-  avalanche: 4,
-  polygonZkEvm: 5,
-  base: 6,
-};
+// For reference - this is how chains are stored in the gauges subgraph
+// const chainToEnum = {
+//   arbitrum: 0,
+//   xdai: 1,
+//   polygon: 2,
+//   optimism: 3,
+//   avalanche: 4,
+//   polygonZkEvm: 5,
+//   base: 6,
+// };
 
 const queryChildGauge = gql`
   query ($chain: String!) {
@@ -40,13 +41,6 @@ const getChildChainRootGauge = async (chain) => {
   );
 
   return rootGauges;
-};
-
-const emissionRate = () => {
-  const INITIAL_RATE = 145000;
-  const START_EPOCH_TIME = 1648465251;
-  const RATE_REDUCTION_TIME = 365 * 86400;
-  const RATE_REDUCTION_COEFFICIENT = 2 ** (1 / 4);
 };
 
 module.exports = {

--- a/src/adaptors/balancer-v2/childChainGauges.js
+++ b/src/adaptors/balancer-v2/childChainGauges.js
@@ -1,0 +1,54 @@
+const { request, gql } = require('graphql-request');
+const { capitalizeFirstLetter } = require('../utils');
+
+const urlBase = 'https://api.thegraph.com/subgraphs/name/balancer-labs';
+const urlGaugesEthereum = `${urlBase}/balancer-gauges`;
+
+const chainToEnum = {
+  arbitrum: 0,
+  xdai: 1,
+  polygon: 2,
+  optimism: 3,
+  avalanche: 4,
+  polygonZkEvm: 5,
+  base: 6,
+};
+
+const queryChildGauge = gql`
+  query ($chain: String!) {
+    rootGauges(where: { chain: $chain }) {
+      chain
+      id
+      recipient
+      relativeWeightCap
+    }
+  }
+`;
+
+/**
+ * @param chain chainString
+ * @returns array of: {chain, id (root gauge address on ethereum), recipient (gauge on child chain), relativeWeightCap}
+ */
+const getChildChainRootGauge = async (chain) => {
+  chain = capitalizeFirstLetter(chain);
+
+  const variables = { chain };
+  const { rootGauges } = await request(
+    urlGaugesEthereum,
+    queryChildGauge,
+    variables
+  );
+
+  return rootGauges;
+};
+
+const emissionRate = () => {
+  const INITIAL_RATE = 145000;
+  const START_EPOCH_TIME = 1648465251;
+  const RATE_REDUCTION_TIME = 365 * 86400;
+  const RATE_REDUCTION_COEFFICIENT = 2 ** (1 / 4);
+};
+
+module.exports = {
+  getChildChainRootGauge,
+};

--- a/src/adaptors/balancer-v2/index.js
+++ b/src/adaptors/balancer-v2/index.js
@@ -8,10 +8,12 @@ const gaugeABIArbitrum = require('./abis/gauge_arbitrum.json');
 const gaugeABIPolygon = require('./abis/gauge_polygon.json');
 const gaugeABIGnosis = require('./abis/gauge_gnosis.json');
 const gaugeABIBase = require('./abis/gauge_base.json');
+const balTokenAdminABI = require('./abis/balancer_token_admin.json');
 const gaugeControllerEthereum = require('./abis/gauge_controller_ethereum.json');
 const protocolFeesCollectorABI = require('./abis/protocol_fees_collector.json');
 const { lte } = require('lodash');
 const { excludePools } = require('../../utils/exclude');
+const { getChildChainRootGauge } = require('./childChainGauges.js');
 
 // Subgraph URLs
 const urlBase = 'https://api.thegraph.com/subgraphs/name/balancer-labs';
@@ -29,6 +31,7 @@ const urlGaugesBase = `https://api.studio.thegraph.com/query/24660/balancer-gaug
 
 const protocolFeesCollector = '0xce88686553686DA562CE7Cea497CE749DA109f9F';
 const gaugeController = '0xC128468b7Ce63eA702C1f104D55A2566b13D3ABD';
+const balancerTokenAdmin = '0xf302f9F50958c5593770FDf4d4812309fF77414f';
 
 const BAL = '0xba100000625a3754423978a60c9317c58a424e3d';
 
@@ -226,25 +229,29 @@ const aprLM = async (tvlData, urlLM, queryLM, chainString, gaugeABI) => {
   // get liquidity gauges for each pool
   const { liquidityGauges } = await request(urlLM, queryLM);
 
-  // get BAL inflation rate (constant among gauge contract ids)
-  let inflationRate;
-  let price;
-  if (chainString === 'ethereum') {
-    inflationRate =
-      (
-        await sdk.api.abi.call({
-          target: liquidityGauges[0].id,
-          abi: gaugeABI.find((n) => n.name === 'inflation_rate'),
-          chain: chainString,
-        })
-      ).output / 1e18;
-
-    // get BAL price
-    const key = `${chainString}:${BAL}`.toLowerCase();
-    price = (
-      await superagent.get(`https://coins.llama.fi/prices/current/${key}`)
-    ).body.coins[key].price;
+  let childChainRootGauges;
+  if (chainString != 'ethereum') {
+    childChainRootGauges = await getChildChainRootGauge(chainString);
   }
+
+  // Global source of truth for the inflation rate. All mainnet gauges use the BalancerTokenAdmin contract to update their locally stored inflation rate during checkpoints.
+  const inflationRate =
+    (
+      await sdk.api.abi.call({
+        target: balancerTokenAdmin,
+        abi: balTokenAdminABI.find((n) => n.name === 'getInflationRate'),
+        chain: 'ethereum',
+      })
+    ).output / 1e18;
+
+  // Price is used for additional non-BAL reward tokens
+  let price;
+
+  // get BAL price
+  const balKey = `ethereum:${BAL}`.toLowerCase();
+  const balPrice = (
+    await superagent.get(`https://coins.llama.fi/prices/current/${balKey}`)
+  ).body.coins[balKey].price;
 
   // add LM rewards if available to each pool in data
   for (const pool of liquidityGauges) {
@@ -257,40 +264,52 @@ const aprLM = async (tvlData, urlLM, queryLM, chainString, gaugeABI) => {
       const aprLMRewards = [];
       const rewardTokens = [];
 
-      if (chainString === 'ethereum') {
-        // get relative weight (of base BAL token rewards for a pool)
-        const relativeWeight =
+      // pool.id returned for mainnet will be the correct gauge address required for the gauge_relative_weight call
+      let relativeWeightParams = pool.id;
+
+      // pool.id returned for child chains is the child chain gauge, so we must replace this with it's mainnet root chain gauge that gauge_relative_weight expects.
+      if (chainString != 'ethereum') {
+        const poolGaugeOnEthereum = childChainRootGauges.find(
+          (gauge) => gauge.recipient == pool.id
+        );
+
+        if (poolGaugeOnEthereum) {
+          relativeWeightParams = poolGaugeOnEthereum.id;
+        }
+      }
+
+      // get relative weight (of base BAL token rewards for a pool)
+      const relativeWeight =
+        (
+          await sdk.api.abi.call({
+            target: gaugeController,
+            abi: gaugeControllerEthereum.find(
+              (n) => n.name === 'gauge_relative_weight'
+            ),
+            params: [relativeWeightParams],
+            chain: 'ethereum',
+          })
+        ).output / 1e18;
+
+      // for base BAL rewards
+      if (relativeWeight !== 0) {
+        const workingSupply =
           (
             await sdk.api.abi.call({
-              target: gaugeController,
-              abi: gaugeControllerEthereum.find(
-                (n) => n.name === 'gauge_relative_weight'
-              ),
-              params: [pool.id],
-              chain: 'ethereum',
+              target: pool.id,
+              abi: gaugeABI.find((n) => n.name === 'working_supply'),
+              chain: chainString,
             })
           ).output / 1e18;
 
-        // for base BAL rewards
-        if (relativeWeight !== 0) {
-          const workingSupply =
-            (
-              await sdk.api.abi.call({
-                target: pool.id,
-                abi: gaugeABI.find((n) => n.name === 'working_supply'),
-                chain: 'ethereum',
-              })
-            ).output / 1e18;
-
-          // bpt == balancer pool token
-          const bptPrice = x.tvl / x.totalShares;
-          const balPayable = inflationRate * 7 * 86400 * relativeWeight;
-          const weeklyReward = (0.4 / (workingSupply + 0.4)) * balPayable;
-          const yearlyReward = weeklyReward * 52 * price;
-          const aprLM = (yearlyReward / bptPrice) * 100;
-          aprLMRewards.push(aprLM === Infinity ? 0 : aprLM);
-          rewardTokens.push(BAL);
-        }
+        // bpt == balancer pool token
+        const bptPrice = x.tvl / x.totalShares;
+        const balPayable = inflationRate * 7 * 86400 * relativeWeight;
+        const weeklyReward = (0.4 / (workingSupply + 0.4)) * balPayable;
+        const yearlyReward = weeklyReward * 52 * balPrice;
+        const aprLM = (yearlyReward / bptPrice) * 100;
+        aprLMRewards.push(aprLM === Infinity ? 0 : aprLM);
+        rewardTokens.push(BAL);
       }
 
       // first need to find the reward token

--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -420,3 +420,9 @@ const makeMulticall = async (abi, addresses, chain, params = null) => {
 };
 
 exports.makeMulticall = makeMulticall;
+
+const capitalizeFirstLetter = (str) => {
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+};
+
+exports.capitalizeFirstLetter = capitalizeFirstLetter;


### PR DESCRIPTION
- Adds support for Balancer's L2 BAL rewards on polygon, arbitrum, gnosis, and base
- Refactor inflationRate to use ``getInflationRate`` from mainnet BalancerTokenAdmin contract instead of calls to each individual gauge contract. This is the global source of truth for the BAL inflation rate, and all gauges take their local rate from this contract.

All tests passed - no errors thrown.

apyRewards match what is shown on Balancer frontend give or take a few points (likely due to rounding differences).