### PR TITLE
[Synapse] Get pools from router instead of hardcoding addresses

### DIFF
--- a/src/adaptors/synapse/abis.json
+++ b/src/adaptors/synapse/abis.json
@@ -1,4 +1,46 @@
 {
+    "allPools": {
+        "inputs": [],
+        "name": "allPools",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "pool",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "lpToken",
+                        "type": "address"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "bool",
+                                "name": "isWeth",
+                                "type": "bool"
+                            },
+                            {
+                                "internalType": "address",
+                                "name": "token",
+                                "type": "address"
+                            }
+                        ],
+                        "internalType": "struct PoolToken[]",
+                        "name": "tokens",
+                        "type": "tuple[]"
+                    }
+                ],
+                "internalType": "struct Pool[]",
+                "name": "pools",
+                "type": "tuple[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
     "balanceOf": {
         "inputs": [
             {

--- a/src/adaptors/synapse/index.js
+++ b/src/adaptors/synapse/index.js
@@ -6,100 +6,36 @@ const _ = require("lodash")
 // Pools are the treasurys that hold the underlying assets
 const config = {
     Arbitrum: {
+        ROUTER: "0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a",
         SYN_TOKEN_ADDRESS: "0x080F6AEd32Fc474DD5717105Dba5ea57268F46eb",
         LP_STAKING_ADDRESS: "0x73186f2Cf2493f20836b17b21ae79fc12934E207",
-        Pools: [
-            {
-                address: "0xa067668661C84476aFcDc6fA5D758C4c01C34352", // nETH - WETH (8m)
-                underlyingTokenCount: 2
-            },
-            {
-                address: "0x9Dd329F5411466d9e0C488fF72519CA9fEf0cb40", // 3Pool (USDC - USDT - nUSD) (12m)
-                underlyingTokenCount: 3
-            },
-            {
-                address: "0x0Db3FE3B770c95A0B99D1Ed6F2627933466c0Dd8", // nETH - WETH (8m)
-                underlyingTokenCount: 4
-            },
-        ]
     },
     Avax: {
+        ROUTER: "0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a",
         SYN_TOKEN_ADDRESS: "0x1f1E7c893855525b303f99bDF5c3c05Be09ca251",
         LP_STAKING_ADDRESS: "0x3a01521F8E7F012eB37eAAf1cb9490a5d9e18249",
-        Pools: [
-            {
-                address: "0xED2a7edd7413021d440b09D654f3b87712abAB66", // nUSD, DAI, USDC, USDT (10m)
-                underlyingTokenCount: 4 
-            },
-            {
-                address: "0x77a7e60555bC18B4Be44C181b2575eee46212d44", // avWETH, nETH (6m)
-                underlyingTokenCount: 2
-            }
-        ],
         formattedChainName: "Avalanche"
     },
     Base: {
+        ROUTER: "0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a",
         SYN_TOKEN_ADDRESS: "0x432036208d2717394d2614d6697c46DF3Ed69540",
         LP_STAKING_ADDRESS: "0xfFC2d603fde1F99ad94026c00B6204Bb9b8c36E9",
-        Pools: [
-            {
-                address: "0x6223bD82010E2fB69F329933De20897e7a4C225f", // nETH ETH (13m)
-                underlyingTokenCount: 2
-            }
-        ]
     },
     Ethereum: {
+        ROUTER: "0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a",
         SYN_TOKEN_ADDRESS: "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
         LP_STAKING_ADDRESS: "0xd10eF2A513cEE0Db54E959eF16cAc711470B62cF",
-        Pools: [
-            {
-                address: "0x1116898DdA4015eD8dDefb84b6e8Bc24528Af2d8", // DAI, USDC, USDT (17m)
-                underlyingTokenCount: 3
-            }
-        ]
-    },
-    Fantom: {
-        SYN_TOKEN_ADDRESS: "0xE55e19Fb4F2D85af758950957714292DAC1e25B2",
-        LP_STAKING_ADDRESS: "0xaed5b25be1c3163c907a471082640450f928ddfe",
-        Pools: [
-            {
-                address: "0x8D9bA570D6cb60C7e3e0F31343Efe75AB8E65FB1", // nETH ETH (50k)
-                underlyingTokenCount: 2
-            },
-            {
-                address: "0x85662fd123280827e11C59973Ac9fcBE838dC3B4", // 3pool nUSD USDC USDT (5m)
-                underlyingTokenCount: 3
-            },
-            {
-                address: "0x2913E812Cf0dcCA30FB28E6Cac3d2DCFF4497688", // Legacy stableswap USDC USDT MIM nUSD (600k)
-                underlyingTokenCount: 4
-            }
-        ],
     },
     Optimism: {
+        ROUTER: "0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a",
         SYN_TOKEN_ADDRESS: "0x5A5fFf6F753d7C11A56A52FE47a177a87e431655",
         LP_STAKING_ADDRESS: "0xe8c610fcb63A4974F02Da52f0B4523937012Aaa0",
-        Pools: [
-            {
-                address: "0xE27BFf97CE92C3e1Ff7AA9f86781FDd6D48F5eE9", // nETH ETH (3m)
-                underlyingTokenCount: 2
-            },
-            {
-                address: "0xF44938b0125A6662f9536281aD2CD6c499F22004", // nUSD USDC (4m)
-                underlyingTokenCount: 2
-            }
-        ]
     },
     Polygon: {
+        ROUTER: "0x7E7A0e201FD38d3ADAA9523Da6C109a07118C96a",
         SYN_TOKEN_ADDRESS: "0xf8F9efC0db77d8881500bb06FF5D6ABc3070E695",
         LP_STAKING_ADDRESS: "0x7875Af1a6878bdA1C129a4e2356A3fD040418Be5",
-        Pools: [
-            {
-                address: "0x85fCD7Dd0a1e1A9FCD5FD886ED522dE8221C3EE5", // USDC USDT nUSDC DAI (8m)
-                underlyingTokenCount: 4
-            }
-        ]
-    },    
+    },
 }
 
 const chainNames = Object.keys(config)
@@ -208,19 +144,19 @@ const main = async () => {
 
         const LP_STAKING_ADDRESS = configPerChain.LP_STAKING_ADDRESS
         const SYN_TOKEN_ADDRESS = configPerChain.SYN_TOKEN_ADDRESS
+        const ROUTER = configPerChain.ROUTER
 
         const totalAllocPoint = (await sdk.api.abi.call({ abi: abi.totalAllocPoint, target: LP_STAKING_ADDRESS, chain: chainKey })).output;
         const synapsePerSecond = (await sdk.api.abi.call({ abi: abi.synapsePerSecond, target: LP_STAKING_ADDRESS, chain: chainKey })).output;
         const poolLength = parseInt((await sdk.api.abi.call({ abi: abi.poolLength, target: LP_STAKING_ADDRESS, chain: chainKey })).output)
 
-        const allLpTokens = (
-            await sdk.api.abi.multiCall({
-              calls: configPerChain.Pools.map(poolData => ({ target: poolData.address})),
-              abi: abi.swapStorage,
-              chain: chainKey,
-            })
-        ).output.map(data => ({lpToken: data.output.lpToken, poolAddress: data.input.target, underlyingTokenCount: (configPerChain.Pools.find(poolData => poolData.address ===  data.input.target)).underlyingTokenCount}))
-
+        const allLpTokens = (await sdk.api.abi.call({ abi: abi.allPools, target: ROUTER, chain: chainKey})).output.map(data => ({ 
+            lpToken: data.lpToken, 
+            poolAddress: data.pool, 
+            tokens: data.tokens.map(tokenData => tokenData.token),
+            underlyingTokenCount: data.tokens.length
+        }))
+        
         for (let y = 0; y < poolLength; y++) {
 
             // For each pool index, we have to see if we have info about it.
@@ -234,7 +170,13 @@ const main = async () => {
             // If you want to include these, add it to the config var
             if (!underlyingAssetsTreasury) { continue } 
 
-            const {tvlUsd,underlyingTokens, allUnderlyingTokenSymbols} = await getTvl(chainKey, underlyingAssetsTreasury.poolAddress, underlyingAssetsTreasury.lpToken, underlyingAssetsTreasury.underlyingTokenCount, synPrice)
+            const { tvlUsd,underlyingTokens, allUnderlyingTokenSymbols } = await getTvl(
+                chainKey, 
+                underlyingAssetsTreasury.poolAddress, 
+                underlyingAssetsTreasury.lpToken, 
+                underlyingAssetsTreasury.underlyingTokenCount, 
+                synPrice
+            )
             const apy = calcApy(synPrice, tvlUsd, synapsePerSecond / (1 * 10 ** 18), totalAllocPoint, relevantInfo.allocPoint)
 
             allPools.push({
@@ -243,6 +185,7 @@ const main = async () => {
                 symbol: allUnderlyingTokenSymbols.join("-"),
                 project: 'synapse',
                 underlyingTokens,
+                rewardTokens: [SYN_TOKEN_ADDRESS],
                 tvlUsd,
                 apy
             })


### PR DESCRIPTION
Using a router means this adapter will only need to be updated for each new chain synapse launches on, not per pool.

I removed fantom configs there are no synapse pools on the chain

### other changes

- Added SYN token as reward asset for all returned pools

### NOTE:
- no new pools were added or removed compared to before, it is more of a quality of life upgrade to ensure synapse pools are added to defillama as soon as they are launched on supported chains instead of needing a PR