### PR TITLE
Add alien-base-v3 yields on defillama

### DIFF
--- a/src/adaptors/alien-base-v3/albReward.js
+++ b/src/adaptors/alien-base-v3/albReward.js
@@ -1,0 +1,302 @@
+const abiMcV3 = require('./masterchefv3.json');
+const { getBunniVaultsForPool, getPricePerFullShare, getProtocolFee, getPoolData, getTokensForPool, getTotalSupply, getReservesForBunniVault } = require('./calls');
+
+const utils = require('../utils');
+const sdk = require('@defillama/sdk');
+const bn = require('bignumber.js');
+const fetch = require('node-fetch');
+const { fetchPoolAvgInfo, fetchPoolsFromSubgraph, fetchTokenPricesFromSubgraph } = require('./subgraphCalls');
+
+const ALB = {
+  base: '0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4',
+};
+
+const chainIds = {
+  base: {
+    id: 8453,
+    mchef: '0x52eaeCAC2402633d98b95213d0b473E069D86590',
+    abi: abiMcV3,
+  },
+};
+
+const getFarmApyReward = (pid, tvlUsd, chain, prices, subgraphPrices, rewards) => {
+  const { addresses, symbols, decimals, rewardsPerSec } = rewards;
+
+  let apyReward = 0;
+  const SECONDS_IN_YEAR = 31536000;
+
+  for (let i = 0; i < addresses.length; i++) {
+    const tokenAddress = addresses[i];
+    const rewardPerSec = rewardsPerSec[i];
+    const tokenDecimals = decimals[i];
+
+    const tokenPrice = prices[`${chain}:${tokenAddress.toLowerCase()}`]?.price || subgraphPrices[tokenAddress.toLowerCase()]?.derivedUSD || 0;
+
+    const yearlyRewardUsd = (rewardPerSec / Math.pow(10, tokenDecimals)) * SECONDS_IN_YEAR * tokenPrice;
+
+    apyReward += (yearlyRewardUsd / tvlUsd) * 100;
+  }
+
+  return { apyReward, rewardTokens: addresses };
+};
+
+const calculateApyBase = (avgVolume, liquidity, totalSupply, poolLiquidity, fee, protocolFee, totalUsd) => {
+  // console.log('We are calculating APY with the following parameters: ', {
+  //   avgVolume,
+  //   liquidity,
+  //   totalSupply,
+  //   poolLiquidity,
+  //   fee,
+  //   protocolFee,
+  // });
+  const liqRatio = (liquidity * totalSupply) / poolLiquidity / 1e18;
+  return (
+    ((avgVolume *
+      365 *
+      (Number(fee) / 1e6) *
+      liqRatio *
+      (1 - protocolFee)) /
+      totalUsd) *
+    100
+  );
+};
+
+const processPoolInfos = async (poolInfos) => {
+  const pools = await fetchPoolsFromSubgraph();
+  const {protocolFee, newProtocolFee} = await getProtocolFee();
+
+  const allTokens = [
+    ...new Set(pools.map((p) => [p.token0, p.token1]).flat()),
+  ];
+
+  const { albPrice, prices } = await getBaseTokensPrice(allTokens, 'base');
+  const subgraphPrices = await fetchTokenPricesFromSubgraph();
+
+  const results = [];
+
+  for (const pool of pools) {
+    const bunniVaults = await getBunniVaultsForPool(pool.id);
+    const avgInfo = await fetchPoolAvgInfo(pool.id);
+
+    for (const bunniVault of bunniVaults) {
+      const tokens = await getTokensForPool(bunniVault.poolAddress, 'base');
+      if (!tokens) {
+        console.log(`Could not find tokens for pool ${bunniVault.poolAddress}`);
+        continue;
+      };
+
+      const matchingPoolInfo = poolInfos.find((info) => info.lpToken === bunniVault.bunniToken);
+      
+      const poolData = await getPoolData(bunniVault.poolAddress, 'base');
+      if (!poolData) {
+        console.log(`Could not find pool data for pool ${bunniVault.poolAddress}`);
+        continue
+      }
+
+      const { slot0, fee, liquidity } = poolData;
+
+      const pricePerShare = await getPricePerFullShare(bunniVault);
+      if (!pricePerShare) {
+        console.log(`Could not find price per share for pool ${bunniVault.poolAddress}`);
+        continue;
+      }
+
+      const totalSupply = await getTotalSupply(bunniVault.bunniToken, 'base');
+      const reserves = await getReservesForBunniVault(bunniVault, tokens.token0.decimals, tokens.token1.decimals);
+
+      const currentTick = slot0.tick;
+      const isInRange = (Number(currentTick) >= Number(bunniVault.tickLower)) && (Number(currentTick) <= Number(bunniVault.tickUpper));
+
+      const token0Price = prices[`base:${tokens.token0.address?.toLowerCase()}`]?.price || subgraphPrices[tokens.token0.address?.toLowerCase()]?.derivedUSD || 0;
+      const token1Price = prices[`base:${tokens.token1.address?.toLowerCase()}`]?.price || subgraphPrices[tokens.token1.address?.toLowerCase()]?.derivedUSD || 0;
+
+      const token0USDValue = reserves.reserve0 * token0Price;
+      const token1USDValue = reserves.reserve1 * token1Price;
+      const totalUSDValue = token0USDValue + token1USDValue;
+
+      const apyBase = isInRange
+        ? calculateApyBase(
+            avgInfo.volumeUSD,
+            Number(pricePerShare.liquidity),
+            Number(totalSupply),
+            Number(liquidity),
+            Number(fee),
+            protocolFee,
+            totalUSDValue
+          )
+        : 0;
+
+      let extraApy = 0;
+
+      if (matchingPoolInfo && matchingPoolInfo?.rewards) {
+        const { apyReward, rewardTokens } = getFarmApyReward(
+          matchingPoolInfo.pid,
+          totalUSDValue,
+          'base',
+          prices,
+          subgraphPrices,
+          matchingPoolInfo.rewards
+        );
+        extraApy = apyReward;
+      }
+      const tickRange = Number(bunniVault.tickUpper) - Number(bunniVault.tickLower);
+      let poolMeta = '';
+      if (
+        Math.abs(Number(bunniVault.tickLower) + 887272) <= 1000 &&
+        Math.abs(Number(bunniVault.tickUpper) - 887272) <= 1000
+      ) {
+        poolMeta = 'Infinite';
+      } else if (tickRange > 10000) {
+        poolMeta = 'Wide';
+      } else if ((tickRange >= 3000 && tickRange <= 10000)) {
+        poolMeta = 'Narrow';
+      } else if (tickRange < 3000) {
+        poolMeta = 'Ultra Narrow';
+      }
+
+      if (totalUSDValue > 0) results.push({
+        pool: bunniVault.poolAddress,
+        bunniToken: bunniVault.bunniToken,
+        chain: 'base',
+        symbol: prices[`base:${tokens.token0.address?.toLowerCase()}`]?.symbol + '-' + prices[`base:${tokens.token1.address?.toLowerCase()}`]?.symbol,
+        project: 'alien-base-v3',
+        apyBase,
+        apyReward: extraApy,
+        rewardTokens: matchingPoolInfo?.rewards?.addresses || [],
+        underlyingTokens: [tokens.token0.address, tokens.token1.address],
+        url: `https://app.alienbase.xyz/add/${tokens.token0.address}/${tokens.token1.address}`,
+        tvlUsd: totalUSDValue,
+        poolMeta,
+      });
+      // console.log(`For the bunni token ${bunniVault.bunniToken}, APY: ${apyBase.toFixed(2)}%`);
+      // if (matchingPoolInfo?.rewards) {
+      //   console.log(`For the bunni token ${bunniVault.bunniToken}, EXTRA APY Reward: ${extraApy?.toFixed(2)}%`);
+      // }
+    }
+  }
+
+  return results;
+};
+
+
+const getAlbAprs = async (chain) => {
+  if (chainIds[chain] === undefined) return [];
+
+  const masterChef = chainIds[chain].mchef;
+  const abi = chainIds[chain].abi;
+
+  const poolLength = await sdk.api.abi
+    .call({
+      abi: abi.find((m) => m.name === 'poolLength'),
+      target: masterChef,
+      chain,
+    })
+    .then((o) => o.output);
+  const totalAllocPoint = await sdk.api.abi
+    .call({
+      abi: abi.find((m) => m.name === 'totalAllocPoint'),
+      target: masterChef,
+      chain,
+    })
+    .then((o) => o.output);
+  const latestPeriodAlbPerSecond = await sdk.api.abi
+    .call({
+      abi: abi.find((m) => m.name === 'albPerSec'),
+      target: masterChef,
+      chain,
+    })
+    .then((o) => o.output);
+
+  const albPerSecond = new bn(latestPeriodAlbPerSecond.toString())
+    .div(1e18)
+    // .div(1e12)
+    .toString();
+
+    const poolInfoCalls = Array.from({ length: +poolLength })
+    .map((_, i) => i)
+    .filter((i) => i !== 0)
+    .map((i) => {
+      return {
+        target: masterChef,
+        params: i,
+      };
+    });
+  
+  const poolInfos = await sdk.api.abi
+    .multiCall({
+      abi: abi.find((m) => m.name === 'poolInfo'),
+      calls: poolInfoCalls,
+      chain,
+    })
+    .then((o) =>
+      o.output
+        .map((r, index) => ({
+          ...r.output,
+          pid: index + 1,
+        }))
+        .filter((r) => r.allocPoint !== '0' && r.totalLiquidity !== '0')
+    );
+  
+  const validPIDs = poolInfos.map((info) => info.pid);
+  
+  const poolRewardsCalls = validPIDs.map((pid) => ({
+    target: masterChef,
+    params: pid,
+  }));
+  
+  const poolRewards = await sdk.api.abi.multiCall({
+    abi: abi.find((m) => m.name === 'poolRewardsPerSec'),
+    calls: poolRewardsCalls,
+    chain,
+  });
+  
+  const mergedPools = poolInfos.map((info, index) => {
+    const rewards = poolRewards.output[index].output;
+  
+    return {
+      ...info,
+      rewards: {
+        addresses: rewards.addresses,
+        symbols: rewards.symbols,
+        decimals: rewards.decimals,
+        rewardsPerSec: rewards.rewardsPerSec,
+      },
+    };
+  });
+  
+  const processedInfo = await processPoolInfos(mergedPools);
+
+  return processedInfo;
+};
+
+const getBaseTokensPrice = async (allTokens, chain) => {
+  let priceKeys = {
+    alb: '0x1dd2d631c92b1acdfcdd51a0f7145a50130050c4',
+  };
+
+  let prices = (
+    await utils.getData(
+      `https://coins.llama.fi/prices/current/${Object.values(priceKeys)
+        .map((t) => `base:${t}`)
+        .concat(allTokens.map((t) => `${chain}:${t.id}`))
+        .join(',')}`
+    )
+  ).coins;
+
+  const albriceData = prices[`base:${priceKeys.alb}`];
+
+  const albId = `${chain}:${ALB[chain]}`;
+
+  if (ALB[chain] && !prices[albId]) {
+    prices[albId] = albriceData;
+  }
+
+  return { albPrice: albriceData.price, prices };
+};
+
+module.exports = {
+  getAlbAprs,
+  ALB,
+  chainIds,
+  getBaseTokensPrice,
+};

--- a/src/adaptors/alien-base-v3/bunniHub.json
+++ b/src/adaptors/alien-base-v3/bunniHub.json
@@ -1,0 +1,907 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IUniswapV3Factory",
+        "name": "factory_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner_",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "protocolFee_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "T",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "bunniKeyHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "liquidity",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Compound",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "bunniKeyHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "liquidity",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0Pool",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1Pool",
+        "type": "uint256"
+      }
+    ],
+    "name": "CompoundSkim",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "bunniKeyHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "liquidity",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IBunniToken",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "bunniKeyHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IUniswapV3Pool",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "indexed": false,
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      }
+    ],
+    "name": "NewBunni",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "PayProtocolFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newProtocolFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetProtocolFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "bunniKeyHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "liquidity",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IUniswapV3Pool",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "int24",
+            "name": "tickLower",
+            "type": "int24"
+          },
+          {
+            "internalType": "int24",
+            "name": "tickUpper",
+            "type": "int24"
+          }
+        ],
+        "internalType": "struct BunniKey",
+        "name": "key",
+        "type": "tuple"
+      }
+    ],
+    "name": "compound",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "addedLiquidity",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IUniswapV3Pool",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "int24",
+            "name": "tickLower",
+            "type": "int24"
+          },
+          {
+            "internalType": "int24",
+            "name": "tickUpper",
+            "type": "int24"
+          }
+        ],
+        "internalType": "struct BunniKey",
+        "name": "key",
+        "type": "tuple"
+      }
+    ],
+    "name": "compoundSkim",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "addedLiquidity",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IUniswapV3Pool",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "int24",
+            "name": "tickLower",
+            "type": "int24"
+          },
+          {
+            "internalType": "int24",
+            "name": "tickUpper",
+            "type": "int24"
+          }
+        ],
+        "internalType": "struct BunniKey",
+        "name": "key",
+        "type": "tuple"
+      }
+    ],
+    "name": "deployBunniToken",
+    "outputs": [
+      {
+        "internalType": "contract IBunniToken",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "contract IUniswapV3Pool",
+                "name": "pool",
+                "type": "address"
+              },
+              {
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24"
+              },
+              {
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24"
+              }
+            ],
+            "internalType": "struct BunniKey",
+            "name": "key",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount0Desired",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount1Desired",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount0Min",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount1Min",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct IBunniHub.DepositParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint128",
+        "name": "addedLiquidity",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "contract IUniswapV3Factory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IUniswapV3Pool",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "int24",
+            "name": "tickLower",
+            "type": "int24"
+          },
+          {
+            "internalType": "int24",
+            "name": "tickUpper",
+            "type": "int24"
+          }
+        ],
+        "internalType": "struct BunniKey",
+        "name": "key",
+        "type": "tuple"
+      }
+    ],
+    "name": "getBunniToken",
+    "outputs": [
+      {
+        "internalType": "contract IBunniToken",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "multicall",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "results",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "selfPermit",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expiry",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "selfPermitAllowed",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expiry",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "selfPermitAllowedIfNecessary",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "selfPermitIfNecessary",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "setProtocolFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20[]",
+        "name": "tokenList",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "sweepTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0Owed",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1Owed",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "uniswapV3MintCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "contract IUniswapV3Pool",
+                "name": "pool",
+                "type": "address"
+              },
+              {
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24"
+              },
+              {
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24"
+              }
+            ],
+            "internalType": "struct BunniKey",
+            "name": "key",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "shares",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount0Min",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount1Min",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "deadline",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IBunniHub.WithdrawParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "removedLiquidity",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/adaptors/alien-base-v3/bunniLens.json
+++ b/src/adaptors/alien-base-v3/bunniLens.json
@@ -1,0 +1,288 @@
+[
+    {
+      "inputs": [
+            { "internalType": "contract IBunniHub", "name": "hub_", "type": "address"
+            }
+        ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    { "inputs": [], "name": "T", "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+            {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+            },
+            {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+            }
+        ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "inputs": [
+            {
+          "components": [
+                    {
+              "internalType": "contract IUniswapV3Pool",
+              "name": "pool",
+              "type": "address"
+                    },
+                    { "internalType": "int24", "name": "tickLower", "type": "int24"
+                    },
+                    { "internalType": "int24", "name": "tickUpper", "type": "int24"
+                    }
+                ],
+          "internalType": "struct BunniKey",
+          "name": "key",
+          "type": "tuple"
+            },
+            { "internalType": "address", "name": "pair", "type": "address"
+            },
+            { "internalType": "address", "name": "token", "type": "address"
+            }
+        ],
+      "name": "addKey",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+            { "internalType": "address", "name": "token", "type": "address"
+            }
+        ],
+      "name": "getBunniKeyForToken",
+      "outputs": [
+            {
+          "components": [
+                    {
+              "internalType": "contract IUniswapV3Pool",
+              "name": "pool",
+              "type": "address"
+                    },
+                    { "internalType": "int24", "name": "tickLower", "type": "int24"
+                    },
+                    { "internalType": "int24", "name": "tickUpper", "type": "int24"
+                    }
+                ],
+          "internalType": "struct BunniKey",
+          "name": "key",
+          "type": "tuple"
+            }
+        ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+            { "internalType": "address", "name": "pool", "type": "address"
+            },
+            { "internalType": "uint256", "name": "index", "type": "uint256"
+            }
+        ],
+      "name": "getBunniVault",
+      "outputs": [
+            {
+          "components": [
+                    {
+              "internalType": "contract IUniswapV3Pool",
+              "name": "pool",
+              "type": "address"
+                    },
+                    { "internalType": "int24", "name": "tickLower", "type": "int24"
+                    },
+                    { "internalType": "int24", "name": "tickUpper", "type": "int24"
+                    }
+                ],
+          "internalType": "struct BunniKey",
+          "name": "key",
+          "type": "tuple"
+            },
+            { "internalType": "contract IBunniToken", "name": "token", "type": "address"
+            }
+        ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+            { "internalType": "address", "name": "pool", "type": "address"
+            }
+        ],
+      "name": "getBunniVaults",
+      "outputs": [
+            {
+          "components": [
+                    {
+              "internalType": "contract IUniswapV3Pool",
+              "name": "pool",
+              "type": "address"
+                    },
+                    { "internalType": "int24", "name": "tickLower", "type": "int24"
+                    },
+                    { "internalType": "int24", "name": "tickUpper", "type": "int24"
+                    }
+                ],
+          "internalType": "struct BunniKey[]",
+          "name": "keys",
+          "type": "tuple[]"
+            },
+            {
+          "internalType": "contract IBunniToken[]",
+          "name": "tokens",
+          "type": "address[]"
+            }
+        ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+            {
+          "components": [
+                    {
+              "internalType": "contract IUniswapV3Pool",
+              "name": "pool",
+              "type": "address"
+                    },
+                    { "internalType": "int24", "name": "tickLower", "type": "int24"
+                    },
+                    { "internalType": "int24", "name": "tickUpper", "type": "int24"
+                    }
+                ],
+          "internalType": "struct BunniKey",
+          "name": "key",
+          "type": "tuple"
+            }
+        ],
+      "name": "getReserves",
+      "outputs": [
+            { "internalType": "uint112", "name": "reserve0", "type": "uint112"
+            },
+            { "internalType": "uint112", "name": "reserve1", "type": "uint112"
+            }
+        ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+            {
+          "components": [
+                    {
+              "internalType": "contract IUniswapV3Pool",
+              "name": "pool",
+              "type": "address"
+                    },
+                    { "internalType": "int24", "name": "tickLower", "type": "int24"
+                    },
+                    { "internalType": "int24", "name": "tickUpper", "type": "int24"
+                    }
+                ],
+          "internalType": "struct BunniKey",
+          "name": "key",
+          "type": "tuple"
+            }
+        ],
+      "name": "getTokenForBunniKey",
+      "outputs": [
+            { "internalType": "address", "name": "token", "type": "address"
+            }
+        ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "hub",
+      "outputs": [
+            { "internalType": "contract IBunniHub", "name": "", "type": "address"
+            }
+        ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+            { "internalType": "address", "name": "", "type": "address"
+            }
+        ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+            {
+          "components": [
+                    {
+              "internalType": "contract IUniswapV3Pool",
+              "name": "pool",
+              "type": "address"
+                    },
+                    { "internalType": "int24", "name": "tickLower", "type": "int24"
+                    },
+                    { "internalType": "int24", "name": "tickUpper", "type": "int24"
+                    }
+                ],
+          "internalType": "struct BunniKey",
+          "name": "key",
+          "type": "tuple"
+            }
+        ],
+      "name": "pricePerFullShare",
+      "outputs": [
+            { "internalType": "uint128", "name": "liquidity", "type": "uint128"
+            },
+            { "internalType": "uint256", "name": "amount0", "type": "uint256"
+            },
+            { "internalType": "uint256", "name": "amount1", "type": "uint256"
+            }
+        ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+            { "internalType": "uint256", "name": "index", "type": "uint256"
+            },
+            { "internalType": "address", "name": "pair", "type": "address"
+            },
+            { "internalType": "address", "name": "token", "type": "address"
+            }
+        ],
+      "name": "removeKey",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+            { "internalType": "address", "name": "newOwner", "type": "address"
+            }
+        ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+]
+  

--- a/src/adaptors/alien-base-v3/calls.js
+++ b/src/adaptors/alien-base-v3/calls.js
@@ -1,0 +1,254 @@
+const sdk = require('@defillama/sdk');
+const bn = require('bignumber.js');
+const fetch = require('node-fetch');
+
+const bunniLensAbi = require('./bunniLens.json');
+const v3PoolAbi = require('./v3PoolAbi.json');
+const bunniHubAbi = require('./bunniHub.json');
+const abiMcV3 = require('./masterchefv3.json');
+
+const bunniLens = '0x3ceb26bb6ad94f2dfdd98f10cb4d6caf02bec9dc';
+const newBunniLens = '0xf71e5E59f762B1D13e3797D24Bf0C8986A05b621';
+const bunniHub = '0xdc53487e2a6ef468260bc938f645f84caaccac6f';
+const newBunniHub = '0xd1Fac4F51457E4a6D35BdC7311718e5D6de92BB9';
+
+const tokenCache = {};
+
+const getTokenDecimals = async (tokenAddress, chain) => {
+  if (tokenCache[tokenAddress]) {
+    return tokenCache[tokenAddress].decimals;
+  }
+
+  const erc20Abi = [
+    {
+      constant: true,
+      inputs: [],
+      name: 'decimals',
+      outputs: [{ name: '', type: 'uint8' }],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function',
+    },
+  ];
+
+  try {
+    const decimals = await sdk.api.abi.call({
+      abi: erc20Abi.find((m) => m.name === 'decimals'),
+      target: tokenAddress,
+      chain,
+    });
+
+    tokenCache[tokenAddress] = { decimals: decimals.output };
+
+    return decimals.output;
+  } catch (err) {
+    console.log(`Error fetching decimals for token ${tokenAddress}:`, err);
+    return 18;
+  }
+};
+
+const getTokensForPool = async (poolAddress, chain) => {
+  try {
+    const [token0Address, token1Address] = await Promise.all([
+      sdk.api.abi.call({
+        abi: v3PoolAbi.find((m) => m.name === 'token0'),
+        target: poolAddress,
+        chain,
+      }),
+      sdk.api.abi.call({
+        abi: v3PoolAbi.find((m) => m.name === 'token1'),
+        target: poolAddress,
+        chain,
+      }),
+    ]);
+
+    const [token0Decimals, token1Decimals] = await Promise.all([
+      getTokenDecimals(token0Address.output, chain),
+      getTokenDecimals(token1Address.output, chain),
+    ]);
+
+    return {
+      token0: { address: token0Address.output, decimals: token0Decimals },
+      token1: { address: token1Address.output, decimals: token1Decimals },
+    };
+  } catch (err) {
+    console.log(`Error fetching tokens for pool ${poolAddress}:`, err);
+    return null;
+  }
+};
+
+const getBunniVaultsForPool = async (poolAddress) => {
+  const getBunniVaults = async (poolAddress) => {
+    return sdk.api.abi.call({
+      abi: bunniLensAbi.find((m) => m.name === 'getBunniVaults'),
+      target: bunniLens,
+      params: [poolAddress],
+      chain: 'base',
+    });
+  };
+
+  const getNewBunniVaults = async (poolAddress) => {
+    return sdk.api.abi.call({
+      abi: bunniLensAbi.find((m) => m.name === 'getBunniVaults'),
+      target: newBunniLens,
+      params: [poolAddress],
+      chain: 'base',
+    });
+  };
+
+  try {
+    const result = await getBunniVaults(poolAddress);
+    const newResult = await getNewBunniVaults(poolAddress);
+
+    return [
+      ...result.output.keys.map((vault, i) => ({
+        poolAddress,
+        bunniToken: result.output.tokens[i],
+        tickLower: vault[1],
+        tickUpper: vault[2],
+        isNew: false,
+      })),
+      ...newResult.output.keys.map((vault, i) => ({
+        poolAddress,
+        bunniToken: newResult.output.tokens[i],
+        tickLower: vault[1],
+        tickUpper: vault[2],
+        isNew: true,
+      })),
+    ];
+  } catch (err) {
+    console.log(`Error fetching bunniVaults for pool ${poolAddress}:`, err);
+    return [];
+  }
+};
+
+const getPricePerFullShare = async (bunniVault) => {
+  try {
+    const result = await sdk.api.abi.call({
+      abi: bunniLensAbi.find((m) => m.name === 'pricePerFullShare'),
+      target: bunniVault?.isNew ? newBunniLens : bunniLens,
+      params: [
+        {
+          pool: bunniVault.poolAddress,
+          tickLower: bunniVault.tickLower,
+          tickUpper: bunniVault.tickUpper,
+        },
+      ],
+      chain: 'base',
+    });
+
+    const liquidity = result.output.liquidity;
+    const amount0 = result.output.amount0;
+    const amount1 = result.output.amount1;
+
+    return { liquidity, amount0, amount1 };
+  } catch (err) {
+    console.log(`Error fetching price per full share for bunniVault ${bunniVault.poolAddress}:`, err);
+    return null;
+  }
+};
+
+const getProtocolFee = async () => {
+  try {
+    const protocolFee = await sdk.api.abi.call({
+      abi: bunniHubAbi.find((m) => m.name === 'protocolFee'),
+      target: bunniHub,
+      chain: 'base',
+    });
+    const newPprotocolFee = await sdk.api.abi.call({
+      abi: bunniHubAbi.find((m) => m.name === 'protocolFee'),
+      target: newBunniHub,
+      chain: 'base',
+    });
+    return { protocolFee: protocolFee.output / 1e18, newProtocolFee: newPprotocolFee.output / 1e18 };
+  } catch (err) {
+    console.log('Error fetching protocol fee:', err);
+    return 0;
+  }
+};
+
+const getPoolData = async (poolAddress, chain) => {
+  try {
+    const slot0Call = sdk.api.abi.call({
+      target: poolAddress,
+      abi: v3PoolAbi.find((m) => m.name === 'slot0'),
+      chain,
+    });
+
+    const feeCall = sdk.api.abi.call({
+      target: poolAddress,
+      abi: v3PoolAbi.find((m) => m.name === 'fee'),
+      chain,
+    });
+
+    const liquidityCall = sdk.api.abi.call({
+      target: poolAddress,
+      abi: v3PoolAbi.find((m) => m.name === 'liquidity'),
+      chain,
+    });
+
+    const [slot0Result, feeResult, liquidityResult] = await Promise.all([slot0Call, feeCall, liquidityCall]);
+
+    const slot0 = slot0Result?.output || null;
+    const fee = feeResult?.output || null;
+    const liquidity = liquidityResult?.output || null;
+
+    return {
+      slot0,
+      fee,
+      liquidity,
+    };
+  } catch (err) {
+    console.log(`Error fetching pool data for ${poolAddress}:`, err);
+    return null;
+  }
+};
+
+const getTotalSupply = async (bunniToken, chain) => {
+  try {
+    const totalSupply = await sdk.api.abi.call({
+      abi: 'erc20:totalSupply',
+      target: bunniToken,
+      chain,
+    });
+
+    return totalSupply.output;
+  } catch (err) {
+    console.log(`Error fetching total supply for bunniToken ${bunniToken}:`, err);
+    return 0;
+  }
+};
+
+const getReservesForBunniVault = async (bunniVault, token0Decimals, token1Decimals) => {
+
+    const getReserves = async (pool, tickLower, tickUpper) => {
+      return sdk.api.abi.call({
+        abi: bunniLensAbi.find((m) => m.name === 'getReserves'),
+        target: bunniVault?.isNew ? newBunniLens : bunniLens,
+        params: [{ pool, tickLower, tickUpper }],
+        chain: 'base'
+      });
+    };
+  
+    try {
+      const result = await getReserves(bunniVault.poolAddress, bunniVault.tickLower, bunniVault.tickUpper);
+      const reserve0 = result.output.reserve0 / Math.pow(10, token0Decimals);
+      const reserve1 = result.output.reserve1 / Math.pow(10, token1Decimals);
+      
+      return { reserve0, reserve1 };
+    } catch (err) {
+      console.log(`Error fetching reserves for bunniVault ${bunniVault.poolAddress}`, err);
+      return null;
+    }
+  };
+
+module.exports = {
+  getTokenDecimals,
+  getTokensForPool,
+  getBunniVaultsForPool,
+  getPricePerFullShare,
+  getReservesForBunniVault,
+  getProtocolFee,
+  getPoolData,
+  getTotalSupply,
+};

--- a/src/adaptors/alien-base-v3/estimateFee.ts
+++ b/src/adaptors/alien-base-v3/estimateFee.ts
@@ -1,0 +1,250 @@
+// forked from see https://github.com/chunza2542/uniswap.fish
+// @ts-nocheck
+const bn = require('bignumber.js');
+
+interface Tick {
+  tickIdx: string;
+  liquidityNet: string;
+  price0: string;
+  price1: string;
+}
+
+bn.config({ EXPONENTIAL_AT: 999999, DECIMAL_PLACES: 40 });
+
+const Q96 = new bn(2).pow(96);
+
+const getTickFromPrice = (
+  price: number,
+  token0Decimal: string,
+  token1Decimal: string
+): number => {
+  const token0 = expandDecimals(price, Number(token0Decimal));
+  const token1 = expandDecimals(1, Number(token1Decimal));
+  const sqrtPrice = encodeSqrtPriceX96(token1).div(encodeSqrtPriceX96(token0));
+
+  return Math.log(sqrtPrice.toNumber()) / Math.log(Math.sqrt(1.0001));
+};
+
+// for calculation detail, please visit README.md (Section: Calculation Breakdown, No. 1)
+interface TokensAmount {
+  amount0: number;
+  amount1: number;
+}
+const getTokensAmountFromDepositAmountUSD = (
+  P: number,
+  Pl: number,
+  Pu: number,
+  priceUSDX: number,
+  priceUSDY: number,
+  depositAmountUSD: number
+): TokensAmount => {
+  const deltaL =
+    depositAmountUSD /
+    ((Math.sqrt(P) - Math.sqrt(Pl)) * priceUSDY +
+      (1 / Math.sqrt(P) - 1 / Math.sqrt(Pu)) * priceUSDX);
+
+  let deltaY = deltaL * (Math.sqrt(P) - Math.sqrt(Pl));
+  if (deltaY * priceUSDY < 0) deltaY = 0;
+  if (deltaY * priceUSDY > depositAmountUSD)
+    deltaY = depositAmountUSD / priceUSDY;
+
+  let deltaX = deltaL * (1 / Math.sqrt(P) - 1 / Math.sqrt(Pu));
+  if (deltaX * priceUSDX < 0) deltaX = 0;
+  if (deltaX * priceUSDX > depositAmountUSD)
+    deltaX = depositAmountUSD / priceUSDX;
+
+  return { amount0: deltaX, amount1: deltaY };
+};
+
+// for calculation detail, please visit README.md (Section: Calculation Breakdown, No. 2)
+const getLiquidityForAmount0 = (
+  sqrtRatioAX96: bn,
+  sqrtRatioBX96: bn,
+  amount0: bn
+): bn => {
+  // amount0 * (sqrt(upper) * sqrt(lower)) / (sqrt(upper) - sqrt(lower))
+  const intermediate = mulDiv(sqrtRatioBX96, sqrtRatioAX96, Q96);
+  return mulDiv(amount0, intermediate, sqrtRatioBX96.minus(sqrtRatioAX96));
+};
+
+const getLiquidityForAmount1 = (
+  sqrtRatioAX96: bn,
+  sqrtRatioBX96: bn,
+  amount1: bn
+): bn => {
+  // amount1 / (sqrt(upper) - sqrt(lower))
+  return mulDiv(amount1, Q96, sqrtRatioBX96.minus(sqrtRatioAX96));
+};
+
+const getSqrtPriceX96 = (
+  price: number,
+  token0Decimal: number,
+  token1Decimal: number
+): bn => {
+  const token0 = expandDecimals(price, token0Decimal);
+  const token1 = expandDecimals(1, token1Decimal);
+
+  return token0.div(token1).sqrt().multipliedBy(Q96);
+};
+
+const getLiquidityDelta = (
+  P: number,
+  lowerP: number,
+  upperP: number,
+  amount0: number,
+  amount1: number,
+  token0Decimal: number,
+  token1Decimal: number
+): bn => {
+  const amt0 = expandDecimals(amount0, token1Decimal);
+  const amt1 = expandDecimals(amount1, token0Decimal);
+
+  const sqrtRatioX96 = getSqrtPriceX96(P, token0Decimal, token1Decimal);
+  const sqrtRatioAX96 = getSqrtPriceX96(lowerP, token0Decimal, token1Decimal);
+  const sqrtRatioBX96 = getSqrtPriceX96(upperP, token0Decimal, token1Decimal);
+
+  let liquidity: bn;
+  if (sqrtRatioX96.lte(sqrtRatioAX96)) {
+    liquidity = getLiquidityForAmount0(sqrtRatioAX96, sqrtRatioBX96, amt0);
+  } else if (sqrtRatioX96.lt(sqrtRatioBX96)) {
+    const liquidity0 = getLiquidityForAmount0(
+      sqrtRatioX96,
+      sqrtRatioBX96,
+      amt0
+    );
+    const liquidity1 = getLiquidityForAmount1(
+      sqrtRatioAX96,
+      sqrtRatioX96,
+      amt1
+    );
+
+    liquidity = bn.min(liquidity0, liquidity1);
+  } else {
+    liquidity = getLiquidityForAmount1(sqrtRatioAX96, sqrtRatioBX96, amt1);
+  }
+
+  return liquidity;
+};
+
+const estimateFee = (
+  liquidityDelta: bn,
+  liquidity: bn,
+  volume24H: number,
+  feeTier: string
+): number => {
+  const feeTierPercentage = getFeeTierPercentage(feeTier);
+  const liquidityPercentage = liquidityDelta
+    .div(liquidity.plus(liquidityDelta))
+    .toNumber();
+
+  return feeTierPercentage * volume24H * liquidityPercentage;
+};
+
+const getLiquidityFromTick = (poolTicks: Tick[], tick: number): bn => {
+  // calculate a cumulative of liquidityNet from all ticks that poolTicks[i] <= tick
+  let liquidity: bn = new bn(0);
+  for (let i = 0; i < poolTicks.length - 1; ++i) {
+    liquidity = liquidity.plus(new bn(poolTicks[i].liquidityNet));
+
+    const lowerTick = Number(poolTicks[i].tickIdx);
+    const upperTick = Number(poolTicks[i + 1]?.tickIdx);
+
+    if (lowerTick <= tick && tick <= upperTick) {
+      break;
+    }
+  }
+
+  return liquidity;
+};
+
+// private helper functions
+const encodeSqrtPriceX96 = (price: number | string | bn): bn => {
+  return new bn(price).sqrt().multipliedBy(Q96).integerValue(3);
+};
+
+const expandDecimals = (n: number | string | bn, exp: number): bn => {
+  return new bn(n).multipliedBy(new bn(10).pow(exp));
+};
+
+const mulDiv = (a: bn, b: bn, multiplier: bn) => {
+  return a.multipliedBy(b).div(multiplier);
+};
+
+const getFeeTierPercentage = (tier: string): number => {
+  if (tier === '100') return 0.01 / 100;
+  if (tier === '300') return 0.03 / 100;
+  if (tier === '500') return 0.05 / 100;
+  if (tier === '750') return 0.075 / 100;
+  if (tier === '2500') return 0.25 / 100;
+  if (tier === '10000') return 1 / 100;
+  return 0;
+};
+
+const FEE_BASE = 10_000;
+
+function parseProtocolFees(feeProtocol) {
+  const packed = Number(feeProtocol);
+  if (Number.isNaN(packed)) {
+    throw new Error(`Invalid fee protocol ${feeProtocol}`);
+  }
+
+  const token0ProtocolFee = packed % 2 ** 16;
+  const token1ProtocolFee = packed >> 16;
+  return [token0ProtocolFee / FEE_BASE, token1ProtocolFee / FEE_BASE];
+}
+
+module.exports.EstimatedFees = (
+  priceAssumptionValue,
+  priceRangeValue,
+  currentPriceUSDToken1,
+  currentPriceUSDToken0,
+  depositAmountUSD,
+  decimalsToken0,
+  decimalsToken1,
+  feeTier,
+  volume,
+  feeProtocol,
+  poolTicks
+) => {
+  const P = priceAssumptionValue;
+  let Pl = priceRangeValue[0];
+  let Pu = priceRangeValue[1];
+  const priceUSDX = currentPriceUSDToken1 || 1;
+  const priceUSDY = currentPriceUSDToken0 || 1;
+  // For now the protocol fee is the same on both tokens so here we just use the fee on token0
+  const [protocolFee] = parseProtocolFees(feeProtocol);
+
+  const { amount0, amount1 } = getTokensAmountFromDepositAmountUSD(
+    P,
+    Pl,
+    Pu,
+    priceUSDX,
+    priceUSDY,
+    depositAmountUSD
+  );
+
+  const deltaL = getLiquidityDelta(
+    P,
+    Pl,
+    Pu,
+    amount0,
+    amount1,
+    Number(decimalsToken0 || 18),
+    Number(decimalsToken1 || 18)
+  );
+
+  let currentTick = getTickFromPrice(
+    P,
+    decimalsToken0 || '18',
+    decimalsToken1 || '18'
+  );
+
+  const L = getLiquidityFromTick(poolTicks, currentTick);
+
+  const estimatedFee =
+    P >= Pl && P <= Pu ? estimateFee(deltaL, L, volume, feeTier) : 0;
+
+  const estimatedFeeAfterProtocolFee = estimatedFee * (1 - protocolFee);
+
+  return estimatedFeeAfterProtocolFee;
+};

--- a/src/adaptors/alien-base-v3/index.js
+++ b/src/adaptors/alien-base-v3/index.js
@@ -1,0 +1,325 @@
+const sdk = require('@defillama/sdk');
+const { request, gql } = require('graphql-request');
+const superagent = require('superagent');
+
+const utils = require('../utils');
+const { EstimatedFees } = require('./estimateFee');
+const { getAlbAprs, ALB, chainIds } = require('./albReward');
+const { checkStablecoin } = require('../../handlers/triggerEnrichment');
+const { boundaries } = require('../../utils/exclude');
+const { queryPrior, query, SUBGRAPH_URL } = require('./subgraphCalls');
+
+const chain = 'base';
+
+const fetchAndCombineAPR = async (chain, url, query, queryPrior, timestamp, stablecoins) => {
+  const albPools = await topLvl(chain, url, query, queryPrior, 'v3', timestamp, stablecoins);
+  const bunniAPRResults = await getAlbAprs(chain);
+
+  const combinedResults = [];
+
+  albPools.forEach((albPool) => {
+    const bunniAPR = bunniAPRResults.find((bunni) => bunni.pool === albPool.pool);
+
+    combinedResults.push({
+      ...albPool,
+      apyBase: albPool.apyBase,
+      apyReward: albPool.apyReward || 0,
+      rewardTokens: albPool.rewardTokens || [],
+      underlyingTokens: albPool.underlyingTokens,
+    });
+
+    if (bunniAPR) {
+      combinedResults.push({
+        ...albPool,
+        pool: bunniAPR.bunniToken,
+        apyBase: bunniAPR.apyBase,
+        tvlUsd: bunniAPR.tvlUsd,
+        apyReward: bunniAPR.apyReward,
+        rewardTokens: bunniAPR.rewardTokens || [],
+        poolMeta: bunniAPR.poolMeta,
+        underlyingTokens: albPool.underlyingTokens,
+      });
+    }
+  });
+
+  bunniAPRResults.forEach((bunniAPR) => {
+    if (!combinedResults.find((r) => r.pool === bunniAPR.bunniToken)) {
+      combinedResults.push({
+        pool: bunniAPR.bunniToken,
+        chain: bunniAPR.chain,
+        symbol: bunniAPR.symbol,
+        project: bunniAPR.project,
+        apyBase: bunniAPR.apyBase,
+        apyReward: bunniAPR.apyReward,
+        rewardTokens: bunniAPR.rewardTokens,
+        underlyingTokens: bunniAPR.underlyingTokens,
+        url: bunniAPR.url,
+        tvlUsd: bunniAPR.tvlUsd,
+        poolMeta: bunniAPR.poolMeta,
+      });
+    }})
+
+  return combinedResults;
+};
+
+const topLvl = async (
+  chainString,
+  url,
+  query,
+  queryPrior,
+  version,
+  timestamp,
+  stablecoins
+) => {
+  try {
+    const [block, blockPrior] = await utils.getBlocks(chainString, timestamp, [
+      url,
+    ]);
+
+    const [_, blockPrior7d] = await utils.getBlocks(
+      chainString,
+      timestamp,
+      [url],
+      604800
+    );
+
+    // pull data
+    let queryC = query;
+    let dataNow = await request(url, queryC.replace('<PLACEHOLDER>', block));
+    dataNow = dataNow.pools;
+    // console.log('dataNow', dataNow);
+
+    dataNow = dataNow.map((p) => {
+      return {
+        ...p,
+        reserve0: p.totalValueLockedToken0,
+        reserve1: p.totalValueLockedToken1,
+      };
+    });
+
+    // pull 24h offset data to calculate fees from swap volume
+    let queryPriorC = queryPrior;
+    let dataPrior = await request(
+      url,
+      queryPriorC.replace('<PLACEHOLDER>', blockPrior)
+    );
+    dataPrior = dataPrior.pools;
+
+    // calculate tvl
+    dataNow = await utils.tvl(dataNow, chainString);
+
+    // to reduce the nb of subgraph calls for tick range, we apply the lb db filter in here
+    dataNow = dataNow.filter(
+      (p) => p.totalValueLockedUSD >= boundaries.tvlUsdDB.lb
+    );
+    // add the symbol for the stablecoin (we need to distinguish btw stable and non stable pools
+    // so we apply the correct tick range)
+    dataNow = dataNow.map((p) => {
+      const symbol = utils.formatSymbol(
+        `${p.token0.symbol}-${p.token1.symbol}`
+      );
+      const stablecoin = checkStablecoin({ ...p, symbol }, stablecoins);
+      return {
+        ...p,
+        symbol,
+        stablecoin,
+      };
+    });
+
+    // for new v3 apy calc
+    const dataPrior7d = (
+      await request(url, queryPriorC.replace('<PLACEHOLDER>', blockPrior7d))
+    ).pools;
+
+    // calc apy (note: old way of using 24h fees * 365 / tvl. keeping this for now) and will store the
+    // new apy calc as a separate field
+    dataNow = dataNow.map((el) =>
+      utils.apy(el, dataPrior, dataPrior7d, version)
+    );
+
+    const enableV3Apy = true;
+    if (enableV3Apy) {
+      dataNow = dataNow.map((p) => ({
+        ...p,
+        token1_in_token0: p.price1 / p.price0,
+      }));
+
+      // batching the tick query into 3 chunks to prevent it from breaking
+      const nbBatches = 3;
+      const chunkSize = Math.ceil(dataNow.length / nbBatches);
+      const chunks = [
+        dataNow.slice(0, chunkSize).map((i) => i.id),
+        dataNow.slice(chunkSize, chunkSize * 2).map((i) => i.id),
+        dataNow.slice(chunkSize * 2, dataNow.length).map((i) => i.id),
+      ];
+
+      const tickData = {};
+      // we fetch 3 pages for each pool
+      for (const page of [0, 1, 2]) {
+        console.log(`page nb: ${page}`);
+        let pageResults = {};
+        for (const chunk of chunks) {
+          console.log(chunk.length);
+          const tickQuery = `
+          query {
+            ${chunk
+              .map(
+                (poolAddress, index) => `
+              pool_${poolAddress}: ticks(
+                first: 1000,
+                skip: ${page * 1000},
+                where: { poolAddress: "${poolAddress}" },
+                orderBy: tickIdx
+              ) {
+                tickIdx
+                liquidityNet
+                price0
+                price1
+              }
+            `
+              )
+              .join('\n')}
+          }
+        `;
+
+          try {
+            const response = await request(url, tickQuery);
+            pageResults = { ...pageResults, ...response };
+          } catch (err) {
+            console.log(err);
+          }
+        }
+        tickData[`page_${page}`] = pageResults;
+      }
+
+      // reformat tickData
+      const ticks = {};
+      Object.values(tickData).forEach((page) => {
+        Object.entries(page).forEach(([pool, values]) => {
+          if (!ticks[pool]) {
+            ticks[pool] = [];
+          }
+          ticks[pool] = ticks[pool].concat(values);
+        });
+      });
+
+      // assume an investment of 1e5 USD
+      const investmentAmount = 1e5;
+
+      // tick range
+      const pct = 0.3;
+      const pctStablePool = 0.001;
+
+      dataNow = dataNow.map((p) => {
+        const poolTicks = ticks[`pool_${p.id}`] ?? [];
+
+        if (!poolTicks.length) {
+          console.log(`No pool ticks found for ${p.id}`);
+          return { ...p, estimatedFee: null, apy7d: null };
+        }
+
+        const delta = p.stablecoin ? pctStablePool : pct;
+
+        const priceAssumption = p.stablecoin ? 1 : p.token1_in_token0;
+
+        const estimatedFee = EstimatedFees(
+          priceAssumption,
+          [p.token1_in_token0 * (1 - delta), p.token1_in_token0 * (1 + delta)],
+          p.price1,
+          p.price0,
+          investmentAmount,
+          p.token0.decimals,
+          p.token1.decimals,
+          p.feeTier,
+          p.volumeUSD7d,
+          p.feeProtocol,
+          poolTicks
+        );
+
+        const apy7d = ((estimatedFee * 52) / investmentAmount) * 100;
+
+        return { ...p, estimatedFee, apy7d };
+      });
+    }
+
+    return dataNow.map((p) => {
+      const poolMeta = `${p.feeTier / 1e4}%`;
+      const underlyingTokens = [p.token0.id, p.token1.id];
+      const token0 = underlyingTokens === undefined ? '' : underlyingTokens[0];
+      const token1 = underlyingTokens === undefined ? '' : underlyingTokens[1];
+
+      const chainId = chainIds[chainString].id;
+
+      const feeTier = Number(poolMeta.replace('%', '')) * 10000;
+      const url = `https://app.alienbase.xyz/add/${token0}/${token1}/${feeTier}?chainId=${chainId}`;
+
+      return {
+        pool: p.id,
+        chain: utils.formatChain(chainString),
+        project: 'alien-base-v3',
+        poolMeta: poolMeta,
+        symbol: p.symbol,
+        tvlUsd: p.totalValueLockedUSD,
+        apyBase: p.apy1d,
+        apyBase7d: p.apy7d,
+        underlyingTokens,
+        url,
+        volumeUsd1d: p.volumeUSD1d,
+        volumeUsd7d: p.volumeUSD7d,
+      };
+    });
+  } catch (e) {
+    if (e.message.includes('Stale subgraph')) return [];
+    else throw e;
+  }
+};
+
+const main = async (timestamp = null) => {
+  if (!timestamp) {
+    timestamp = Math.floor(Date.now() / 1000);
+  }
+  const stablecoins = (
+    await superagent.get(
+      'https://stablecoins.llama.fi/stablecoins?includePrices=true'
+    )
+  ).body.peggedAssets.map((s) => s.symbol.toLowerCase());
+  if (!stablecoins.includes('eur')) stablecoins.push('eur');
+  if (!stablecoins.includes('3crv')) stablecoins.push('3crv');
+
+  const data = [];
+    try {
+      data.push(
+        await topLvl(
+          chain,
+          SUBGRAPH_URL,
+          query,
+          queryPrior,
+          'v3',
+          timestamp,
+          stablecoins
+        )
+      );
+    } catch (err) {
+      console.log(err);
+    }
+
+    const combinedResults = await fetchAndCombineAPR(
+      chain,
+      SUBGRAPH_URL,
+      query,
+      queryPrior,
+      timestamp,
+      stablecoins
+    );
+
+    // console.log('Returning:', combinedResults.flat().filter((p) => utils.keepFinite(p)));
+  
+    return combinedResults
+      .flat()
+      .filter((p) => utils.keepFinite(p));
+  };
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+};

--- a/src/adaptors/alien-base-v3/masterchefv3.json
+++ b/src/adaptors/alien-base-v3/masterchefv3.json
@@ -1,0 +1,1195 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IBoringERC20",
+        "name": "_alb",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_albPerSec",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_teamAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_treasuryAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_investorAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_teamPercent",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_treasuryPercent",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_investorPercent",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "allocPoint",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IBoringERC20",
+        "name": "lpToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "depositFeeBP",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "harvestInterval",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IComplexRewarder[]",
+        "name": "rewarders",
+        "type": "address[]"
+      }
+    ],
+    "name": "Add",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "previousAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "AllocPointsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "EmergencyWithdraw",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "previousValue",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "EmissionRateUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountLockedUp",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardLockedUp",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "allocPoint",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "depositFeeBP",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "harvestInterval",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract IComplexRewarder[]",
+        "name": "rewarders",
+        "type": "address[]"
+      }
+    ],
+    "name": "Set",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newAddress",
+        "type": "address"
+      }
+    ],
+    "name": "SetInvestorAddress",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldPercent",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newPercent",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetInvestorPercent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newAddress",
+        "type": "address"
+      }
+    ],
+    "name": "SetTeamAddress",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldPercent",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newPercent",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetTeamPercent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newAddress",
+        "type": "address"
+      }
+    ],
+    "name": "SetTreasuryAddress",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldPercent",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newPercent",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetTreasuryPercent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lastRewardTimestamp",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpSupply",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "accAlbPerShare",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdatePool",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MAXIMUM_DEPOSIT_FEE_RATE",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAXIMUM_HARVEST_INTERVAL",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_allocPoint",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IBoringERC20",
+        "name": "_lpToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_depositFeeBP",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_harvestInterval",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IComplexRewarder[]",
+        "name": "_rewarders",
+        "type": "address[]"
+      }
+    ],
+    "name": "add",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "alb",
+    "outputs": [
+      {
+        "internalType": "contract IBoringERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "albPerSec",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "canHarvest",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "depositWithPermit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
+    "name": "emergencyWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_pids",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "harvestMany",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "investorAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "investorPercent",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "massUpdatePools",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "pendingTokens",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "addresses",
+        "type": "address[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "symbols",
+        "type": "string[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "decimals",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "poolInfo",
+    "outputs": [
+      {
+        "internalType": "contract IBoringERC20",
+        "name": "lpToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "allocPoint",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastRewardTimestamp",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "accAlbPerShare",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "depositFeeBP",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint256",
+        "name": "harvestInterval",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "totalLp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
+    "name": "poolRewarders",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "rewarders",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
+    "name": "poolRewardsPerSec",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "addresses",
+        "type": "address[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "symbols",
+        "type": "string[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "decimals",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "rewardsPerSec",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pid",
+        "type": "uint256"
+      }
+    ],
+    "name": "poolTotalLp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_allocPoint",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_depositFeeBP",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_harvestInterval",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IComplexRewarder[]",
+        "name": "_rewarders",
+        "type": "address[]"
+      }
+    ],
+    "name": "set",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_investorAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setInvestorAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newInvestorPercent",
+        "type": "uint256"
+      }
+    ],
+    "name": "setInvestorPercent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_teamAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setTeamAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newTeamPercent",
+        "type": "uint256"
+      }
+    ],
+    "name": "setTeamPercent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_treasuryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setTreasuryAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newTreasuryPercent",
+        "type": "uint256"
+      }
+    ],
+    "name": "setTreasuryPercent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startFarming",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "startTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "teamAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "teamPercent",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAlbInPools",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAllocPoint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalLockedUpRewards",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasuryAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasuryPercent",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_allocPoint",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateAllocPoint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_albPerSec",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateEmissionRate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      }
+    ],
+    "name": "updatePool",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "userInfo",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rewardDebt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rewardLockedUp",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "nextHarvestUntil",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pid",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/adaptors/alien-base-v3/subgraphCalls.js
+++ b/src/adaptors/alien-base-v3/subgraphCalls.js
@@ -1,0 +1,148 @@
+const { gql } = require("graphql-request");
+const SUBGRAPH_URL = 'https://api.studio.thegraph.com/query/59130/v3alb/version/latest';
+
+const queryPrior = gql`
+  {
+    pools( first: 1000 orderBy: totalValueLockedUSD orderDirection:desc block: {number: <PLACEHOLDER>}) {
+      id
+      volumeUSD
+    }
+  }
+`;
+
+const query = gql`
+  {
+    pools(first: 100, where: {totalValueLockedUSD_gt: 1000}, orderBy:totalValueLockedUSD, orderDirection: desc) {
+      id
+      totalValueLockedToken0
+      totalValueLockedToken1
+      volumeUSD
+      feeTier
+      feeProtocol
+      token0 {
+        symbol
+        id
+        decimals
+      }
+      token1 {
+        symbol
+        id
+        decimals
+      }
+    }
+  }
+`;
+
+const fetchPoolsFromSubgraph = async () => {
+  const query = `
+    query {
+      pools(first: 100, where: {totalValueLockedUSD_gt: 1000}) {
+        id
+        token0 {
+          id
+        }
+        token1 {
+          id
+        }
+        liquidity
+        totalValueLockedUSD
+        volumeUSD
+      }
+    }
+  `;
+
+  try {
+    const response = await fetch(SUBGRAPH_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query }),
+    });
+    const { data } = await response.json();
+    return data.pools;
+  } catch (err) {
+    console.log('Error fetching pools:', err);
+    return [];
+  }
+};
+
+const averageArray = (dataToCalculate) => {
+  let data = [...dataToCalculate];
+  if (data.length > 3) {
+    data = data.sort((a, b) => a - b).slice(1, data.length - 1);
+  }
+  return data.reduce((result, val) => result + val, 0) / data.length;
+};
+
+const fetchPoolAvgInfo = async (address) => {
+  const query = `
+    query getVolume($days: Int!, $address: String!) {
+      poolDayDatas(first: $days, orderBy: date, orderDirection: desc, where: { pool: $address }) {
+        volumeUSD
+        tvlUSD
+        feesUSD
+        protocolFeesUSD
+      }
+    }
+  `;
+  try {
+    const response = await fetch(SUBGRAPH_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, variables: { days: 7, address: address.toLowerCase() } }),
+    });
+    const { data } = await response.json();
+    const poolDayDatas = data.poolDayDatas;
+
+    const volumes = poolDayDatas.map((d) => Number(d.volumeUSD));
+
+    return {
+      volumeUSD: averageArray(volumes),
+    };
+  } catch (err) {
+    console.log('Error fetching pool volume info:', err);
+    return { volumeUSD: 0 };
+  }
+};
+
+const fetchTokenPricesFromSubgraph = async () => {
+  const query = `
+    query {
+      tokens(first: 100) {
+        id
+        name
+        symbol
+        derivedUSD
+      }
+    }
+  `;
+
+  try {
+    const response = await fetch(SUBGRAPH_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query }),
+    });
+    const { data } = await response.json();
+    
+    const tokenPrices = {};
+    data.tokens.forEach((token) => {
+      tokenPrices[token.id?.toLowerCase()] = {
+        symbol: token.symbol,
+        derivedUSD: parseFloat(token.derivedUSD)
+      };
+    });
+    return tokenPrices;
+  } catch (err) {
+    console.log('Error fetching token prices:', err);
+    return {};
+  }
+};
+
+module.exports = {
+  fetchPoolsFromSubgraph,
+  fetchTokenPricesFromSubgraph,
+  fetchPoolAvgInfo,
+  queryPrior,
+  query,
+  SUBGRAPH_URL,
+};

--- a/src/adaptors/alien-base-v3/v3PoolAbi.json
+++ b/src/adaptors/alien-base-v3/v3PoolAbi.json
@@ -1,0 +1,988 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Burn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount0",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount1",
+        "type": "uint128"
+      }
+    ],
+    "name": "Collect",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount0",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount1",
+        "type": "uint128"
+      }
+    ],
+    "name": "CollectProtocol",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "paid0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "paid1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Flash",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "observationCardinalityNextOld",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "observationCardinalityNextNew",
+        "type": "uint16"
+      }
+    ],
+    "name": "IncreaseObservationCardinalityNext",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint160",
+        "name": "sqrtPriceX96",
+        "type": "uint160"
+      },
+      {
+        "indexed": false,
+        "internalType": "int24",
+        "name": "tick",
+        "type": "int24"
+      }
+    ],
+    "name": "Initialize",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "indexed": true,
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "feeProtocol0Old",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "feeProtocol1Old",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "feeProtocol0New",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "feeProtocol1New",
+        "type": "uint8"
+      }
+    ],
+    "name": "SetFeeProtocol",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "amount0",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "amount1",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint160",
+        "name": "sqrtPriceX96",
+        "type": "uint160"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "liquidity",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "int24",
+        "name": "tick",
+        "type": "int24"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount0Requested",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount1Requested",
+        "type": "uint128"
+      }
+    ],
+    "name": "collect",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "amount0",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount1",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount0Requested",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount1Requested",
+        "type": "uint128"
+      }
+    ],
+    "name": "collectProtocol",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "amount0",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount1",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fee",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeGrowthGlobal0X128",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeGrowthGlobal1X128",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "flash",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "observationCardinalityNext",
+        "type": "uint16"
+      }
+    ],
+    "name": "increaseObservationCardinalityNext",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint160",
+        "name": "sqrtPriceX96",
+        "type": "uint160"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "liquidity",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxLiquidityPerTick",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount",
+        "type": "uint128"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "observations",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "blockTimestamp",
+        "type": "uint32"
+      },
+      {
+        "internalType": "int56",
+        "name": "tickCumulative",
+        "type": "int56"
+      },
+      {
+        "internalType": "uint160",
+        "name": "secondsPerLiquidityCumulativeX128",
+        "type": "uint160"
+      },
+      {
+        "internalType": "bool",
+        "name": "initialized",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32[]",
+        "name": "secondsAgos",
+        "type": "uint32[]"
+      }
+    ],
+    "name": "observe",
+    "outputs": [
+      {
+        "internalType": "int56[]",
+        "name": "tickCumulatives",
+        "type": "int56[]"
+      },
+      {
+        "internalType": "uint160[]",
+        "name": "secondsPerLiquidityCumulativeX128s",
+        "type": "uint160[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "positions",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "liquidity",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "feeGrowthInside0LastX128",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "feeGrowthInside1LastX128",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint128",
+        "name": "tokensOwed0",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "tokensOwed1",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolFees",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "token0",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "token1",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "feeProtocol0",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "feeProtocol1",
+        "type": "uint8"
+      }
+    ],
+    "name": "setFeeProtocol",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "slot0",
+    "outputs": [
+      {
+        "internalType": "uint160",
+        "name": "sqrtPriceX96",
+        "type": "uint160"
+      },
+      {
+        "internalType": "int24",
+        "name": "tick",
+        "type": "int24"
+      },
+      {
+        "internalType": "uint16",
+        "name": "observationIndex",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "observationCardinality",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "observationCardinalityNext",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint8",
+        "name": "feeProtocol",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "unlocked",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int24",
+        "name": "tickLower",
+        "type": "int24"
+      },
+      {
+        "internalType": "int24",
+        "name": "tickUpper",
+        "type": "int24"
+      }
+    ],
+    "name": "snapshotCumulativesInside",
+    "outputs": [
+      {
+        "internalType": "int56",
+        "name": "tickCumulativeInside",
+        "type": "int56"
+      },
+      {
+        "internalType": "uint160",
+        "name": "secondsPerLiquidityInsideX128",
+        "type": "uint160"
+      },
+      {
+        "internalType": "uint32",
+        "name": "secondsInside",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "zeroForOne",
+        "type": "bool"
+      },
+      {
+        "internalType": "int256",
+        "name": "amountSpecified",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint160",
+        "name": "sqrtPriceLimitX96",
+        "type": "uint160"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "swap",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "amount0",
+        "type": "int256"
+      },
+      {
+        "internalType": "int256",
+        "name": "amount1",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int16",
+        "name": "",
+        "type": "int16"
+      }
+    ],
+    "name": "tickBitmap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tickSpacing",
+    "outputs": [
+      {
+        "internalType": "int24",
+        "name": "",
+        "type": "int24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int24",
+        "name": "",
+        "type": "int24"
+      }
+    ],
+    "name": "ticks",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "liquidityGross",
+        "type": "uint128"
+      },
+      {
+        "internalType": "int128",
+        "name": "liquidityNet",
+        "type": "int128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "feeGrowthOutside0X128",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "feeGrowthOutside1X128",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int56",
+        "name": "tickCumulativeOutside",
+        "type": "int56"
+      },
+      {
+        "internalType": "uint160",
+        "name": "secondsPerLiquidityOutsideX128",
+        "type": "uint160"
+      },
+      {
+        "internalType": "uint32",
+        "name": "secondsOutside",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bool",
+        "name": "initialized",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
Yields on Alien Base V3 use a combo of regular Uniswap V3 APR (forked from Uniswap) and a custom-built adapter for Bunni Protocol vaults (forked from the original).

Fees are distributed based on the proportion of active Uniswap liquidity for each vault + volume. Vaults are excluded if they're out of range for base APY but might be included in rewardAPY if the farm is still active. Every value is fetched onchain.

Let us know if you have any questions, thanks!