### PR TITLE
SONNE Finance on Base chain reward APR non propogation error fixed.

### DIFF
--- a/src/adaptors/sonne-finance/index.js
+++ b/src/adaptors/sonne-finance/index.js
@@ -172,7 +172,7 @@ const lendingApy = async (chain) => {
     chain
   );
 
-  const SONNE = CHAINS[chain].SONNE;
+  const SONNE = CHAINS.optimism.SONNE;
 
   const prices = await getPrices(
     underlyingTokens


### PR DESCRIPTION
SONNE Finance on Base chain Supply/Borrow reward APR were not been populated. Problem was identified when get prices from BASE for SONNE token.
With this change, SONNE price address will always be set to the address from the Optimism chain to include optimism price as canon in calculation.