### PR TITLE
feat: seamless protocol ilms update

### DIFF
--- a/src/adaptors/seamless-protocol/ilm-registry-abi.json
+++ b/src/adaptors/seamless-protocol/ilm-registry-abi.json
@@ -1,0 +1,118 @@
+[
+  {
+    "type": "function",
+    "name": "addILM",
+    "inputs": [
+      {
+        "name": "ilmAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "countILM",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "ilmCount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAllILMs",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "ilms",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getILM",
+    "inputs": [
+      {
+        "name": "index",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "ilm",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isILM",
+    "inputs": [
+      {
+        "name": "ilmAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isContained",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "removeILM",
+    "inputs": [
+      {
+        "name": "ilmAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "ILMAdded",
+    "inputs": [
+      {
+        "name": "ilm",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ILMRemoved",
+    "inputs": [
+      {
+        "name": "ilm",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  }
+]

--- a/src/adaptors/seamless-protocol/index.js
+++ b/src/adaptors/seamless-protocol/index.js
@@ -261,14 +261,12 @@ const lendingPoolsApy = async () => {
   return pools.flat().filter((p) => utils.keepFinite(p));
 };
 
-const getLpPrices = async (blockNumber, assets, decimals) => {
-  const allILMs = await getAllILMs();
-
+const getLpPrices = async (blockNumber, ilms, assets, decimals) => {
   const equityUSD = (
     await sdk.api.abi.multiCall({
       chain,
       abi: loopStrategyAbi.find(({ name }) => name === 'equityUSD'),
-      calls: allILMs.map((address) => ({ target: address })),
+      calls: ilms.map((address) => ({ target: address })),
       block: blockNumber,
     })
   ).output.map(({ output }) => output);
@@ -277,7 +275,7 @@ const getLpPrices = async (blockNumber, assets, decimals) => {
     await sdk.api.abi.multiCall({
       chain,
       abi: loopStrategyAbi.find(({ name }) => name === 'totalSupply'),
-      calls: allILMs.map((address) => ({ target: address })),
+      calls: ilms.map((address) => ({ target: address })),
       block: blockNumber,
     })
   ).output.map(({ output }) => output);
@@ -348,16 +346,19 @@ const ilmApys = async () => {
 
   const latestBlockPrices = await getLpPrices(
     latestBlock.number,
+    allILMs,
     assets,
     decimals
   );
   const prevBlock1DayPrices = await getLpPrices(
     prevBlock1Day.number,
+    allILMs,
     assets,
     decimals
   );
   const prevBlock7DayPrices = await getLpPrices(
     prevBlock7Day.number,
+    allILMs,
     assets,
     decimals
   );

--- a/src/adaptors/seamless-protocol/index.js
+++ b/src/adaptors/seamless-protocol/index.js
@@ -21,8 +21,6 @@ const chainUrlParam = {
 // https://docs.seamlessprotocol.com/technical/smart-contracts
 const ORACLE_ADDRESS = '0xFDd4e83890BCcd1fbF9b10d71a5cc0a738753b01';
 const ILM_REGISTRY_ADDRESS = '0x36291d2d51a0122b9facbe3c3f989cc6b1f859b3';
-const SEAM_ADDRESS = '0x1C7a460413dD4e964f96D8dFC56E7223cE88CD85';
-const esSEAM_ADDRESS = '0x998e44232BEF4F8B033e5A5175BDC97F2B10d5e5';
 
 const API_URLS = {
   base: sdk.graph.modifyEndpoint(
@@ -111,16 +109,6 @@ const getAllCollateralAssetsForILMs = async () => {
 };
 
 const getPrices = async (addresses) => {
-  const esSeamLowerCase = esSEAM_ADDRESS.toLowerCase();
-  const seamLowerCase = SEAM_ADDRESS.toLowerCase();
-
-  addresses = addresses.map((elem) => {
-    const [chain, address] = elem.split(':');
-    const replacementAddress =
-      address === esSeamLowerCase ? seamLowerCase : address;
-    return `${chain}:${replacementAddress}`;
-  });
-
   const prices = (
     await superagent.get(
       `https://coins.llama.fi/prices/current/${addresses
@@ -128,15 +116,6 @@ const getPrices = async (addresses) => {
         .toLowerCase()}`
     )
   ).body.coins;
-
-  Object.entries(prices).forEach(([key, value]) => {
-    if (key.includes(seamLowerCase)) {
-      prices[key.replace(seamLowerCase, esSeamLowerCase)] = {
-        ...value,
-        symbol: 'esSEAM',
-      };
-    }
-  });
 
   const pricesBySymbol = Object.entries(prices).reduce(
     (acc, [name, price]) => ({


### PR DESCRIPTION
Implemented dynamic fetching of ILM from `ILMRegistry` smart contract. Now all ILMs should be shown into DefiLlama. I added ILMRegistry abi in file called _ilm-registry-abi.json_ in order to follow standard for previously named _loop-strategy-abi.json_. Inside `ilmApys` function we fetch addresses of all ILMs and we send list of ILMs into `getLpPrices` function. I tried to do as less changes as possible in order to make review easier. Logic for calculating base apy and 7 day apy didn't change.

Also inside function `calculateApy` there is incorrect formatting from `bigint` to `number`. It should be on 8 decimals and not on 18. This does not effect end result.

I noticed that esSEAM is not included in calculation on DefiLlama for both ILMs and Lending markets. I fixed that by taking SEAM price. 

We are getting reward token for ILMs from subgraph. Subgraph gives us opportunity to filter but not by asset. I noticed that id of reward element is in this format `reward_token_address:asset:incentives_controller`. I did filtering based on second address which corresponds to address of strategy LP tokens. 