### PR TITLE
Add kamino lend yields

### DIFF
--- a/src/adaptors/kamino-lend/index.js
+++ b/src/adaptors/kamino-lend/index.js
@@ -1,0 +1,36 @@
+const axios = require('axios');
+const utils = require('../utils');
+
+const getApy = async () => {
+    const markets = ['7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF'];
+    const reserveApys = [];
+    for (const market of markets) {
+        const reserves = (await axios.get(`https://api.kamino.finance/kamino-market/${market}/reserves/metrics?env=mainnet-beta`)).data;
+
+        reserveApys.push(
+            ...reserves.map((r) => {
+                return {
+                    pool: r.reserve,
+                    chain: 'Solana',
+                    project: 'kamino-lend',
+                    symbol: utils.formatSymbol(r.liquidityToken),
+                    underlyingTokens: [r.liquidityTokenMint],
+                    tvlUsd: Number(r.totalSupplyUsd - r.totalBorrowUsd),
+                    url: `https://app.kamino.finance/lending/reserve/${r.reserve}`,
+                    apyBase: Number(r.supplyApy) * 100,
+                    totalSupplyUsd: Number(r.totalSupplyUsd),
+                    totalBorrowUsd: Number(r.totalBorrowUsd),
+                    apyBaseBorrow: Number(r.borrowApy) * 100,
+                    ltv: Number(r.maxLtv),
+                };
+            })
+        );
+    }
+
+    return reserveApys;
+};
+
+module.exports = {
+    apy: getApy,
+    url: 'https://app.kamino.finance/',
+};


### PR DESCRIPTION
Added yields for kamino-lend (https://defillama.com/protocol/kamino-lend) by using our API - unfortunately, most of these APY metrics use historical data that is not available on-chain and had to use our API. 

We do not have any rewards setup yet, so I've omitted those.