### PR TITLE
Fix Moonwell APY on Moonbeam

### DIFF
--- a/src/adaptors/moonwell/abi.js
+++ b/src/adaptors/moonwell/abi.js
@@ -1,4 +1,999 @@
 module.exports = {
+  VIEWS_ABI: [
+    {
+      "type": "function",
+      "name": "comptroller",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract Comptroller"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getAllMarketsInfo",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Market[]",
+          "components": [
+            {
+              "name": "market",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "isListed",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "mintPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "collateralFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "underlyingPrice",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalSupply",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalBorrows",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalReserves",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "cash",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "exchangeRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowIndex",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "reserveFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "incentives",
+              "type": "tuple[]",
+              "internalType": "struct BaseMoonwellViews.MarketIncentives[]",
+              "components": [
+                {
+                  "name": "token",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "supplyIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "borrowIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getGovernanceTokenPrice",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketIncentives",
+      "inputs": [
+        {
+          "name": "market",
+          "type": "address",
+          "internalType": "contract MToken"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.MarketIncentives[]",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "supplyIncentivesPerSec",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowIncentivesPerSec",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketInfo",
+      "inputs": [
+        {
+          "name": "_mToken",
+          "type": "address",
+          "internalType": "contract MToken"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.Market",
+          "components": [
+            {
+              "name": "market",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "isListed",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "mintPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "collateralFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "underlyingPrice",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalSupply",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalBorrows",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalReserves",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "cash",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "exchangeRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowIndex",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "reserveFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "incentives",
+              "type": "tuple[]",
+              "internalType": "struct BaseMoonwellViews.MarketIncentives[]",
+              "components": [
+                {
+                  "name": "token",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "supplyIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "borrowIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketsInfo",
+      "inputs": [
+        {
+          "name": "_mTokens",
+          "type": "address[]",
+          "internalType": "contract MToken[]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Market[]",
+          "components": [
+            {
+              "name": "market",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "isListed",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "mintPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "collateralFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "underlyingPrice",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalSupply",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalBorrows",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalReserves",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "cash",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "exchangeRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowIndex",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "reserveFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "incentives",
+              "type": "tuple[]",
+              "internalType": "struct BaseMoonwellViews.MarketIncentives[]",
+              "components": [
+                {
+                  "name": "token",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "supplyIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "borrowIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getNativeTokenPrice",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getProtocolInfo",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.ProtocolInfo",
+          "components": [
+            {
+              "name": "seizePaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "transferPaused",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getStakingInfo",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.StakingInfo",
+          "components": [
+            {
+              "name": "cooldown",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "unstakeWindow",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "distributionEnd",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalSupply",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "emissionPerSecond",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "lastUpdateTimestamp",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "index",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getTokensBalances",
+      "inputs": [
+        {
+          "name": "_tokens",
+          "type": "address[]",
+          "internalType": "address[]"
+        },
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Balances[]",
+          "components": [
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserBalances",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Balances[]",
+          "components": [
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserBorrowsBalances",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Balances[]",
+          "components": [
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserClaimsVotingPower",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.Votes",
+          "components": [
+            {
+              "name": "delegatedVotingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "votingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "delegates",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserMarketsMemberships",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Memberships[]",
+          "components": [
+            {
+              "name": "membership",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserRewards",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Rewards[]",
+          "components": [
+            {
+              "name": "market",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "rewardToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "supplyRewardsAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowRewardsAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserStakingInfo",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.UserStakingInfo",
+          "components": [
+            {
+              "name": "cooldown",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "pendingRewards",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalStaked",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserStakingVotingPower",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.Votes",
+          "components": [
+            {
+              "name": "delegatedVotingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "votingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "delegates",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserTokensVotingPower",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.Votes",
+          "components": [
+            {
+              "name": "delegatedVotingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "votingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "delegates",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserVotingPower",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.UserVotes",
+          "components": [
+            {
+              "name": "claimsVotes",
+              "type": "tuple",
+              "internalType": "struct BaseMoonwellViews.Votes",
+              "components": [
+                {
+                  "name": "delegatedVotingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "votingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "delegates",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            },
+            {
+              "name": "stakingVotes",
+              "type": "tuple",
+              "internalType": "struct BaseMoonwellViews.Votes",
+              "components": [
+                {
+                  "name": "delegatedVotingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "votingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "delegates",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            },
+            {
+              "name": "tokenVotes",
+              "type": "tuple",
+              "internalType": "struct BaseMoonwellViews.Votes",
+              "components": [
+                {
+                  "name": "delegatedVotingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "votingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "delegates",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "governanceToken",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract Well"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "inputs": [
+        {
+          "name": "_comptroller",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenSaleDistributor",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "safetyModule",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "_governanceToken",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "nativeMarket",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "governanceTokenLP",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "Initialized",
+      "inputs": [
+        {
+          "name": "version",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        }
+      ],
+      "anonymous": false
+    }
+  ],
   MRD_ABI: [
     { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
     {

--- a/src/adaptors/moonwell/abi.js
+++ b/src/adaptors/moonwell/abi.js
@@ -1,0 +1,887 @@
+module.exports = {
+  MRD_ABI: [
+    { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'contract MToken',
+          name: 'mToken',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'borrower',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'emissionToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'totalAccrued',
+          type: 'uint256'
+        }
+      ],
+      name: 'DisbursedBorrowerRewards',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'contract MToken',
+          name: 'mToken',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'supplier',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'emissionToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'totalAccrued',
+          type: 'uint256'
+        }
+      ],
+      name: 'DisbursedSupplierRewards',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'token',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'amount',
+          type: 'uint256'
+        }
+      ],
+      name: 'FundsRescued',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'contract MToken',
+          name: 'mToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'emissionToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'newIndex',
+          type: 'uint256'
+        },
+        {
+          indexed: false,
+          internalType: 'uint32',
+          name: 'newTimestamp',
+          type: 'uint32'
+        }
+      ],
+      name: 'GlobalBorrowIndexUpdated',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'contract MToken',
+          name: 'mToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'emissionToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'newSupplyIndex',
+          type: 'uint256'
+        },
+        {
+          indexed: false,
+          internalType: 'uint32',
+          name: 'newSupplyGlobalTimestamp',
+          type: 'uint32'
+        }
+      ],
+      name: 'GlobalSupplyIndexUpdated',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'uint8',
+          name: 'version',
+          type: 'uint8'
+        }
+      ],
+      name: 'Initialized',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'address payable',
+          name: 'user',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'rewardToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'amount',
+          type: 'uint256'
+        }
+      ],
+      name: 'InsufficientTokensToEmit',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'contract MToken',
+          name: 'mToken',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'emissionToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'oldRewardSpeed',
+          type: 'uint256'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'newRewardSpeed',
+          type: 'uint256'
+        }
+      ],
+      name: 'NewBorrowRewardSpeed',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'contract MToken',
+          name: 'mToken',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'owner',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'emissionToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'supplySpeed',
+          type: 'uint256'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'borrowSpeed',
+          type: 'uint256'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'endTime',
+          type: 'uint256'
+        }
+      ],
+      name: 'NewConfigCreated',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'oldEmissionCap',
+          type: 'uint256'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'newEmissionCap',
+          type: 'uint256'
+        }
+      ],
+      name: 'NewEmissionCap',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'contract MToken',
+          name: 'mToken',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'emissionToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'currentOwner',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'newOwner',
+          type: 'address'
+        }
+      ],
+      name: 'NewEmissionConfigOwner',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'oldPauseGuardian',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'newPauseGuardian',
+          type: 'address'
+        }
+      ],
+      name: 'NewPauseGuardian',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'contract MToken',
+          name: 'mToken',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'emissionToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'currentEndTime',
+          type: 'uint256'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'newEndTime',
+          type: 'uint256'
+        }
+      ],
+      name: 'NewRewardEndTime',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'contract MToken',
+          name: 'mToken',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'emissionToken',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'oldRewardSpeed',
+          type: 'uint256'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'newRewardSpeed',
+          type: 'uint256'
+        }
+      ],
+      name: 'NewSupplyRewardSpeed',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'account',
+          type: 'address'
+        }
+      ],
+      name: 'Paused',
+      type: 'event'
+    },
+    { anonymous: false, inputs: [], name: 'RewardsPaused', type: 'event' },
+    { anonymous: false, inputs: [], name: 'RewardsUnpaused', type: 'event' },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'address',
+          name: 'account',
+          type: 'address'
+        }
+      ],
+      name: 'Unpaused',
+      type: 'event'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_owner', type: 'address' },
+        { internalType: 'address', name: '_emissionToken', type: 'address' },
+        {
+          internalType: 'uint256',
+          name: '_supplyEmissionPerSec',
+          type: 'uint256'
+        },
+        {
+          internalType: 'uint256',
+          name: '_borrowEmissionsPerSec',
+          type: 'uint256'
+        },
+        { internalType: 'uint256', name: '_endTime', type: 'uint256' }
+      ],
+      name: '_addEmissionConfig',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: '_pauseRewards',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'address', name: '_tokenAddress', type: 'address' },
+        { internalType: 'uint256', name: '_amount', type: 'uint256' }
+      ],
+      name: '_rescueFunds',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'uint256', name: '_newEmissionCap', type: 'uint256' }
+      ],
+      name: '_setEmissionCap',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'address', name: '_newPauseGuardian', type: 'address' }
+      ],
+      name: '_setPauseGuardian',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: '_unpauseRewards',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_emissionToken', type: 'address' },
+        { internalType: 'uint256', name: '_newBorrowSpeed', type: 'uint256' }
+      ],
+      name: '_updateBorrowSpeed',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_emissionToken', type: 'address' },
+        { internalType: 'uint256', name: '_newEndTime', type: 'uint256' }
+      ],
+      name: '_updateEndTime',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_emissionToken', type: 'address' },
+        { internalType: 'address', name: '_newOwner', type: 'address' }
+      ],
+      name: '_updateOwner',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_emissionToken', type: 'address' },
+        { internalType: 'uint256', name: '_newSupplySpeed', type: 'uint256' }
+      ],
+      name: '_updateSupplySpeed',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'comptroller',
+      outputs: [
+        { internalType: 'contract Comptroller', name: '', type: 'address' }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_borrower', type: 'address' },
+        { internalType: 'bool', name: '_sendTokens', type: 'bool' }
+      ],
+      name: 'disburseBorrowerRewards',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_supplier', type: 'address' },
+        { internalType: 'bool', name: '_sendTokens', type: 'bool' }
+      ],
+      name: 'disburseSupplierRewards',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'emissionCap',
+      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' }
+      ],
+      name: 'getAllMarketConfigs',
+      outputs: [
+        {
+          components: [
+            { internalType: 'address', name: 'owner', type: 'address' },
+            { internalType: 'address', name: 'emissionToken', type: 'address' },
+            { internalType: 'uint256', name: 'endTime', type: 'uint256' },
+            {
+              internalType: 'uint224',
+              name: 'supplyGlobalIndex',
+              type: 'uint224'
+            },
+            {
+              internalType: 'uint32',
+              name: 'supplyGlobalTimestamp',
+              type: 'uint32'
+            },
+            {
+              internalType: 'uint224',
+              name: 'borrowGlobalIndex',
+              type: 'uint224'
+            },
+            {
+              internalType: 'uint32',
+              name: 'borrowGlobalTimestamp',
+              type: 'uint32'
+            },
+            {
+              internalType: 'uint256',
+              name: 'supplyEmissionsPerSec',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: 'borrowEmissionsPerSec',
+              type: 'uint256'
+            }
+          ],
+          internalType: 'struct MultiRewardDistributorCommon.MarketConfig[]',
+          name: '',
+          type: 'tuple[]'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_emissionToken', type: 'address' }
+      ],
+      name: 'getConfigForMarket',
+      outputs: [
+        {
+          components: [
+            { internalType: 'address', name: 'owner', type: 'address' },
+            { internalType: 'address', name: 'emissionToken', type: 'address' },
+            { internalType: 'uint256', name: 'endTime', type: 'uint256' },
+            {
+              internalType: 'uint224',
+              name: 'supplyGlobalIndex',
+              type: 'uint224'
+            },
+            {
+              internalType: 'uint32',
+              name: 'supplyGlobalTimestamp',
+              type: 'uint32'
+            },
+            {
+              internalType: 'uint224',
+              name: 'borrowGlobalIndex',
+              type: 'uint224'
+            },
+            {
+              internalType: 'uint32',
+              name: 'borrowGlobalTimestamp',
+              type: 'uint32'
+            },
+            {
+              internalType: 'uint256',
+              name: 'supplyEmissionsPerSec',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: 'borrowEmissionsPerSec',
+              type: 'uint256'
+            }
+          ],
+          internalType: 'struct MultiRewardDistributorCommon.MarketConfig',
+          name: '',
+          type: 'tuple'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'getCurrentEmissionCap',
+      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_emissionToken', type: 'address' }
+      ],
+      name: 'getCurrentOwner',
+      outputs: [{ internalType: 'address', name: '', type: 'address' }],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'address', name: 'mToken', type: 'address' },
+        { internalType: 'uint256', name: 'index', type: 'uint256' }
+      ],
+      name: 'getGlobalBorrowIndex',
+      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'address', name: 'mToken', type: 'address' },
+        { internalType: 'uint256', name: 'index', type: 'uint256' }
+      ],
+      name: 'getGlobalSupplyIndex',
+      outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_user', type: 'address' }
+      ],
+      name: 'getOutstandingRewardsForUser',
+      outputs: [
+        {
+          components: [
+            { internalType: 'address', name: 'emissionToken', type: 'address' },
+            { internalType: 'uint256', name: 'totalAmount', type: 'uint256' },
+            { internalType: 'uint256', name: 'supplySide', type: 'uint256' },
+            { internalType: 'uint256', name: 'borrowSide', type: 'uint256' }
+          ],
+          internalType: 'struct MultiRewardDistributorCommon.RewardInfo[]',
+          name: '',
+          type: 'tuple[]'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [{ internalType: 'address', name: '_user', type: 'address' }],
+      name: 'getOutstandingRewardsForUser',
+      outputs: [
+        {
+          components: [
+            { internalType: 'address', name: 'mToken', type: 'address' },
+            {
+              components: [
+                {
+                  internalType: 'address',
+                  name: 'emissionToken',
+                  type: 'address'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'totalAmount',
+                  type: 'uint256'
+                },
+                {
+                  internalType: 'uint256',
+                  name: 'supplySide',
+                  type: 'uint256'
+                },
+                { internalType: 'uint256', name: 'borrowSide', type: 'uint256' }
+              ],
+              internalType: 'struct MultiRewardDistributorCommon.RewardInfo[]',
+              name: 'rewards',
+              type: 'tuple[]'
+            }
+          ],
+          internalType:
+            'struct MultiRewardDistributorCommon.RewardWithMToken[]',
+          name: '',
+          type: 'tuple[]'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'initialIndexConstant',
+      outputs: [{ internalType: 'uint224', name: '', type: 'uint224' }],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'address', name: '_comptroller', type: 'address' },
+        { internalType: 'address', name: '_pauseGuardian', type: 'address' }
+      ],
+      name: 'initialize',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'address', name: '', type: 'address' },
+        { internalType: 'uint256', name: '', type: 'uint256' }
+      ],
+      name: 'marketConfigs',
+      outputs: [
+        {
+          components: [
+            { internalType: 'address', name: 'owner', type: 'address' },
+            { internalType: 'address', name: 'emissionToken', type: 'address' },
+            { internalType: 'uint256', name: 'endTime', type: 'uint256' },
+            {
+              internalType: 'uint224',
+              name: 'supplyGlobalIndex',
+              type: 'uint224'
+            },
+            {
+              internalType: 'uint32',
+              name: 'supplyGlobalTimestamp',
+              type: 'uint32'
+            },
+            {
+              internalType: 'uint224',
+              name: 'borrowGlobalIndex',
+              type: 'uint224'
+            },
+            {
+              internalType: 'uint32',
+              name: 'borrowGlobalTimestamp',
+              type: 'uint32'
+            },
+            {
+              internalType: 'uint256',
+              name: 'supplyEmissionsPerSec',
+              type: 'uint256'
+            },
+            {
+              internalType: 'uint256',
+              name: 'borrowEmissionsPerSec',
+              type: 'uint256'
+            }
+          ],
+          internalType: 'struct MultiRewardDistributorCommon.MarketConfig',
+          name: 'config',
+          type: 'tuple'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'pauseGuardian',
+      outputs: [{ internalType: 'address', name: '', type: 'address' }],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'paused',
+      outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' }
+      ],
+      name: 'updateMarketBorrowIndex',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_borrower', type: 'address' },
+        { internalType: 'bool', name: '_sendTokens', type: 'bool' }
+      ],
+      name: 'updateMarketBorrowIndexAndDisburseBorrowerRewards',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' }
+      ],
+      name: 'updateMarketSupplyIndex',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        { internalType: 'contract MToken', name: '_mToken', type: 'address' },
+        { internalType: 'address', name: '_supplier', type: 'address' },
+        { internalType: 'bool', name: '_sendTokens', type: 'bool' }
+      ],
+      name: 'updateMarketSupplyIndexAndDisburseSupplierRewards',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    }
+  ]
+}

--- a/src/adaptors/moonwell/index.js
+++ b/src/adaptors/moonwell/index.js
@@ -99,15 +99,16 @@ const getApy = async () => {
         price = Number(_price)
       }
 
-      const tvlUsd =
+      const totalSupplyUsd =
         Number(pool.totalSupply) * Number(pool.exchangeRate) * price
       const totalBorrowUsd = Number(pool.totalBorrows) * price
+
       return {
         pool: pool.id.toLowerCase(),
         chain: utils.formatChain('moonbeam'),
         project: 'moonwell',
         symbol: pool.underlyingSymbol,
-        tvlUsd,
+        tvlUsd: totalSupplyUsd - totalBorrowUsd,
         apyBase: Number(pool.supplyRate),
         apyReward:
           Number(pool.supplyRewardNative) + Number(pool.supplyRewardProtocol),
@@ -122,7 +123,7 @@ const getApy = async () => {
           '0xacc15dc74880c9944775448304b263d191c6077f'
         ],
         // borrow fields
-        totalSupplyUsd: tvlUsd + totalBorrowUsd,
+        totalSupplyUsd,
         totalBorrowUsd,
         apyBaseBorrow: Number(pool.borrowRate),
         apyRewardBorrow:
@@ -149,7 +150,7 @@ const getApy = async () => {
         chain: utils.formatChain('base'),
         project: 'moonwell',
         symbol: pool.underlyingSymbol == 'WETH' ? 'ETH' : pool.underlyingSymbol,
-        tvlUsd: totalSupplyUsd + totalBorrowUsd,
+        tvlUsd: totalSupplyUsd - totalBorrowUsd,
         apyBase: Number(pool.supplyRate),
         apyReward: 0,
         underlyingTokens: [pool.underlyingAddress],

--- a/src/adaptors/moonwell/index.js
+++ b/src/adaptors/moonwell/index.js
@@ -1,8 +1,50 @@
-const utils = require('../utils');
-const { request, gql, batchRequests } = require('graphql-request');
+const utils = require('../utils')
+const sdk = require('@defillama/sdk4')
+const { request, gql, batchRequests } = require('graphql-request')
+const { MRD_ABI } = require('./abi')
+const axios = require('axios')
+
+const MRD_CONTRACT = '0xe9005b078701e2A0948D2EaC43010D35870Ad9d2'
+
+const getPrices = async addresses => {
+  const prices = (
+    await axios.get(
+      `https://coins.llama.fi/prices/current/${addresses
+        .join(',')
+        .toLowerCase()}`
+    )
+  ).data.coins
+
+  const pricesByAddress = Object.entries(prices).reduce(
+    (acc, [name, price]) => ({
+      ...acc,
+      [name.split(':')[1]]: {
+        decimals: price.decimals,
+        symbol: price.symbol,
+        price: price.price
+      }
+    }),
+    {}
+  )
+
+  return pricesByAddress
+}
+
+const multicallMRD = async markets => {
+  return (
+    await sdk.api.abi.multiCall({
+      chain: 'base',
+      calls: markets.map(market => ({
+        target: MRD_CONTRACT,
+        params: [market]
+      })),
+      abi: MRD_ABI.find(({ name }) => name === 'getAllMarketConfigs')
+    })
+  ).output.map(({ output }) => output)
+}
 
 const API_URL =
-  'https://api.thegraph.com/subgraphs/name/moonwell-fi/moonwell-moonbeam';
+  'https://api.thegraph.com/subgraphs/name/moonwell-fi/moonwell-moonbeam'
 const query = gql`
   {
     markets {
@@ -22,25 +64,44 @@ const query = gql`
       borrowRewardProtocol
     }
   }
-`;
+`
+
+const BASE_API_URL =
+  'https://subgraph.satsuma-prod.com/dd48bfe50148/moonwell/base/api'
+const base_query = gql`
+  {
+    markets {
+      id
+      borrowRate
+      supplyRate
+      totalBorrows
+      totalSupply
+      underlyingSymbol
+      underlyingPriceUSD
+      exchangeRate
+      underlyingAddress
+      collateralFactor
+    }
+  }
+`
 const getApy = async () => {
-  const res = await request(API_URL, query);
-  return res.markets
-    .map((pool) => {
+  const res = await request(API_URL, query)
+  const moonbeamResults = res.markets
+    .map(pool => {
       let price =
         pool.underlyingSymbol.toLowerCase() === 'usdc'
           ? 1
-          : Number(pool.underlyingPriceUSD);
+          : Number(pool.underlyingPriceUSD)
       if (price === 0 && pool.underlyingSymbol.toLowerCase() === 'weth') {
         const _price = res.markets.find(
-          (e) => e.id === '0xaaa20c5a584a9fecdfedd71e46da7858b774a9ce'
-        ).underlyingPriceUSD;
-        price = Number(_price);
+          e => e.id === '0xaaa20c5a584a9fecdfedd71e46da7858b774a9ce'
+        ).underlyingPriceUSD
+        price = Number(_price)
       }
 
       const tvlUsd =
-        Number(pool.totalSupply) * Number(pool.exchangeRate) * price;
-      const totalBorrowUsd = Number(pool.totalBorrows) * price;
+        Number(pool.totalSupply) * Number(pool.exchangeRate) * price
+      const totalBorrowUsd = Number(pool.totalBorrows) * price
       return {
         pool: pool.id.toLowerCase(),
         chain: utils.formatChain('moonbeam'),
@@ -54,11 +115,11 @@ const getApy = async () => {
           pool.underlyingAddress ===
           '0x0000000000000000000000000000000000000000'
             ? '0xAcc15dC74880C9944775448304B263D191c6077F'
-            : pool.underlyingAddress,
+            : pool.underlyingAddress
         ],
         rewardTokens: [
           '0x511ab53f793683763e5a8829738301368a2411e3',
-          '0xacc15dc74880c9944775448304b263d191c6077f',
+          '0xacc15dc74880c9944775448304b263d191c6077f'
         ],
         // borrow fields
         totalSupplyUsd: tvlUsd + totalBorrowUsd,
@@ -66,14 +127,169 @@ const getApy = async () => {
         apyBaseBorrow: Number(pool.borrowRate),
         apyRewardBorrow:
           Number(pool.borrowRewardNative) + Number(pool.borrowRewardProtocol),
-        ltv: Number(pool.collateralFactor),
-      };
+        ltv: Number(pool.collateralFactor)
+      }
     })
-    .filter((e) => e.ltv);
-};
+    .filter(e => e.ltv)
+
+  let base_res = await request(BASE_API_URL, base_query)
+  let baseResults = base_res.markets
+    .map(pool => {
+      let price =
+        pool.underlyingSymbol.toLowerCase() === 'usdc'
+          ? 1
+          : Number(pool.underlyingPriceUSD)
+
+      const totalSupplyUsd =
+        Number(pool.totalSupply) * Number(pool.exchangeRate) * price
+
+      const totalBorrowUsd = Number(pool.totalBorrows) * price
+      return {
+        pool: pool.id.toLowerCase(),
+        chain: utils.formatChain('base'),
+        project: 'moonwell',
+        symbol: pool.underlyingSymbol == 'WETH' ? 'ETH' : pool.underlyingSymbol,
+        tvlUsd: totalSupplyUsd + totalBorrowUsd,
+        apyBase: Number(pool.supplyRate),
+        apyReward: 0,
+        underlyingTokens: [pool.underlyingAddress],
+        rewardTokens: [],
+        // borrow fields
+        totalSupplyUsd,
+        totalBorrowUsd,
+        apyBaseBorrow: Number(pool.borrowRate),
+        apyRewardBorrow: 0,
+        ltv: Number(pool.collateralFactor),
+        incentives: [] //helper
+      }
+    })
+    .filter(e => e.ltv)
+
+  const mrd_markets = await multicallMRD(base_res.markets.map(r => r.id))
+
+  const prices_id = mrd_markets.flat().reduce((prev, curr) => {
+    const [
+      _owner,
+      _emissionToken,
+      _endTime,
+      _supplyGlobalIndex,
+      _supplyGlobalTimestamp,
+      _borrowGlobalIndex,
+      _borrowGlobalTimestamp,
+      _supplyEmissionsPerSec,
+      _borrowEmissionsPerSec
+    ] = curr
+
+    let lookup
+    if (
+      _emissionToken.toLowerCase() ==
+      '0xff8adec2221f9f4d8dfbafa6b9a297d17603493d'
+    ) {
+      //WELL base -> WELL moonbeam
+      lookup = `moonbeam:0x511ab53f793683763e5a8829738301368a2411e3`
+    } else {
+      lookup = `base:${_emissionToken}`
+    }
+    return {
+      ...prev,
+      [_emissionToken]: lookup
+    }
+  }, {})
+
+  const mrd_prices = await getPrices(Object.values(prices_id))
+
+  const SECONDS_PER_DAY = 86400
+  const DAYS_PER_YEAR = 365
+  const NOW = new Date().getTime() / 1000
+
+  let marketIdx = 0
+  for (let market of baseResults) {
+    let marketRewards = mrd_markets[marketIdx]
+    for (let marketWithRewards of marketRewards) {
+      const [
+        _owner,
+        _emissionToken,
+        _endTime,
+        _supplyGlobalIndex,
+        _supplyGlobalTimestamp,
+        _borrowGlobalIndex,
+        _borrowGlobalTimestamp,
+        _supplyEmissionsPerSec,
+        _borrowEmissionsPerSec
+      ] = marketWithRewards
+
+      let token_info
+      if (
+        _emissionToken.toLowerCase() ==
+        '0xff8adec2221f9f4d8dfbafa6b9a297d17603493d'
+      ) {
+        //WELL base -> WELL moonbeam
+        token_info = mrd_prices['0x511ab53f793683763e5a8829738301368a2411e3']
+      } else {
+        token_info = mrd_prices[_emissionToken]
+      }
+
+      let price = token_info.price
+      let decimals = token_info.decimals
+      let symbol = token_info.symbol
+
+      //only active
+      if (_endTime > NOW) {
+        const supplyRewardsPerDay =
+          (_supplyEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY
+
+        const supplyRewardsPerDayUSD = supplyRewardsPerDay * price
+
+        const borrowRewardsPerDay =
+          (_borrowEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY
+
+        const borrowRewardsPerDayUSD = borrowRewardsPerDay * price
+
+        market.incentives.push({
+          address: _emissionToken,
+          supplyRewardsAPR:
+            market.totalSupplyUsd > 0
+              ? (supplyRewardsPerDayUSD / market.totalSupplyUsd) *
+                DAYS_PER_YEAR *
+                100
+              : 0,
+          borrowRewardsAPR:
+            market.totalBorrowUsd > 0
+              ? (borrowRewardsPerDayUSD / market.totalBorrowUsd) *
+                DAYS_PER_YEAR *
+                100
+              : 0
+        })
+      }
+    }
+    marketIdx++
+  }
+
+  for (let market of baseResults) {
+    const supplyIncentivesAPR = market.incentives.reduce(
+      (prev, curr) => prev + curr.supplyRewardsAPR,
+      0
+    )
+
+    const borrowIncentivesAPR = market.incentives.reduce(
+      (prev, curr) => prev + curr.borrowRewardsAPR,
+      0
+    )
+
+    market.rewardTokens = market.incentives.map(r => r.address)
+    market.apyReward = supplyIncentivesAPR
+    market.apyRewardBorrow = parseFloat(
+      Math.abs(borrowIncentivesAPR).toFixed(6)
+    )
+
+    delete market.incentives
+  }
+
+  return [...moonbeamResults, ...baseResults]
+}
 
 module.exports = {
   timetravel: false,
   apy: getApy,
-  url: 'https://moonwell.fi/artemis',
-};
+  url: 'https://moonwell.fi/markets'
+}

--- a/src/adaptors/moonwell/index.js
+++ b/src/adaptors/moonwell/index.js
@@ -1,10 +1,14 @@
 const utils = require('../utils')
 const sdk = require('@defillama/sdk4')
 const { request, gql, batchRequests } = require('graphql-request')
-const { MRD_ABI } = require('./abi')
+const { MRD_ABI, VIEWS_ABI } = require('./abi')
 const axios = require('axios')
 
 const MRD_CONTRACT = '0xe9005b078701e2A0948D2EaC43010D35870Ad9d2'
+const MOONBEAM_VIEWS_CONTRACT = '0xe76C8B8706faC85a8Fbdcac3C42e3E7823c73994'
+const SECONDS_PER_DAY = 86400
+const DAYS_PER_YEAR = 365
+const NOW = new Date().getTime() / 1000
 
 const getPrices = async addresses => {
   const prices = (
@@ -43,6 +47,19 @@ const multicallMRD = async markets => {
   ).output.map(({ output }) => output)
 }
 
+const multicallViews = async () => {
+  return (
+    await sdk.api.abi.multiCall({
+      chain: 'moonbeam',
+      calls: [{
+        target: MOONBEAM_VIEWS_CONTRACT,
+        params: []
+      }],
+      abi: VIEWS_ABI.find(({ name }) => name === 'getAllMarketsInfo')
+    })
+  ).output.map(({ output }) => output)
+}
+
 const API_URL =
   'https://api.thegraph.com/subgraphs/name/moonwell-fi/moonwell-moonbeam'
 const query = gql`
@@ -58,10 +75,6 @@ const query = gql`
       exchangeRate
       underlyingAddress
       collateralFactor
-      supplyRewardNative
-      supplyRewardProtocol
-      borrowRewardNative
-      borrowRewardProtocol
     }
   }
 `
@@ -110,11 +123,10 @@ const getApy = async () => {
         symbol: pool.underlyingSymbol,
         tvlUsd: totalSupplyUsd - totalBorrowUsd,
         apyBase: Number(pool.supplyRate),
-        apyReward:
-          Number(pool.supplyRewardNative) + Number(pool.supplyRewardProtocol),
+        apyReward: 0,
         underlyingTokens: [
           pool.underlyingAddress ===
-          '0x0000000000000000000000000000000000000000'
+            '0x0000000000000000000000000000000000000000'
             ? '0xAcc15dC74880C9944775448304B263D191c6077F'
             : pool.underlyingAddress
         ],
@@ -126,12 +138,112 @@ const getApy = async () => {
         totalSupplyUsd,
         totalBorrowUsd,
         apyBaseBorrow: Number(pool.borrowRate),
-        apyRewardBorrow:
-          Number(pool.borrowRewardNative) + Number(pool.borrowRewardProtocol),
-        ltv: Number(pool.collateralFactor)
+        apyRewardBorrow: 0,
+        ltv: Number(pool.collateralFactor),
+        incentives: [] //helper
       }
     })
     .filter(e => e.ltv)
+
+  const moonbeam_markets = await multicallViews()
+  let moonbeam_incentives = {}
+  if (moonbeam_markets && moonbeam_markets.length == 1) {
+    const moonbeam_markets_data = moonbeam_markets[0]
+    for (const _market of moonbeam_markets_data) {
+      const _incentives = _market[17] // incentives      
+      moonbeam_incentives[_market[0].toLowerCase()] = _incentives.map((i) => {
+        return {
+          rewardToken: i[0].toLowerCase(),
+          supplyIncentivesPerSec: i[1],
+          borrowIncentivesPerSec: i[2],
+        }
+      })
+    }
+  }
+
+  const moonbeam_prices_id = Object.values(moonbeam_incentives).flat().reduce((prev, curr) => {
+    let _emissionToken = curr.rewardToken;
+    let lookup
+    if (
+      _emissionToken.toLowerCase() ==
+      '0xff8adec2221f9f4d8dfbafa6b9a297d17603493d'
+    ) {
+      //WELL base -> WELL moonbeam
+      lookup = `moonbeam:0x511ab53f793683763e5a8829738301368a2411e3`
+    } else {
+      lookup = `moonbeam:${_emissionToken}`
+    }
+    return {
+      ...prev,
+      [_emissionToken]: lookup
+    }
+  }, {})
+
+  const moonbeam_prices = await getPrices(Object.values(moonbeam_prices_id))
+
+  for (let market of moonbeamResults) {
+    let marketRewards = moonbeam_incentives[market.pool]
+
+    for (let marketWithRewards of marketRewards) {
+      const {
+        rewardToken: _emissionToken,
+        supplyIncentivesPerSec: _supplyEmissionsPerSec,
+        borrowIncentivesPerSec: _borrowEmissionsPerSec
+      } = marketWithRewards
+
+      let token_info = moonbeam_prices[_emissionToken.toLowerCase()]
+      let price = token_info.price
+      let decimals = token_info.decimals
+      let symbol = token_info.symbol
+
+      const supplyRewardsPerDay =
+        (_supplyEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY
+
+      const supplyRewardsPerDayUSD = supplyRewardsPerDay * price
+
+      const borrowRewardsPerDay =
+        (_borrowEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY
+
+      const borrowRewardsPerDayUSD = borrowRewardsPerDay * price
+
+      market.incentives.push({
+        address: _emissionToken,
+        supplyRewardsAPR:
+          market.totalSupplyUsd > 0
+            ? (supplyRewardsPerDayUSD / market.totalSupplyUsd) *
+            DAYS_PER_YEAR *
+            100
+            : 0,
+        borrowRewardsAPR:
+          market.totalBorrowUsd > 0
+            ? (borrowRewardsPerDayUSD / market.totalBorrowUsd) *
+            DAYS_PER_YEAR *
+            100
+            : 0
+      })
+    }
+  }
+
+  for (let market of moonbeamResults) {
+    const supplyIncentivesAPR = market.incentives.reduce(
+      (prev, curr) => prev + curr.supplyRewardsAPR,
+      0
+    )
+
+    const borrowIncentivesAPR = market.incentives.reduce(
+      (prev, curr) => prev + curr.borrowRewardsAPR,
+      0
+    )
+
+    market.rewardTokens = market.incentives.map(r => r.address)
+    market.apyReward = supplyIncentivesAPR
+    market.apyRewardBorrow = parseFloat(
+      Math.abs(borrowIncentivesAPR).toFixed(6)
+    )
+
+    delete market.incentives
+  }
+
 
   let base_res = await request(BASE_API_URL, base_query)
   let baseResults = base_res.markets
@@ -196,9 +308,6 @@ const getApy = async () => {
 
   const mrd_prices = await getPrices(Object.values(prices_id))
 
-  const SECONDS_PER_DAY = 86400
-  const DAYS_PER_YEAR = 365
-  const NOW = new Date().getTime() / 1000
 
   let marketIdx = 0
   for (let market of baseResults) {
@@ -248,14 +357,14 @@ const getApy = async () => {
           supplyRewardsAPR:
             market.totalSupplyUsd > 0
               ? (supplyRewardsPerDayUSD / market.totalSupplyUsd) *
-                DAYS_PER_YEAR *
-                100
+              DAYS_PER_YEAR *
+              100
               : 0,
           borrowRewardsAPR:
             market.totalBorrowUsd > 0
               ? (borrowRewardsPerDayUSD / market.totalBorrowUsd) *
-                DAYS_PER_YEAR *
-                100
+              DAYS_PER_YEAR *
+              100
               : 0
         })
       }

--- a/src/adaptors/moonwell/index.js
+++ b/src/adaptors/moonwell/index.js
@@ -136,10 +136,7 @@ const getApy = async () => {
   let base_res = await request(BASE_API_URL, base_query)
   let baseResults = base_res.markets
     .map(pool => {
-      let price =
-        pool.underlyingSymbol.toLowerCase() === 'usdc'
-          ? 1
-          : Number(pool.underlyingPriceUSD)
+      let price = Number(pool.underlyingPriceUSD)
 
       const totalSupplyUsd =
         Number(pool.totalSupply) * Number(pool.exchangeRate) * price
@@ -227,7 +224,7 @@ const getApy = async () => {
         //WELL base -> WELL moonbeam
         token_info = mrd_prices['0x511ab53f793683763e5a8829738301368a2411e3']
       } else {
-        token_info = mrd_prices[_emissionToken]
+        token_info = mrd_prices[_emissionToken.toLowerCase()]
       }
 
       let price = token_info.price


### PR DESCRIPTION
We changed our Subgraph and removed some columns, this caused the Moonbeam APY to fail.

In this PR we changed to use onchain data to calculate the APY.