### PR TITLE
Enable more Curve Chains (Kava, Base)

### DIFF
--- a/src/adaptors/curve-dex/config.js
+++ b/src/adaptors/curve-dex/config.js
@@ -8,8 +8,8 @@ exports.BLOCKCHAINIDS = [
   'optimism',
   'xdai',
   'moonbeam',
-  // 'kava',
-  // 'base',
+  'kava',
+  'base',
   // 'celo',
 ];
 // https://github.com/curvefi/curve-api/blob/main/endpoints.md#getpools

--- a/src/adaptors/curve-dex/index.js
+++ b/src/adaptors/curve-dex/index.js
@@ -45,6 +45,7 @@ const getSubGraphData = async (blockchainId) => {
     return {};
   }
   if (response?.success) {
+    if (!response.data?.poolList?.length) return {};
     const poolSubgraphsByAddress = Object.fromEntries(
       response.data.poolList.map((pool) => [pool.address, pool])
     );


### PR DESCRIPTION
Added a null check to API calls, enables Kava and Base chains to be added, since many of the endpoints (e.g. https://api.curve.fi/api/getPools/base/main) return 0 results for custom pools (which are empty on these chains)

![image](https://github.com/DefiLlama/yield-server/assets/71284258/bf369f17-099b-4209-851d-674ce24b4900)
