### PR TITLE
Add Super OETH on Base

### DIFF
--- a/src/adaptors/origin-ether/index.js
+++ b/src/adaptors/origin-ether/index.js
@@ -1,8 +1,11 @@
 const { ethers, Contract, BigNumber } = require('ethers');
 const sdk = require('@defillama/sdk');
+const { capitalizeFirstLetter } = require('../utils');
 
-const WETH_TOKEN = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
-const OETH_TOKEN = '0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3';
+const ETHEREUM_WETH_TOKEN = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const ETHEREUM_OETH_TOKEN = '0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3';
+const BASE_WETH_TOKEN = '0x4200000000000000000000000000000000000006';
+const BASE_SUPER_OETH_TOKEN = '0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3';
 
 const utils = require('../utils');
 
@@ -13,43 +16,64 @@ const vaultABI = {
   stateMutability: 'view',
   type: 'function',
 };
-const vaultAddress = '0x39254033945AA2E4809Cc2977E7087BEE48bd7Ab';
+const oethVaultAddress = '0x39254033945AA2E4809Cc2977E7087BEE48bd7Ab';
+const superOETHbVaultAddress = '0x98a0CbeF61bD2D21435f433bE4CD42B56B38CC93';
 
-const poolsFunction = async () => {
-  const apyData = await utils.getData(
-    'https://analytics.ousd.com/api/v2/oeth/apr/trailing'
-  );
-  const totalValueEth = (
-    await sdk.api.abi.call({
-      target: vaultAddress,
-      abi: vaultABI,
-    })
-  ).output;
-
+const fetchPoolData = async ({ chain, vaultAddress, apyUrl, token, symbol, project, underlyingToken }) => {
   const priceData = await utils.getData(
     'https://coins.llama.fi/prices/current/coingecko:ethereum?searchWidth=4h'
   );
   const ethPrice = priceData.coins['coingecko:ethereum'].price;
 
+  const apyData = await utils.getData(apyUrl);
+
+  const totalValueEth = (
+    await sdk.api.abi.call({
+      chain,
+      target: vaultAddress,
+      abi: vaultABI,
+    })
+  ).output;
+
   const tvlUsd = (totalValueEth / 1e18) * ethPrice;
 
-  const oethData = {
-    pool: OETH_TOKEN,
-    chain: 'Ethereum',
-    project: 'origin-ether',
-    symbol: 'OETH',
+  return {
+    pool: token,
+    chain: capitalizeFirstLetter(chain),
+    project,
+    symbol,
     tvlUsd,
     apy: Number(apyData.apy),
-    underlyingTokens: [
-      WETH_TOKEN,
-    ],
+    underlyingTokens: [underlyingToken],
   };
+};
 
-  return [oethData];
+const poolsFunction = async () => {
+  const oethData = await fetchPoolData({
+    chain: 'ethereum',
+    vaultAddress: oethVaultAddress,
+    apyUrl: 'https://analytics.ousd.com/api/v2/oeth/apr/trailing',
+    token: ETHEREUM_OETH_TOKEN,
+    symbol: 'OETH',
+    project: 'origin-ether',
+    underlyingToken: ETHEREUM_WETH_TOKEN,
+  });
+
+  const superOETHbData = await fetchPoolData({
+    chain: 'base',
+    vaultAddress: superOETHbVaultAddress,
+    apyUrl: 'https://api.originprotocol.com/api/v2/superoethb/apr/trailing',
+    token: BASE_SUPER_OETH_TOKEN,
+    symbol: 'superOETHb',
+    project: 'origin-ether',
+    underlyingToken: BASE_WETH_TOKEN,
+  });
+
+  return [oethData, superOETHbData];
 };
 
 module.exports = {
   timetravel: false,
   apy: poolsFunction,
-  url: 'https://originprotocol.com/oeth',
+  url: 'https://originprotocol.com',
 };


### PR DESCRIPTION
Super OETH has recently been launched as the first supercharged LST of its kind. The first deployment is on Base and it offers a materially different APY compared to vanilla OETH on Ethereum. This PR adds a second pool to the Origin Ether adapter and refactors some of the code in the process.