### PR TITLE
update tokemak cr use to be weighted by destination value

### DIFF
--- a/src/adaptors/tokemak/abis/ERC20.js
+++ b/src/adaptors/tokemak/abis/ERC20.js
@@ -1,0 +1,125 @@
+module.exports = {
+  erc20Abi: [
+    {
+      type: 'function',
+      name: 'allowance',
+      inputs: [
+        { name: 'owner', type: 'address', internalType: 'address' },
+        { name: 'spender', type: 'address', internalType: 'address' },
+      ],
+      outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+      stateMutability: 'view',
+    },
+    {
+      type: 'function',
+      name: 'approve',
+      inputs: [
+        { name: 'spender', type: 'address', internalType: 'address' },
+        { name: 'amount', type: 'uint256', internalType: 'uint256' },
+      ],
+      outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+      stateMutability: 'nonpayable',
+    },
+    {
+      type: 'function',
+      name: 'balanceOf',
+      inputs: [{ name: 'account', type: 'address', internalType: 'address' }],
+      outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+      stateMutability: 'view',
+    },
+    {
+      type: 'function',
+      name: 'decimals',
+      inputs: [],
+      outputs: [{ name: '', type: 'uint8', internalType: 'uint8' }],
+      stateMutability: 'view',
+    },
+    {
+      type: 'function',
+      name: 'name',
+      inputs: [],
+      outputs: [{ name: '', type: 'string', internalType: 'string' }],
+      stateMutability: 'view',
+    },
+    {
+      type: 'function',
+      name: 'symbol',
+      inputs: [],
+      outputs: [{ name: '', type: 'string', internalType: 'string' }],
+      stateMutability: 'view',
+    },
+    {
+      type: 'function',
+      name: 'totalSupply',
+      inputs: [],
+      outputs: [{ name: '', type: 'uint256', internalType: 'uint256' }],
+      stateMutability: 'view',
+    },
+    {
+      type: 'function',
+      name: 'transfer',
+      inputs: [
+        { name: 'to', type: 'address', internalType: 'address' },
+        { name: 'amount', type: 'uint256', internalType: 'uint256' },
+      ],
+      outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+      stateMutability: 'nonpayable',
+    },
+    {
+      type: 'function',
+      name: 'transferFrom',
+      inputs: [
+        { name: 'from', type: 'address', internalType: 'address' },
+        { name: 'to', type: 'address', internalType: 'address' },
+        { name: 'amount', type: 'uint256', internalType: 'uint256' },
+      ],
+      outputs: [{ name: '', type: 'bool', internalType: 'bool' }],
+      stateMutability: 'nonpayable',
+    },
+    {
+      type: 'event',
+      name: 'Approval',
+      inputs: [
+        {
+          name: 'owner',
+          type: 'address',
+          indexed: true,
+          internalType: 'address',
+        },
+        {
+          name: 'spender',
+          type: 'address',
+          indexed: true,
+          internalType: 'address',
+        },
+        {
+          name: 'value',
+          type: 'uint256',
+          indexed: false,
+          internalType: 'uint256',
+        },
+      ],
+      anonymous: false,
+    },
+    {
+      type: 'event',
+      name: 'Transfer',
+      inputs: [
+        {
+          name: 'from',
+          type: 'address',
+          indexed: true,
+          internalType: 'address',
+        },
+        { name: 'to', type: 'address', indexed: true, internalType: 'address' },
+        {
+          name: 'value',
+          type: 'uint256',
+          indexed: false,
+          internalType: 'uint256',
+        },
+      ],
+      anonymous: false,
+    },
+  ],
+};

--- a/src/adaptors/tokemak/index.js
+++ b/src/adaptors/tokemak/index.js
@@ -5,6 +5,7 @@ const axios = require('axios');
 
 const { autopoolAbi } = require('./abis/Autopool');
 const { autopoolETHStrategyAbi } = require('./abis/AutopoolETHStrategy');
+const { erc20Abi } = require('./abis/ERC20');
 
 const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 const V2_GEN3_ETH_MAINNET_SUBGRAPH_URL =
@@ -37,6 +38,7 @@ const autopoolsQuery = gql`
         id
         underlyer {
           decimals
+          name
         }
       }
       strategy {
@@ -66,51 +68,166 @@ const getWethPrice = async () => {
 async function main() {
   const autopools = await getAutopools();
 
-  // Get the summary stats for all autopools and destinations
-  const results = await sdk.api.abi.multiCall({
-    abi: autopoolETHStrategyAbi.find(
-      ({ name }) => name === 'getDestinationSummaryStats'
-    ),
-    calls: autopools.flatMap((autopool) => {
-      return autopool.destinationVaults.map((destVault) => {
-        return {
-          target: autopool.strategy.id,
-          params: [
-            destVault.id,
-            1,
-            BigNumber.from(10).pow(destVault.underlyer.decimals).toString(),
-          ],
-        };
-      });
-    }),
-    chain: 'ethereum',
-    permitFailure: false,
-  });
+  const multicalls = [];
 
-  // Determine the max compositeReturn for each Autopool
+  // Get the summary stats for all autopools and destinations
+  multicalls.push(
+    sdk.api.abi.multiCall({
+      abi: autopoolETHStrategyAbi.find(
+        ({ name }) => name === 'getDestinationSummaryStats'
+      ),
+      calls: autopools.flatMap((autopool) => {
+        return autopool.destinationVaults.map((destVault) => {
+          return {
+            target: autopool.strategy.id,
+            params: [
+              destVault.id,
+              1,
+              BigNumber.from(10).pow(destVault.underlyer.decimals).toString(),
+            ],
+          };
+        });
+      }),
+      chain: 'ethereum',
+      permitFailure: false,
+    })
+  );
+
+  // Get the destination info for all Autopools
+  multicalls.push(
+    sdk.api.abi.multiCall({
+      abi: autopoolAbi.find(({ name }) => name === 'getDestinationInfo'),
+      calls: autopools.flatMap((autopool) => {
+        return autopool.destinationVaults.map((destVault) => {
+          return {
+            target: autopool.id,
+            params: [destVault.id],
+          };
+        });
+      }),
+      chain: 'ethereum',
+      permitFailure: false,
+    })
+  );
+
+  // Get the current balance of destination tokens held by the Autopools
+  multicalls.push(
+    sdk.api.abi.multiCall({
+      abi: autopoolAbi.find(({ name }) => name === 'balanceOf'),
+      calls: autopools.flatMap((autopool) => {
+        return autopool.destinationVaults.map((destVault) => {
+          return {
+            target: destVault.id,
+            params: [autopool.id],
+          };
+        });
+      }),
+      chain: 'ethereum',
+      permitFailure: false,
+    })
+  );
+
+  // Get the totalAssets of all Autopools
+  multicalls.push(
+    sdk.api.abi.multiCall({
+      abi: autopoolAbi.find(
+        ({ name, inputs }) => name === 'totalAssets' && inputs.length == 0
+      ),
+      calls: autopools.map((autopool) => {
+        return {
+          target: autopool.id,
+          params: [],
+        };
+      }),
+      chain: 'ethereum',
+      permitFailure: false,
+    })
+  );
+
+  // Get the totalIdle of all Autopools
+  multicalls.push(
+    sdk.api.abi.multiCall({
+      abi: autopoolAbi.find(({ name, inputs }) => name === 'getAssetBreakdown'),
+      calls: autopools.map((autopool) => {
+        return {
+          target: autopool.id,
+          params: [],
+        };
+      }),
+      chain: 'ethereum',
+      permitFailure: false,
+    })
+  );
+
+  const multicallResults = await Promise.all(multicalls);
+
+  const summaryStatResults = multicallResults[0];
+  const destinationInfoResults = multicallResults[1];
+  const balanceOfResults = multicallResults[2];
+  const totalAssetResults = multicallResults[3];
+  const getAssetBreakdownResults = multicallResults[4];
+
+  // Determine the compositeReturn for each Autopool weighted by
+  // the debt value held from that Destination
   let ix = 0;
   const autopoolCRs = {};
   for (let a = 0; a < autopools.length; a++) {
     const autopool = autopools[a];
+    const totalAssets = Number(
+      etherUtils.formatUnits(totalAssetResults.output[a].output, 18)
+    );
+    const totalIdle = Number(
+      etherUtils.formatUnits(
+        getAssetBreakdownResults.output[a].output.totalIdle
+      )
+    );
     const dl = autopool.destinationVaults.length;
-    let maxCompositeReturn = 0;
+    let compositeReturn = 0;
     for (let d = 0; d < dl; d++) {
-      const result = results.output[ix + d];
+      const summaryStatResult = summaryStatResults.output[ix + d];
+      const destinationInfoResult = destinationInfoResults.output[ix + d];
+      const balanceOfResult = balanceOfResults.output[ix + d];
 
-      let cr = Number(
-        etherUtils.formatUnits(result.output.compositeReturn, 18)
+      const ownedShares = BigNumber.from(
+        destinationInfoResult.output.ownedShares
+      );
+      const cachedMinDebtValue = BigNumber.from(
+        destinationInfoResult.output.cachedMinDebtValue
+      );
+      const cachedMaxDebtValue = BigNumber.from(
+        destinationInfoResult.output.cachedMaxDebtValue
+      );
+      const vaultBalOfDest = BigNumber.from(balanceOfResult.output);
+
+      const debtValueHeldByVaultEth = Number(
+        etherUtils.formatUnits(
+          (ownedShares.gt(BigNumber.from(0))
+            ? cachedMinDebtValue
+                .mul(vaultBalOfDest)
+                .div(ownedShares)
+                .add(cachedMaxDebtValue.mul(vaultBalOfDest).div(ownedShares))
+            : BigNumber.from(0)
+          ).div(BigNumber.from(2)),
+          18
+        )
       );
 
-      // Calculate compositeReturn net of estimated fees
-      cr =
-        (cr - Number(etherUtils.formatUnits(autopool.periodicFee, 4))) *
-        (1 - Number(etherUtils.formatUnits(autopool.streamingFee, 4)));
+      const debtValueWeight = debtValueHeldByVaultEth / totalAssets;
 
-      if (cr > maxCompositeReturn) {
-        maxCompositeReturn = cr;
-      }
+      const cr = Number(
+        etherUtils.formatUnits(summaryStatResult.output.compositeReturn, 18)
+      );
+
+      compositeReturn += debtValueWeight * cr;
     }
-    autopoolCRs[autopool.id] = maxCompositeReturn;
+
+    // Calculate compositeReturn net of estimated fees
+    compositeReturn =
+      (compositeReturn / (1 - totalIdle / totalAssets) -
+        Number(etherUtils.formatUnits(autopool.periodicFee, 4))) *
+      (1 - Number(etherUtils.formatUnits(autopool.streamingFee, 4)));
+
+    autopoolCRs[autopool.id] = compositeReturn;
 
     ix += dl;
   }


### PR DESCRIPTION
When calculating the apyBase for an Autopilot pool, we are currently using the highest CRM of pools we're deployed to. This update is to weight that value based on the value deployed to pool. 