### PR TITLE
IPOR - add apy from aidrop

### DIFF
--- a/src/adaptors/ipor/index.js
+++ b/src/adaptors/ipor/index.js
@@ -6,11 +6,16 @@ const LP_STATS_ETHEREUM_URL =
   'https://api.ipor.io/monitor/liquiditypool-statistics-1';
 const LP_STATS_ARBITRUM_URL =
   'https://api.ipor.io/monitor/liquiditypool-statistics-42161';
+const ARB_AIRDROP_URL = 'https://api.ipor.io/monitor/arb-airdrop';
+const WSTETH_AIRDROP_URL = 'https://api.ipor.io/monitor/arb-lido-airdrop';
 const COIN_PRICES_URL = 'https://coins.llama.fi/prices/current';
 
 const LM_ADDRESS_ETHEREUM = '0xCC3Fc4C9Ba7f8b8aA433Bc586D390A70560FF366';
 const LM_ADDRESS_ARBITRUM = '0xdE645aB0560E5A413820234d9DDED5f4a55Ff6dd';
 const IPOR_TOKEN_ETHEREUM = '0x1e4746dc744503b53b4a082cb3607b169a289090';
+const IPOR_TOKEN_ARBITRUM = '0x34229b3f16fbcdfa8d8d9d17c0852f9496f4c7bb';
+const ARB_TOKEN_ARBITRUM = '0x912ce59144191c1204e64559fe8253a0e49e6548';
+const WSTETH_TOKEN_ARBITRUM = '0x5979d7b546e38e414f7e9822514be443a4800529';
 
 const BLOCKS_PER_YEAR = (365 * 24 * 3600) / 12;
 
@@ -19,6 +24,10 @@ const apy = async () => {
     .assets;
   const assetsArbitrum = (await superagent.get(LP_STATS_ARBITRUM_URL)).body
     .assets;
+  const arbAidrdop = (await superagent.get(ARB_AIRDROP_URL)).body;
+  const arbAirdropLastEpochFinished = Date.parse(arbAidrdop.epochEnd) < Date.now(); //epochEnd will be date in past when last airdrop epoch will be finished
+  const wstEthAirdrop = (await superagent.get(WSTETH_AIRDROP_URL)).body;
+  const wstEthAirdropLastEpochFinished = Date.parse(wstEthAirdrop.epochEnd) < Date.now(); //epochEnd will be date in past when last airdrop epoch will be finished
   const coinKeys = assetsEthereum.map(
     (assetData) => 'ethereum:' + assetData.assetAddress
   );
@@ -28,13 +37,16 @@ const apy = async () => {
 
   coinKeys.push('ethereum:' + IPOR_TOKEN_ETHEREUM);
   coinKeys.push(...coinKeysArbitrum);
-
+  coinKeys.push('arbitrum:' + ARB_TOKEN_ARBITRUM);
+  coinKeys.push('arbitrum:' + WSTETH_TOKEN_ARBITRUM);
   const coinPrices = (
     await superagent.get(
       `${COIN_PRICES_URL}/${coinKeys.join(',').toLowerCase()}`
     )
   ).body.coins;
   const iporTokenUsdPrice = coinPrices['ethereum:' + IPOR_TOKEN_ETHEREUM].price;
+  const arbTokenUsdPrice = coinPrices['arbitrum:' + ARB_TOKEN_ARBITRUM].price;
+  const wstethTokenUsdPrice = coinPrices['arbitrum:' + WSTETH_TOKEN_ARBITRUM].price;
 
   const lpTokenEthereumAddresses = assetsEthereum.map(
     (assetData) => assetData.ipTokenAssetAddress
@@ -135,6 +147,13 @@ const apy = async () => {
   }
 
   for (const asset of assetsArbitrum) {
+    const rewardsToken = [IPOR_TOKEN_ARBITRUM];
+    if (asset.asset === 'wstETH' && !wstEthAirdropLastEpochFinished) {
+      rewardsToken.push(WSTETH_TOKEN_ARBITRUM);
+    }
+    if (!arbAirdropLastEpochFinished) {
+      rewardsToken.push(ARB_TOKEN_ARBITRUM);
+    }
     const lpApr = asset.periods.find(
       ({ period }) => period === 'MONTH'
     ).ipTokenReturnValue;
@@ -165,6 +184,38 @@ const apy = async () => {
         2) * //50% early withdraw fee
       100; //percentage
 
+    let apyWstEthAirdrop = 0;
+    if (asset.asset === 'wstETH' && !wstEthAirdropLastEpochFinished) {
+      const rewardsWstEthIporRatio = wstEthAirdrop.pools.find(
+        (assetData) => assetData.asset === asset.asset
+      ).rewardsArbIporRatio;
+      apyWstEthAirdrop =
+        (((liquidityMiningGlobalStats.rewardsPerBlock /
+          1e8 /
+          (liquidityMiningGlobalStats.aggregatedPowerUp / 1e18)) *
+          0.2 * //base powerup
+          BLOCKS_PER_YEAR *
+          wstethTokenUsdPrice * rewardsWstEthIporRatio) /
+          lpTokenPrice /
+          coinPrice) *
+        100; //percentage
+    }
+
+    const rewardsArbIporRatio = arbAidrdop.pools.find(
+      (assetData) => assetData.asset === asset.asset
+    ).rewardsArbIporRatio;
+    const apyAirdrop = !arbAirdropLastEpochFinished ?
+      (((liquidityMiningGlobalStats.rewardsPerBlock /
+        1e8 /
+        (liquidityMiningGlobalStats.aggregatedPowerUp / 1e18)) *
+        0.2 * //base powerup
+        BLOCKS_PER_YEAR *
+        arbTokenUsdPrice * rewardsArbIporRatio) /
+        lpTokenPrice /
+        coinPrice) *
+      100 //percentage
+      : 0;
+
     pools.push({
       pool: asset.ipTokenAssetAddress + '-arbitrum',
       chain: 'Arbitrum',
@@ -172,9 +223,9 @@ const apy = async () => {
       symbol: asset.asset,
       tvlUsd: lpBalance * coinPrice,
       apyBase: Number(lpApr),
-      apyReward: Number(apyReward),
+      apyReward: Number(apyReward + apyWstEthAirdrop + apyAirdrop),
       underlyingTokens: [asset.assetAddress],
-      rewardTokens: [IPOR_TOKEN_ETHEREUM],
+      rewardTokens: rewardsToken,
     });
   }
 


### PR DESCRIPTION
Hi,
IPOR Protocol is giving additional rewards to users participating in liquidity mining on Arbitrum. Rewards are proportional to the rewards from liquidity mining. Calculations are run by IPOR backend, and rewards will be issued on an epoch-by-epoch basis via dedicated contracts every week. Rewards are calculated in real-time by the backend and can be claimed at the end of each epoch. The program runs for the next 12 weeks (ARB token for USDC,wstETH pools,  and within a week or so another pool on Arbitrum). Additionally, for the next 4 weeks, wstETH pool will be incentivized with wstETH in the same manner.