### PR TITLE
feat: updated to include wombat LPs

### DIFF
--- a/src/adaptors/yield-yak-aggregator/index.js
+++ b/src/adaptors/yield-yak-aggregator/index.js
@@ -73,10 +73,17 @@ const main = async () => {
             (farm.totalDeposits / farm.lpToken.supply);
         }
       } else {
-        const tokenSymbol = farm.depositToken.address.toLowerCase();
-        const tokenName = farm.name.toLowerCase();
-        const tokenPrice =
-          pricesByAddress[tokenSymbol] || pricesBySymbol[tokenName];
+        let tokenPrice = 0;
+
+        if (farm.platform == 'wombat') {
+          const tokenSymbol = farm.depositToken.underlying[0].toLowerCase();
+          tokenPrice = pricesByAddress[tokenSymbol];
+        } else {
+          const tokenSymbol = farm.depositToken.address.toLowerCase();
+          const tokenName = farm.name.toLowerCase();
+          tokenPrice =
+            pricesByAddress[tokenSymbol] || pricesBySymbol[tokenName];
+        }
 
         if (farm.depositToken.stablecoin) tvlUsd = Number(farm.totalDeposits);
         else if (tokenPrice) tvlUsd = tokenPrice * Number(farm.totalDeposits);


### PR DESCRIPTION
Currently, the YY adapter returns TVL as 0 for single-sided wombat vaults due to attempting to fetch a price for an LP token instead of an underlying token. 

As the price returned is 0, the TVL is also 0, meaning the pool isn't shown on the dashboard. 

This PR adds a separate logic for Wombat Pools without breaking TVL calculations for the rest of the vaults.