### PR TITLE
feat(abracadabra): Add support for compounded ARB reward distribution for GM strategies

### DIFF
--- a/src/adaptors/abracadabra/cauldrons.js
+++ b/src/adaptors/abracadabra/cauldrons.js
@@ -225,9 +225,26 @@ const BASE_STARGATE_LP_STRATEGIES = {
 };
 
 const FEE_COLLECTABLE_STRATEGIES = {
+  arbitrum: [
+    '0x39c54bd10261d42ee1838d5fc71dd307dcb39001',
+    '0xb4fc7be1fc0a6d7b6d5d509c622f56d719cd1373',
+    '0xf53a003e863ba83424048d729460fba056c06b80',
+    '0x25ac30195f5b7653ddd7eb93cae6ff5d924cdaf4',
+    '0x9f026f9edc92150076bb8a0ac44c14a8412c1639',
+  ],
   kava: [
-    '0x30D525cbB79D2baaE7637eA748631a6360Ce7c16'
-  ]
+    '0x30d525cbb79d2baae7637ea748631a6360ce7c16',
+  ],
+}
+
+const STRATEGY_CONFIGURATIONS = {
+  arbitrum: {
+    '0x39c54bd10261d42ee1838d5fc71dd307dcb39001': { ignoreTargetPercentage: true }, // All rewards will be yielded regardless of targetPercentage
+    '0xb4fc7be1fc0a6d7b6d5d509c622f56d719cd1373': { ignoreTargetPercentage: true }, // All rewards will be yielded regardless of targetPercentage
+    '0xf53a003e863ba83424048d729460fba056c06b80': { ignoreTargetPercentage: true }, // All rewards will be yielded regardless of targetPercentage
+    '0x25ac30195f5b7653ddd7eb93cae6ff5d924cdaf4': { ignoreTargetPercentage: true }, // All rewards will be yielded regardless of targetPercentage
+    '0x9f026f9edc92150076bb8a0ac44c14a8412c1639': { ignoreTargetPercentage: true }, // All rewards will be yielded regardless of targetPercentage
+  }
 }
 
 const getMarketLensDetailsForCauldrons = (
@@ -679,7 +696,12 @@ const getApy = async () => {
       }
       if (strategyDetails !== undefined) {
         const strategy = strategyDetails.address.toLowerCase();
-        const targetPercentage = strategyDetails.strategyData.targetPercentage;
+        const strategyConfiguration = _.get(
+          STRATEGY_CONFIGURATIONS,
+          [chain, strategy]
+        );
+        const ignoreTargetPercentage = strategyConfiguration?.ignoreTargetPercentage === true;
+        const targetPercentage = ignoreTargetPercentage ? 100 : strategyDetails.strategyData.targetPercentage;
         const negativeInterestStrategyApy = _.get(
           negativeInterestStrategyApys,
           [chain, strategy]


### PR DESCRIPTION
Added the Abracadabra's DegenBox strategies for the various GM markets. All ARB rewards earned for the GM tokens held in the DegenBox will be compounded into more GM tokens and distributed through the strategies regardless of the amount that is managed by the strategy. Thus, `ignoreTargetPercentage` was added to consider this.