### PR TITLE
Fix Moonwell Moonbeam APYs

### DIFF
--- a/src/adaptors/moonwell/abi.js
+++ b/src/adaptors/moonwell/abi.js
@@ -1,4 +1,999 @@
 module.exports = {
+  VIEWS_ABI: [
+    {
+      "type": "function",
+      "name": "comptroller",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract Comptroller"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getAllMarketsInfo",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Market[]",
+          "components": [
+            {
+              "name": "market",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "isListed",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "mintPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "collateralFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "underlyingPrice",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalSupply",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalBorrows",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalReserves",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "cash",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "exchangeRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowIndex",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "reserveFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "incentives",
+              "type": "tuple[]",
+              "internalType": "struct BaseMoonwellViews.MarketIncentives[]",
+              "components": [
+                {
+                  "name": "token",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "supplyIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "borrowIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getGovernanceTokenPrice",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketIncentives",
+      "inputs": [
+        {
+          "name": "market",
+          "type": "address",
+          "internalType": "contract MToken"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.MarketIncentives[]",
+          "components": [
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "supplyIncentivesPerSec",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowIncentivesPerSec",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketInfo",
+      "inputs": [
+        {
+          "name": "_mToken",
+          "type": "address",
+          "internalType": "contract MToken"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.Market",
+          "components": [
+            {
+              "name": "market",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "isListed",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "mintPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "collateralFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "underlyingPrice",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalSupply",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalBorrows",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalReserves",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "cash",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "exchangeRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowIndex",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "reserveFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "incentives",
+              "type": "tuple[]",
+              "internalType": "struct BaseMoonwellViews.MarketIncentives[]",
+              "components": [
+                {
+                  "name": "token",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "supplyIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "borrowIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getMarketsInfo",
+      "inputs": [
+        {
+          "name": "_mTokens",
+          "type": "address[]",
+          "internalType": "contract MToken[]"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Market[]",
+          "components": [
+            {
+              "name": "market",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "isListed",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyCap",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "mintPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "borrowPaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "collateralFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "underlyingPrice",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalSupply",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalBorrows",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalReserves",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "cash",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "exchangeRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowIndex",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "reserveFactor",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "supplyRate",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "incentives",
+              "type": "tuple[]",
+              "internalType": "struct BaseMoonwellViews.MarketIncentives[]",
+              "components": [
+                {
+                  "name": "token",
+                  "type": "address",
+                  "internalType": "address"
+                },
+                {
+                  "name": "supplyIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "borrowIncentivesPerSec",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getNativeTokenPrice",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getProtocolInfo",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.ProtocolInfo",
+          "components": [
+            {
+              "name": "seizePaused",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "transferPaused",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getStakingInfo",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.StakingInfo",
+          "components": [
+            {
+              "name": "cooldown",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "unstakeWindow",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "distributionEnd",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalSupply",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "emissionPerSecond",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "lastUpdateTimestamp",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "index",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getTokensBalances",
+      "inputs": [
+        {
+          "name": "_tokens",
+          "type": "address[]",
+          "internalType": "address[]"
+        },
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Balances[]",
+          "components": [
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserBalances",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Balances[]",
+          "components": [
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserBorrowsBalances",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Balances[]",
+          "components": [
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserClaimsVotingPower",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.Votes",
+          "components": [
+            {
+              "name": "delegatedVotingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "votingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "delegates",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserMarketsMemberships",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Memberships[]",
+          "components": [
+            {
+              "name": "membership",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "token",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserRewards",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "tuple[]",
+          "internalType": "struct BaseMoonwellViews.Rewards[]",
+          "components": [
+            {
+              "name": "market",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "rewardToken",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "supplyRewardsAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "borrowRewardsAmount",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserStakingInfo",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.UserStakingInfo",
+          "components": [
+            {
+              "name": "cooldown",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "pendingRewards",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "totalStaked",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserStakingVotingPower",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.Votes",
+          "components": [
+            {
+              "name": "delegatedVotingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "votingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "delegates",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserTokensVotingPower",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.Votes",
+          "components": [
+            {
+              "name": "delegatedVotingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "votingPower",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "delegates",
+              "type": "address",
+              "internalType": "address"
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "getUserVotingPower",
+      "inputs": [
+        {
+          "name": "_user",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "_result",
+          "type": "tuple",
+          "internalType": "struct BaseMoonwellViews.UserVotes",
+          "components": [
+            {
+              "name": "claimsVotes",
+              "type": "tuple",
+              "internalType": "struct BaseMoonwellViews.Votes",
+              "components": [
+                {
+                  "name": "delegatedVotingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "votingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "delegates",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            },
+            {
+              "name": "stakingVotes",
+              "type": "tuple",
+              "internalType": "struct BaseMoonwellViews.Votes",
+              "components": [
+                {
+                  "name": "delegatedVotingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "votingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "delegates",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            },
+            {
+              "name": "tokenVotes",
+              "type": "tuple",
+              "internalType": "struct BaseMoonwellViews.Votes",
+              "components": [
+                {
+                  "name": "delegatedVotingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "votingPower",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                },
+                {
+                  "name": "delegates",
+                  "type": "address",
+                  "internalType": "address"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "governanceToken",
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "",
+          "type": "address",
+          "internalType": "contract Well"
+        }
+      ],
+      "stateMutability": "view"
+    },
+    {
+      "type": "function",
+      "name": "initialize",
+      "inputs": [
+        {
+          "name": "_comptroller",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "tokenSaleDistributor",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "safetyModule",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "_governanceToken",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "nativeMarket",
+          "type": "address",
+          "internalType": "address"
+        },
+        {
+          "name": "governanceTokenLP",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "Initialized",
+      "inputs": [
+        {
+          "name": "version",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        }
+      ],
+      "anonymous": false
+    }
+  ],
   MRD_ABI: [
     { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
     {

--- a/src/adaptors/moonwell/index.js
+++ b/src/adaptors/moonwell/index.js
@@ -1,5 +1,5 @@
 const utils = require('../utils')
-const sdk = require('@defillama/sdk4')
+const sdk = require('@defillama/sdk5')
 const { request, gql, batchRequests } = require('graphql-request')
 const { MRD_ABI, VIEWS_ABI } = require('./abi')
 const axios = require('axios')

--- a/src/adaptors/moonwell/index.js
+++ b/src/adaptors/moonwell/index.js
@@ -1,19 +1,24 @@
-const utils = require('../utils');
-const sdk = require('@defillama/sdk5');
-const { request, gql, batchRequests } = require('graphql-request');
-const { MRD_ABI } = require('./abi');
-const axios = require('axios');
+const utils = require('../utils')
+const sdk = require('@defillama/sdk4')
+const { request, gql, batchRequests } = require('graphql-request')
+const { MRD_ABI, VIEWS_ABI } = require('./abi')
+const axios = require('axios')
 
-const MRD_CONTRACT = '0xe9005b078701e2A0948D2EaC43010D35870Ad9d2';
+const MRD_CONTRACT = '0xe9005b078701e2A0948D2EaC43010D35870Ad9d2'
+const MOONBEAM_VIEWS_CONTRACT = '0xe76C8B8706faC85a8Fbdcac3C42e3E7823c73994'
 
-const getPrices = async (addresses) => {
+const SECONDS_PER_DAY = 86400
+const DAYS_PER_YEAR = 365
+const NOW = new Date().getTime() / 1000
+
+const getPrices = async addresses => {
   const prices = (
     await axios.get(
       `https://coins.llama.fi/prices/current/${addresses
         .join(',')
         .toLowerCase()}`
     )
-  ).data.coins;
+  ).data.coins
 
   const pricesByAddress = Object.entries(prices).reduce(
     (acc, [name, price]) => ({
@@ -21,30 +26,43 @@ const getPrices = async (addresses) => {
       [name.split(':')[1]]: {
         decimals: price.decimals,
         symbol: price.symbol,
-        price: price.price,
-      },
+        price: price.price
+      }
     }),
     {}
-  );
+  )
 
-  return pricesByAddress;
-};
+  return pricesByAddress
+}
 
-const multicallMRD = async (markets) => {
+const multicallMRD = async markets => {
   return (
     await sdk.api.abi.multiCall({
       chain: 'base',
-      calls: markets.map((market) => ({
+      calls: markets.map(market => ({
         target: MRD_CONTRACT,
-        params: [market],
+        params: [market]
       })),
-      abi: MRD_ABI.find(({ name }) => name === 'getAllMarketConfigs'),
+      abi: MRD_ABI.find(({ name }) => name === 'getAllMarketConfigs')
     })
-  ).output.map(({ output }) => output);
-};
+  ).output.map(({ output }) => output)
+}
+
+const multicallViews = async () => {
+  return (
+    await sdk.api.abi.multiCall({
+      chain: 'moonbeam',
+      calls: [{
+        target: MOONBEAM_VIEWS_CONTRACT,
+        params: []
+      }],
+      abi: VIEWS_ABI.find(({ name }) => name === 'getAllMarketsInfo')
+    })
+  ).output.map(({ output }) => output)
+}
 
 const API_URL =
-  'https://api.thegraph.com/subgraphs/name/moonwell-fi/moonwell-moonbeam';
+  'https://api.thegraph.com/subgraphs/name/moonwell-fi/moonwell-moonbeam'
 const query = gql`
   {
     markets {
@@ -58,16 +76,12 @@ const query = gql`
       exchangeRate
       underlyingAddress
       collateralFactor
-      supplyRewardNative
-      supplyRewardProtocol
-      borrowRewardNative
-      borrowRewardProtocol
     }
   }
-`;
+`
 
 const BASE_API_URL =
-  'https://subgraph.satsuma-prod.com/dd48bfe50148/moonwell/base/api';
+  'https://subgraph.satsuma-prod.com/dd48bfe50148/moonwell/base/api'
 const base_query = gql`
   {
     markets {
@@ -83,25 +97,25 @@ const base_query = gql`
       collateralFactor
     }
   }
-`;
+`
 const getApy = async () => {
-  const res = await request(API_URL, query);
+  const res = await request(API_URL, query)
   const moonbeamResults = res.markets
-    .map((pool) => {
+    .map(pool => {
       let price =
         pool.underlyingSymbol.toLowerCase() === 'usdc'
           ? 1
-          : Number(pool.underlyingPriceUSD);
+          : Number(pool.underlyingPriceUSD)
       if (price === 0 && pool.underlyingSymbol.toLowerCase() === 'weth') {
         const _price = res.markets.find(
-          (e) => e.id === '0xaaa20c5a584a9fecdfedd71e46da7858b774a9ce'
-        ).underlyingPriceUSD;
-        price = Number(_price);
+          e => e.id === '0xaaa20c5a584a9fecdfedd71e46da7858b774a9ce'
+        ).underlyingPriceUSD
+        price = Number(_price)
       }
 
       const totalSupplyUsd =
-        Number(pool.totalSupply) * Number(pool.exchangeRate) * price;
-      const totalBorrowUsd = Number(pool.totalBorrows) * price;
+        Number(pool.totalSupply) * Number(pool.exchangeRate) * price
+      const totalBorrowUsd = Number(pool.totalBorrows) * price
 
       return {
         pool: pool.id.toLowerCase(),
@@ -110,41 +124,137 @@ const getApy = async () => {
         symbol: pool.underlyingSymbol,
         tvlUsd: totalSupplyUsd - totalBorrowUsd,
         apyBase: Number(pool.supplyRate),
-        apyReward:
-          Number(pool.supplyRewardNative) + Number(pool.supplyRewardProtocol),
+        apyReward: 0,
         underlyingTokens: [
           pool.underlyingAddress ===
-          '0x0000000000000000000000000000000000000000'
+            '0x0000000000000000000000000000000000000000'
             ? '0xAcc15dC74880C9944775448304B263D191c6077F'
-            : pool.underlyingAddress,
+            : pool.underlyingAddress
         ],
         rewardTokens: [
           '0x511ab53f793683763e5a8829738301368a2411e3',
-          '0xacc15dc74880c9944775448304b263d191c6077f',
+          '0xacc15dc74880c9944775448304b263d191c6077f'
         ],
         // borrow fields
         totalSupplyUsd,
         totalBorrowUsd,
         apyBaseBorrow: Number(pool.borrowRate),
-        apyRewardBorrow:
-          Number(pool.borrowRewardNative) + Number(pool.borrowRewardProtocol),
+        apyRewardBorrow: 0,
         ltv: Number(pool.collateralFactor),
-      };
+        incentives: [] //helper
+      }
     })
-    .filter((e) => e.ltv);
+    .filter(e => e.ltv)
 
-  let base_res = await request(BASE_API_URL, base_query);
+  const moonbeam_markets = await multicallViews()
+  let moonbeam_incentives = {}
+  if (moonbeam_markets && moonbeam_markets.length == 1) {
+    const moonbeam_markets_data = moonbeam_markets[0]
+    for (const _market of moonbeam_markets_data) {
+      const _incentives = _market[17] // incentives      
+      moonbeam_incentives[_market[0].toLowerCase()] = _incentives.map((i) => {
+        return {
+          rewardToken: i[0].toLowerCase(),
+          supplyIncentivesPerSec: i[1],
+          borrowIncentivesPerSec: i[2],
+        }
+      })
+    }
+  }
+
+  const moonbeam_prices_id = Object.values(moonbeam_incentives).flat().reduce((prev, curr) => {
+    let _emissionToken = curr.rewardToken;
+    let lookup
+    if (
+      _emissionToken.toLowerCase() ==
+      '0xff8adec2221f9f4d8dfbafa6b9a297d17603493d'
+    ) {
+      //WELL base -> WELL moonbeam
+      lookup = `moonbeam:0x511ab53f793683763e5a8829738301368a2411e3`
+    } else {
+      lookup = `moonbeam:${_emissionToken}`
+    }
+    return {
+      ...prev,
+      [_emissionToken]: lookup
+    }
+  }, {})
+
+  const moonbeam_prices = await getPrices(Object.values(moonbeam_prices_id))
+
+  for (let market of moonbeamResults) {
+    let marketRewards = moonbeam_incentives[market.pool]
+
+    for (let marketWithRewards of marketRewards) {
+      const {
+        rewardToken: _emissionToken,
+        supplyIncentivesPerSec: _supplyEmissionsPerSec,
+        borrowIncentivesPerSec: _borrowEmissionsPerSec
+      } = marketWithRewards
+
+      let token_info = moonbeam_prices[_emissionToken.toLowerCase()]
+      let price = token_info.price
+      let decimals = token_info.decimals
+      let symbol = token_info.symbol
+
+      const supplyRewardsPerDay =
+        (_supplyEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY
+
+      const supplyRewardsPerDayUSD = supplyRewardsPerDay * price
+
+      const borrowRewardsPerDay =
+        (_borrowEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY
+
+      const borrowRewardsPerDayUSD = borrowRewardsPerDay * price
+
+      market.incentives.push({
+        address: _emissionToken,
+        supplyRewardsAPR:
+          market.totalSupplyUsd > 0
+            ? (supplyRewardsPerDayUSD / market.totalSupplyUsd) *
+            DAYS_PER_YEAR *
+            100
+            : 0,
+        borrowRewardsAPR:
+          market.totalBorrowUsd > 0
+            ? (borrowRewardsPerDayUSD / market.totalBorrowUsd) *
+            DAYS_PER_YEAR *
+            100
+            : 0
+      })
+    }
+  }
+
+  for (let market of moonbeamResults) {
+    const supplyIncentivesAPR = market.incentives.reduce(
+      (prev, curr) => prev + curr.supplyRewardsAPR,
+      0
+    )
+
+    const borrowIncentivesAPR = market.incentives.reduce(
+      (prev, curr) => prev + curr.borrowRewardsAPR,
+      0
+    )
+
+    market.rewardTokens = market.incentives.map(r => r.address)
+    market.apyReward = supplyIncentivesAPR
+    market.apyRewardBorrow = parseFloat(
+      Math.abs(borrowIncentivesAPR).toFixed(6)
+    )
+
+    delete market.incentives
+  }
+
+
+  let base_res = await request(BASE_API_URL, base_query)
   let baseResults = base_res.markets
-    .map((pool) => {
-      let price =
-        pool.underlyingSymbol.toLowerCase() === 'usdc'
-          ? 1
-          : Number(pool.underlyingPriceUSD);
+    .map(pool => {
+      let price = Number(pool.underlyingPriceUSD)
 
       const totalSupplyUsd =
-        Number(pool.totalSupply) * Number(pool.exchangeRate) * price;
+        Number(pool.totalSupply) * Number(pool.exchangeRate) * price
 
-      const totalBorrowUsd = Number(pool.totalBorrows) * price;
+      const totalBorrowUsd = Number(pool.totalBorrows) * price
       return {
         pool: pool.id.toLowerCase(),
         chain: utils.formatChain('base'),
@@ -161,12 +271,12 @@ const getApy = async () => {
         apyBaseBorrow: Number(pool.borrowRate),
         apyRewardBorrow: 0,
         ltv: Number(pool.collateralFactor),
-        incentives: [], //helper
-      };
+        incentives: [] //helper
+      }
     })
-    .filter((e) => e.ltv);
+    .filter(e => e.ltv)
 
-  const mrd_markets = await multicallMRD(base_res.markets.map((r) => r.id));
+  const mrd_markets = await multicallMRD(base_res.markets.map(r => r.id))
 
   const prices_id = mrd_markets.flat().reduce((prev, curr) => {
     const [
@@ -178,34 +288,31 @@ const getApy = async () => {
       _borrowGlobalIndex,
       _borrowGlobalTimestamp,
       _supplyEmissionsPerSec,
-      _borrowEmissionsPerSec,
-    ] = curr;
+      _borrowEmissionsPerSec
+    ] = curr
 
-    let lookup;
+    let lookup
     if (
       _emissionToken.toLowerCase() ==
       '0xff8adec2221f9f4d8dfbafa6b9a297d17603493d'
     ) {
       //WELL base -> WELL moonbeam
-      lookup = `moonbeam:0x511ab53f793683763e5a8829738301368a2411e3`;
+      lookup = `moonbeam:0x511ab53f793683763e5a8829738301368a2411e3`
     } else {
-      lookup = `base:${_emissionToken}`;
+      lookup = `base:${_emissionToken}`
     }
     return {
       ...prev,
-      [_emissionToken]: lookup,
-    };
-  }, {});
+      [_emissionToken]: lookup
+    }
+  }, {})
 
-  const mrd_prices = await getPrices(Object.values(prices_id));
+  const mrd_prices = await getPrices(Object.values(prices_id))
 
-  const SECONDS_PER_DAY = 86400;
-  const DAYS_PER_YEAR = 365;
-  const NOW = new Date().getTime() / 1000;
 
-  let marketIdx = 0;
+  let marketIdx = 0
   for (let market of baseResults) {
-    let marketRewards = mrd_markets[marketIdx];
+    let marketRewards = mrd_markets[marketIdx]
     for (let marketWithRewards of marketRewards) {
       const [
         _owner,
@@ -216,81 +323,81 @@ const getApy = async () => {
         _borrowGlobalIndex,
         _borrowGlobalTimestamp,
         _supplyEmissionsPerSec,
-        _borrowEmissionsPerSec,
-      ] = marketWithRewards;
+        _borrowEmissionsPerSec
+      ] = marketWithRewards
 
-      let token_info;
+      let token_info
       if (
         _emissionToken.toLowerCase() ==
         '0xff8adec2221f9f4d8dfbafa6b9a297d17603493d'
       ) {
         //WELL base -> WELL moonbeam
-        token_info = mrd_prices['0x511ab53f793683763e5a8829738301368a2411e3'];
+        token_info = mrd_prices['0x511ab53f793683763e5a8829738301368a2411e3']
       } else {
-        token_info = mrd_prices[_emissionToken.toLowerCase()];
+        token_info = mrd_prices[_emissionToken.toLowerCase()]
       }
 
-      let price = token_info?.price;
-      let decimals = token_info?.decimals;
-      let symbol = token_info?.symbol;
+      let price = token_info.price
+      let decimals = token_info.decimals
+      let symbol = token_info.symbol
 
       //only active
       if (_endTime > NOW) {
         const supplyRewardsPerDay =
-          (_supplyEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY;
+          (_supplyEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY
 
-        const supplyRewardsPerDayUSD = supplyRewardsPerDay * price;
+        const supplyRewardsPerDayUSD = supplyRewardsPerDay * price
 
         const borrowRewardsPerDay =
-          (_borrowEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY;
+          (_borrowEmissionsPerSec / Math.pow(-10, decimals)) * SECONDS_PER_DAY
 
-        const borrowRewardsPerDayUSD = borrowRewardsPerDay * price;
+        const borrowRewardsPerDayUSD = borrowRewardsPerDay * price
 
         market.incentives.push({
           address: _emissionToken,
           supplyRewardsAPR:
             market.totalSupplyUsd > 0
               ? (supplyRewardsPerDayUSD / market.totalSupplyUsd) *
-                DAYS_PER_YEAR *
-                100
+              DAYS_PER_YEAR *
+              100
               : 0,
           borrowRewardsAPR:
             market.totalBorrowUsd > 0
               ? (borrowRewardsPerDayUSD / market.totalBorrowUsd) *
-                DAYS_PER_YEAR *
-                100
-              : 0,
-        });
+              DAYS_PER_YEAR *
+              100
+              : 0
+        })
       }
     }
-    marketIdx++;
+    marketIdx++
   }
 
   for (let market of baseResults) {
     const supplyIncentivesAPR = market.incentives.reduce(
       (prev, curr) => prev + curr.supplyRewardsAPR,
       0
-    );
+    )
 
     const borrowIncentivesAPR = market.incentives.reduce(
       (prev, curr) => prev + curr.borrowRewardsAPR,
       0
-    );
+    )
 
-    market.rewardTokens = market.incentives.map((r) => r.address);
-    market.apyReward = supplyIncentivesAPR;
+    market.rewardTokens = market.incentives.map(r => r.address)
+    market.apyReward = supplyIncentivesAPR
     market.apyRewardBorrow = parseFloat(
       Math.abs(borrowIncentivesAPR).toFixed(6)
-    );
+    )
 
-    delete market.incentives;
+    delete market.incentives
   }
 
-  return [...moonbeamResults, ...baseResults];
-};
+  return [...moonbeamResults, ...baseResults]
+}
 
 module.exports = {
   timetravel: false,
   apy: getApy,
-  url: 'https://moonwell.fi/markets',
-};
+  url: 'https://moonwell.fi/markets'
+}


### PR DESCRIPTION
We changed our Subgraph and removed some columns, this caused the Moonbeam APY to fail.

In this PR we changed to use onchain data to calculate the APY.