### PR TITLE
chore: update arrakis URL

### DIFF
--- a/src/adaptors/arrakis-v1/index.js
+++ b/src/adaptors/arrakis-v1/index.js
@@ -120,7 +120,7 @@ const getApy = async () => {
         apyBase: vault.snapshots[0]
           ? Number(vault.snapshots[0].apr)
           : Number(vault.apr.averageApr),
-        url: `https://beta.arrakis.finance/vaults/${CHAIN_IDS[chain]}/${vault.id}`,
+        url: `https://app.arrakis.fi/vaults/${vault.id}`,
         underlyingTokens: [vault.token0.address, vault.token1.address],
       };
     });


### PR DESCRIPTION
Recently Arrakis moved away from the `beta` website.
Trying to update the old directories the point to the right URL, so that wallets such as Rabby don't label the new one as "low popularity". 