### PR TITLE
feat(morpho-blue): modifying pool s name to reflect the right convention

### DIFF
--- a/src/adaptors/morpho-blue/index.js
+++ b/src/adaptors/morpho-blue/index.js
@@ -53,6 +53,7 @@ const gqlQueries = {
         }
         inputToken {
           id
+          symbol
           lastPriceUSD
           decimals
         }
@@ -303,6 +304,7 @@ async function blueMarkets() {
           (market.totalBorrow * market.borrowedToken.lastPriceUSD) /
           10 ** market.borrowedToken.decimals;
         const totalTVL = totalSupplyUsd - totalBorrowUsd;
+        const ltv = market.lltv / 1e18;
 
         // Return structured APY data for each market
         return [
@@ -311,7 +313,11 @@ async function blueMarkets() {
             pool: `morpho-blue-${market.id}`,
             chain: 'ethereum',
             project: 'morpho-blue',
-            symbol: utils.formatSymbol(market.borrowedToken.symbol),
+            symbol: utils.formatSymbol(
+              `${market.inputToken.symbol}-${market.borrowedToken.symbol}(${
+                ltv * 100
+              }%)`
+            ),
             apyBase:
               rateToApy(
                 market.rates.find((rate) => rate.side === 'LENDER')?.rate || 0
@@ -327,7 +333,7 @@ async function blueMarkets() {
             apyRewardBorrow: borrowRewardsApy + collateralRewardsApy,
             totalSupplyUsd,
             totalBorrowUsd,
-            ltv: market.lltv / 1e18,
+            ltv,
           },
         ];
       })


### PR DESCRIPTION
Similarly to uniswap pools, we modified the name of the pools such that we now have:
collat-loan (LTV%)

Thanks team

Test at: 

```bash
npm run test --adapter=morpho-blue
```

TL;DR:
morpho blue pools=markets:
collat-loan (LTV%), modified ✅ 

metamorpho -> right naming already ✅ 
