### PR TITLE
Radiant/chore/update rewards

### DIFF
--- a/src/adaptors/radiant-v2/index.js
+++ b/src/adaptors/radiant-v2/index.js
@@ -2,7 +2,7 @@ const sdk = require('@defillama/sdk');
 const axios = require('axios');
 const abiLendingPool = require('./abiLendingPool');
 const abiProtocolDataProvider = require('./abiProtocolDataProvider');
-// const abiChefIncentivesController = require('./abiChefIncentivesController');
+const abiChefIncentivesController = require('./abiChefIncentivesController');
 
 const utils = require('../utils');
 
@@ -16,14 +16,20 @@ const chains = {
   arbitrum: {
     LendingPool: '0xF4B1486DD74D07706052A33d31d7c0AAFD0659E1',
     ProtocolDataProvider: '0x596B0cc4c5094507C50b579a662FE7e7b094A2cC',
-    // ChefIncentivesController: '0xebC85d44cefb1293707b11f707bd3CEc34B4D5fA',
+    ChefIncentivesController: '0xebC85d44cefb1293707b11f707bd3CEc34B4D5fA',
     url: '0x091d52CacE1edc5527C99cDCFA6937C1635330E4',
   },
   bsc: {
     LendingPool: '0xd50Cf00b6e600Dd036Ba8eF475677d816d6c4281',
     ProtocolDataProvider: '0x2f9D57E97C3DFED8676e605BC504a48E0c5917E9',
-    // ChefIncentivesController: '0x7C16aBb090d3FB266E9d17F60174B632f4229933',
+    ChefIncentivesController: '0x7C16aBb090d3FB266E9d17F60174B632f4229933',
     url: '0x63764769dA006395515c3f8afF9c91A809eF6607',
+  },
+  ethereum: {
+    LendingPool: '0xA950974f64aA33f27F6C5e017eEE93BF7588ED07',
+    ProtocolDataProvider: '0x362f3BB63Cff83bd169aE1793979E9e537993813',
+    ChefIncentivesController: '0x14b0A611230Dc48E9cc048d3Ae5279847Bf30919',
+    url: '0x70e507f1d20AeC229F435cd1EcaC6A7200119B9F',
   },
 };
 
@@ -94,60 +100,63 @@ const getApy = async () => {
         })
       ).output.map((o) => o.output);
 
-      //   const rewardsPerSecond = (
-      //     await sdk.api.abi.call({
-      //       target: addresses.ChefIncentivesController,
-      //       abi: abiChefIncentivesController.find(
-      //         (m) => m.name === 'rewardsPerSecond'
-      //       ),
-      //       chain,
-      //     })
-      //   ).output;
+      const rewardsPerSecond = (
+        await sdk.api.abi.call({
+          chain,
+          target: addresses.ChefIncentivesController,
+          abi: abiChefIncentivesController.find(
+            (m) => m.name === 'rewardsPerSecond'
+          )
+        })
+      ).output;
 
-      //   const totalAllocPoint = (
-      //     await sdk.api.abi.call({
-      //       abi: abiChefIncentivesController.find(
-      //         (n) => n.name === 'totalAllocPoint'
-      //       ),
-      //       target: addresses.ChefIncentivesController,
-      //       chain,
-      //     })
-      //   ).output;
+      const totalAllocPoint = (
+        await sdk.api.abi.call({
+          chain,
+          target: addresses.ChefIncentivesController,
+          abi: abiChefIncentivesController.find(
+            (n) => n.name === 'totalAllocPoint'
+          )
+        })
+      ).output;
 
-      //   const poolInfoInterest = (
-      //     await sdk.api.abi.multiCall({
-      //       abi: abiChefIncentivesController.find((n) => n.name === 'poolInfo'),
-      //       calls: reserveData.map((t, i) => ({
-      //         target: addresses.ChefIncentivesController,
-      //         params: reserveData[i].aTokenAddress,
-      //       })),
-      //       chain,
-      //     })
-      //   ).output.map((o) => o.output);
+      const poolInfoInterest = (
+        await sdk.api.abi.multiCall({
+          abi: abiChefIncentivesController.find((n) => n.name === 'poolInfo'),
+          calls: reserveData.map((t, i) => ({
+            target: addresses.ChefIncentivesController,
+            params: reserveData[i].aTokenAddress,
+          })),
+          chain,
+        })
+      ).output.map((o) => o.output);
 
-      //   const poolInfoDebt = (
-      //     await sdk.api.abi.multiCall({
-      //       abi: abiChefIncentivesController.find((n) => n.name === 'poolInfo'),
-      //       calls: reserveData.map((t, i) => ({
-      //         target: addresses.ChefIncentivesController,
-      //         params: reserveData[i].variableDebtTokenAddress,
-      //       })),
-      //       chain,
-      //     })
-      //   ).output.map((o) => o.output);
+      const poolInfoDebt = (
+        await sdk.api.abi.multiCall({
+          abi: abiChefIncentivesController.find((n) => n.name === 'poolInfo'),
+          calls: reserveData.map((t, i) => ({
+            target: addresses.ChefIncentivesController,
+            params: reserveData[i].variableDebtTokenAddress,
+          })),
+          chain,
+        })
+      ).output.map((o) => o.output);
+      // console.log('chain:', chain, 'rewardsPerSecond', rewardsPerSecond, 'totalAllocPoint', totalAllocPoint);
 
-      const pricesArray = reservesList.map((t) => `${chain}:${t}`);
-      // .concat(`${chain}:${RDNT}`);
+      // Reference price of RDNT on Arbitrum since its where it is the most liquid.
+      const pricesArray = reservesList.map((t) => `${chain}:${t}`).concat(`arbitrum:${RDNT}`);
 
       const prices = (
         await axios.get(`https://coins.llama.fi/prices/current/${pricesArray}`)
       ).data.coins;
 
-      //   const rewardPerYear =
-      //     (rewardsPerSecond / 1e18) *
-      //     86400 *
-      //     365 *
-      //     prices[`${chain}:${RDNT}`]?.price;
+      const rewardPerYear =
+        (rewardsPerSecond / 1e18) *
+        86400 *
+        365 *
+        prices[`arbitrum:${RDNT}`]?.price;
+      
+      // console.log('rewardPerYear', rewardPerYear);
 
       return reservesList.map((t, i) => {
         const config = reserveConfigurationData[i];
@@ -157,23 +166,27 @@ const getApy = async () => {
 
         const tvlUsd = (liquidity[i] / 10 ** decimals[i]) * price;
         const totalBorrowUsd = (totalBorrow[i] / 10 ** decimals[i]) * price;
+        // TODO
+        // const eligibleTotalBorrowUsd = 
         const totalSupplyUsd = tvlUsd + totalBorrowUsd;
+        // TODO
+        // const eligibleSupplyUsd = 
 
         const apyBase = reserveData[i].currentLiquidityRate / 1e25;
         const apyBaseBorrow = reserveData[i].currentVariableBorrowRate / 1e25;
 
-        // const apyReward =
-        //   (((poolInfoInterest[i].allocPoint / totalAllocPoint) *
-        //     rewardPerYear) /
-        //     totalSupplyUsd) *
-        //   100 *
-        //   earlyExitPenalty;
+        // TODO replace with `eligibleSupplyUsd`
+        const apyReward =
+          (((poolInfoInterest[i].allocPoint / totalAllocPoint) *
+            rewardPerYear) /
+            totalSupplyUsd) *
+          100;
 
-        // const apyRewardBorrow =
-        //   (((poolInfoDebt[i].allocPoint / totalAllocPoint) * rewardPerYear) /
-        //     totalBorrowUsd) *
-        //   100 *
-        //   earlyExitPenalty;
+        // TODO replace with `eligibleBorrowUsd`
+        const apyRewardBorrow =
+          (((poolInfoDebt[i].allocPoint / totalAllocPoint) * rewardPerYear) /
+            totalBorrowUsd) *
+          100;
 
         const ltv = config.ltv / 1e4;
         const borrowable = config.borrowingEnabled;
@@ -190,14 +203,14 @@ const getApy = async () => {
           chain,
           tvlUsd,
           apyBase,
-          //   apyReward: apyReward,
+          apyReward: apyReward,
           underlyingTokens: [t],
           // borrow fields
           totalSupplyUsd,
           totalBorrowUsd,
           apyBaseBorrow,
-          //   apyRewardBorrow: apyRewardBorrow,
-          //   rewardTokens: [RDNT],
+            apyRewardBorrow: apyRewardBorrow,
+          rewardTokens: [RDNT],
           ltv,
           borrowable,
           poolMeta: frozen ? 'frozen' : null,

--- a/src/adaptors/radiant-v2/index.js
+++ b/src/adaptors/radiant-v2/index.js
@@ -141,7 +141,6 @@ const getApy = async () => {
           chain,
         })
       ).output.map((o) => o.output);
-      // console.log('chain:', chain, 'rewardsPerSecond', rewardsPerSecond, 'totalAllocPoint', totalAllocPoint);
 
       // Reference price of RDNT on Arbitrum since its where it is the most liquid.
       const pricesArray = reservesList.map((t) => `${chain}:${t}`).concat(`arbitrum:${RDNT}`);
@@ -156,8 +155,6 @@ const getApy = async () => {
         365 *
         prices[`arbitrum:${RDNT}`]?.price;
       
-      // console.log('rewardPerYear', rewardPerYear);
-
       return reservesList.map((t, i) => {
         const config = reserveConfigurationData[i];
         if (!config.isActive) return null;
@@ -166,26 +163,22 @@ const getApy = async () => {
 
         const tvlUsd = (liquidity[i] / 10 ** decimals[i]) * price;
         const totalBorrowUsd = (totalBorrow[i] / 10 ** decimals[i]) * price;
-        // TODO
-        // const eligibleTotalBorrowUsd = 
+        const eligibleBorrowUsd = (poolInfoDebt[i].totalSupply / 10 ** decimals[i]) * price;
         const totalSupplyUsd = tvlUsd + totalBorrowUsd;
-        // TODO
-        // const eligibleSupplyUsd = 
+        const eligibleSupplyUsd = (poolInfoInterest[i].totalSupply / 10 ** decimals[i]) * price;
 
         const apyBase = reserveData[i].currentLiquidityRate / 1e25;
         const apyBaseBorrow = reserveData[i].currentVariableBorrowRate / 1e25;
 
-        // TODO replace with `eligibleSupplyUsd`
         const apyReward =
           (((poolInfoInterest[i].allocPoint / totalAllocPoint) *
             rewardPerYear) /
-            totalSupplyUsd) *
+            eligibleSupplyUsd) *
           100;
 
-        // TODO replace with `eligibleBorrowUsd`
         const apyRewardBorrow =
           (((poolInfoDebt[i].allocPoint / totalAllocPoint) * rewardPerYear) /
-            totalBorrowUsd) *
+          eligibleBorrowUsd) *
           100;
 
         const ltv = config.ltv / 1e4;


### PR DESCRIPTION
This PR enables back the display of Radiant-v2 rewards. 

The reward apy is based on eligible deposits per reserve.

 To address the following comment:

```js
// note: disabled rewards completely as they require locking of dLP tokens
// https://docs.radiant.capital/radiant/project-info/dlp/dlp-utility
// const earlyExitPenalty = 1 - 0.9;
```

It is suggested to add a tool-tip to  indicate the lock requirement and the penalty for early exit. 
![image](https://github.com/DefiLlama/yield-server/assets/32775237/2af2b2b4-e8c3-480d-994d-2abefa31afc2)
