### PR TITLE
fix(abracadabra): Update MIM2CRV farm pool details

### DIFF
--- a/src/adaptors/abracadabra/multi-reward-farms.js
+++ b/src/adaptors/abracadabra/multi-reward-farms.js
@@ -11,10 +11,17 @@ const FARMS = {
     stakingToken: "0x30dF229cefa463e991e29D42DB0bae2e122B2AC7",
     stakingTokenPool: "0bf3cb38-1908-4d85-87c3-af62651d5a03",
     rewardTokens: [
-      "0x912CE59144191C1204E64559FE8253a0e49E6548",
-      "0x3E6648C5a70A150A88bCE65F4aD4d506Fe15d2AF"
-    ]
-  }]
+      "0x912CE59144191C1204E64559FE8253a0e49E6548", // ARB
+      "0x3E6648C5a70A150A88bCE65F4aD4d506Fe15d2AF" // SPELL
+    ],
+    symbol: "MIM/USDC/USDT",
+    underlyingTokens: [
+      "0xFEa7a6a0B346362BF88A9e4A88416B77a57D6c2A", // MIM
+      "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8", // USDC
+      "0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9", // USDT
+    ],
+    url: "https://app.abracadabra.money/#/farm/4",
+  }],
 }
 
 const getApy = async () => {
@@ -62,18 +69,19 @@ const getApy = async () => {
 
       aprs[farm.toLowerCase()] = aprs[farm.toLowerCase()] + rewardApr;
     });
-    return chainFarms.map(({ address, rewardTokens, stakingToken, stakingTokenPool }) => {
+    return chainFarms.map(({ address, rewardTokens, stakingToken, stakingTokenPool, symbol, underlyingTokens, url }) => {
       const stakingTokenYieldPool = yieldPools.find(({ pool }) => pool === stakingTokenPool);
       return {
         pool: `${address}-${chain}`,
         chain: utils.formatChain(chain),
         project: 'abracadabra',
         tvlUsd: Number(tvlUsdChainFarms[address.toLowerCase()]),
-        symbol: utils.formatSymbol(symbols[stakingToken.toLowerCase()].output),
+        symbol: symbol ?? utils.formatSymbol(symbols[stakingToken.toLowerCase()].output),
         apyBase: stakingTokenYieldPool.apyBase,
         apyReward: aprs[address.toLowerCase()],
         rewardTokens,
-        underlyingTokens: stakingTokenYieldPool.underlyingTokens,
+        underlyingTokens: underlyingTokens ?? stakingTokenYieldPool.underlyingTokens,
+        url,
       }
     });
   }));


### PR DESCRIPTION
I hardcoded the underlying tokens to have MIM, USDC and USDT. Hopefully it'll be listed in the stablecoin yields section with that change. Also hardcoded the symbol to MIM/USDC/USDT as the on-chain symbol: "MIM3CRV-f" doesn't make a whole lot of sense. Lastly also hardcoded the url to the farm.