### PR TITLE
revert apy calculation

### DIFF
--- a/src/adaptors/pearl-v2/index.js
+++ b/src/adaptors/pearl-v2/index.js
@@ -246,13 +246,14 @@ async function computePairInfo(pairInfo, prices, pearlPrice) {
  * Formats a pair info object into a pool object.
  */
 function formatPool(p) {
+  const apyReward = (Math.pow(1 + p.apr / 36500, 365) - 1) * 100; // daily compounding
   return {
     pool: p.pair_address,
     chain: utils.formatChain('real'),
     project: 'pearl-v2',
     symbol: utils.formatSymbol(p.symbol.split('-')[1]),
     tvlUsd: p.pairTvlUsd,
-    apyReward: p.apr,
+    apyReward: apyReward,
     rewardTokens: p.apr ? [PEARL_ADDRESS] : [],
     underlyingTokens: [p.token0, p.token1],
   };


### PR DESCRIPTION
Hi @slasher125, I'm creating this PR, since we made some comments on the old one, but there was no response. This is the comment made on old PR
> > ok, if the project doesn't auto compound neither do we, so in this case APY = APR. pls update that part
> 
> APR and APY are not the same thing, and this has nothing to do with whether or not there's an autocompounder. If you have a TradFi savings account, with a 10% APR, that compounds for you automatically, but these are still different. If you start with $10k, that's $10k x 10% / 12 = $83.33/month that you earn. The APY assumes you leave it in, and measures how much you'd accumulate over the course of a year by doing that. So that's (1 + 10% / 12) ^ 12 - 1 = 10.47%. So you'd end up with $11047 after 1yr. The APR is completely different. That would be like if you withdrew all your interest as soon as it hit, and spent it. In that case, you'd have $10k in the account, and you'd have spent exactly $1k, or 10.0%. That's the APR. The autocompounding is irrelevant.
> 
> As I understand it, we're trying to switch our UI to use APY instead of APR. Both are valid numbers, but APYs are higher, and consistent with DefiLlama. Not everyone understands the difference, and are confused when the numbers appear different. But to use the calculation for APR, and call it an APY, that would be highly misleading, and misrepresent returns to users.

Can you check if this is aligned with your philosophy of what APY is, or you have some other definition? Also a link to original comment https://github.com/DefiLlama/yield-server/pull/1375#issuecomment-2178898429
