### PR TITLE
add navi-protocol adaptor

### DIFF
--- a/src/adaptors/navi-protocol/index.js
+++ b/src/adaptors/navi-protocol/index.js
@@ -1,0 +1,28 @@
+const axios = require('axios');
+
+const poolsFunction = async () => {
+    let pools = await axios.get('https://api-defi.naviprotocol.io/getIndexAssetData');
+
+    const arr = [];
+    Object.entries(pools.data).forEach(([key, val]) => {
+        arr.push({
+            chain: 'Sui',
+            project: 'navi-protocol',
+            pool: val.pool, // `${ReceivedTokenAddress}-${chain}`
+            symbol: val.symbol, // symbol of the tokens in pool
+            tvlUsd: parseFloat(val.total_supply) * parseFloat(val.price),
+            apyBase: parseFloat(val.supply_rate),
+            apyReward: parseFloat(val.boosted) > 0 ? parseFloat(val.boosted) : null,
+            rewardTokens: val.rewardTokens,
+            poolMeta: null
+        });
+    })
+
+    return arr;
+};
+
+module.exports = {
+    timetravel: false,
+    apy: poolsFunction,
+    url: 'https://app.naviprotocol.io/',
+};


### PR DESCRIPTION
There is no on-chain data or function to do that, needs offline loop calculation, so a centralized api is used.

Test Suites: 1 passed, 1 total
Tests:       27 passed, 27 total
Snapshots:   0 total
Time:        0.777 s, estimated 1 s