### PR TITLE
add anzen

### DIFF
--- a/src/adaptors/anzen-v2/index.js
+++ b/src/adaptors/anzen-v2/index.js
@@ -1,0 +1,62 @@
+const sdk = require('@defillama/sdk');
+const axios = require('axios');
+const utils = require('../utils');
+
+const USDz = '0xA469B7Ee9ee773642b3e93E842e5D9b5BaA10067';
+const sUSDz = '0x547213367cfb08ab418e7b54d7883b2c2aa27fd7';
+
+const apy = async () => {
+  const totalSupply =
+    (
+      await sdk.api.abi.call({
+        target: sUSDz,
+        abi: 'erc20:totalSupply',
+      })
+    ).output / 1e18;
+
+  const priceKey = `ethereum:${USDz}`;
+  const price = (
+    await axios.get(`https://coins.llama.fi/prices/current/${priceKey}`)
+  ).data.coins[priceKey].price;
+
+  const tvlUsd = totalSupply * price;
+
+  const currentBlock = await sdk.api.util.getLatestBlock('ethereum');
+  const toBlock = currentBlock.number;
+  const topic =
+    '0xd0e841f234010ad7f57b7c09faffb2245cd240429c6e8fa3cd934a0a8bf58eb0';
+  const logs = (
+    await sdk.api.util.getLogs({
+      target: '0x547213367cfb08ab418e7b54d7883b2c2aa27fd7',
+      topic: '',
+      toBlock,
+      fromBlock: 19881601,
+      keys: [],
+      topics: [topic],
+      chain: 'ethereum',
+    })
+  ).output.sort((a, b) => b.blockNumber - a.blockNumber);
+
+  console.log(logs[0]);
+  // rewards are now beeing streamed every week, which we scale up to a year
+  const rewardsReceived = parseInt(logs[0].topics[1] / 1e18);
+  const aprBase = ((rewardsReceived * 365 / 7) / tvlUsd) * 100;
+  // weekly compoounding
+  const apyBase = utils.aprToApy(aprBase, 52);
+  return [
+    {
+      pool: sUSDz,
+      symbol: 'sUSDz',
+      project: 'anzen-v2',
+      chain: 'Ethereum',
+      tvlUsd,
+      apyBase,
+      poolMeta: '7 days unstaking',
+    },
+  ];
+};
+
+module.exports = {
+  apy,
+  url: 'https://anzen.finance/',
+};


### PR DESCRIPTION
```
npm run test --adapter=anzen-v2

> defillama-apy-adapters@1.0.0 test
> jest

Determining test suites to run...(node:36051) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
{
  address: '0x547213367cfb08ab418e7b54d7883b2c2aa27fd7',
  topics: [
    '0xd0e841f234010ad7f57b7c09faffb2245cd240429c6e8fa3cd934a0a8bf58eb0',
    '0x00000000000000000000000000000000000000000000043c33c1937564800000'
  ],
  data: '0x',
  blockNumber: 20312966,
  transactionHash: '0x817c4969133c7fd8645c66ce595f86bc1ebc8ee86e73b0cdb55bb3f1016b34cd',
  transactionIndex: 76,
  blockHash: '0x95460ba4d64ac855b89a43aa58305f28e30b56667d1929e82db2685246bb74f3',
  logIndex: 243,
  removed: false,
  index: 243
}
 PASS  ./test.js
  Running anzen-v2 Test
    ✓ Check if link to the pool's page exist
    ✓ Check for unique pool ids (1 ms)
    ✓ Check project field is constant in all pools and if folder name and project field in pool objects matches the information in /protocols slug
    Check for allowed field names
      ✓ Expects pool id 0x547213367cfb08ab418e7b54d7883b2c2aa27fd7 to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,symbol,project,chain,tvlUsd,apyBase,poolMeta (1 ms)
    Check apy data types
      ✓ Expects pool with id 0x547213367cfb08ab418e7b54d7883b2c2aa27fd7 to have at least one number apy field
    Check tvl data type
      ✓ tvlUsd field of pool with id 0x547213367cfb08ab418e7b54d7883b2c2aa27fd7 should be number  (1 ms)
    Check other fields data types
      ✓ Expect other fields of pool with id 0x547213367cfb08ab418e7b54d7883b2c2aa27fd7 to match thier data types
    Check if pool has a rewardApy then rewardTokens must also exist
      ✓ The pool 0x547213367cfb08ab418e7b54d7883b2c2aa27fd7 is expected to have a rewardTokens field
    Check if pool id already used by other project
      ✓ Expect duplicate ids array to be empty

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        0.23 s, estimated 1 s
Ran all test suites.

Nb of pools: 1
 

Sample pools: [
  {
    pool: '0x547213367cfb08ab418e7b54d7883b2c2aa27fd7',
    symbol: 'sUSDz',
    project: 'anzen-v2',
    chain: 'Ethereum',
    tvlUsd: 3232691.0060379747,
    apyBase: 37.93338700185984,
    poolMeta: '7 days unstaking'
  }
]
```