### PR TITLE
Orange APR calculation fixes

### DIFF
--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -22,6 +22,7 @@ exports.formatChain = (chain) => {
   )
     return 'zkSync Era';
   if (chain && chain.toLowerCase() === 'polygon_zkevm') return 'Polygon zkEVM';
+  if (chain && chain.toLowerCase() === 'real') return 're.al';
   return chain.charAt(0).toUpperCase() + chain.slice(1);
 };
 


### PR DESCRIPTION
This PR includes the following changes/fixes
- Added all orange v2 vaults
- Added rewards APR for each vault
- Fixed APR calculation for vaults (previously, fee apr was always 0 due to some values being undefined)