### PR TITLE
Lynex-fusion symbol fix

### DIFF
--- a/src/adaptors/lynex-fusion/index.js
+++ b/src/adaptors/lynex-fusion/index.js
@@ -57,9 +57,9 @@ const getApy = async () => {
     const found = activeStrategies.find(
       (item) => item.address.toLowerCase() === poolAddress,
     );
-    const poolMeta = `${found?.type}`
+    const poolMeta = found ? found.title : 'Classic'
     const symbol = found
-      ? `${firstSymbol}/${secondSymbol} (${found.title})`
+      ? `${firstSymbol}/${secondSymbol}`
       : pool.stable
         ? `sAMM-${firstSymbol}/${secondSymbol}`
         : `vAMM-${firstSymbol}/${secondSymbol}`;

--- a/src/adaptors/lynex-fusion/index.js
+++ b/src/adaptors/lynex-fusion/index.js
@@ -5,7 +5,6 @@ const pairAPI = require('./abis/pairAPI.json');
 const factoryAbi = require('./abis/factoryABI.json');
 const { getPrices, getTokenPrice, fetchPeriodFinish, fetchExtraPoolRewards, fromWei, loadActiveStrategies, fetchGammaInfo } = require('./utils');
 
-const TVL_FILTER = 10000
 const TEST_ACCOUNT = '0x1111110000000000000000000000000000000000'
 
 const getApy = async () => {
@@ -60,7 +59,7 @@ const getApy = async () => {
     );
     const poolMeta = `${found?.type}`
     const symbol = found
-      ? `${firstSymbol}/${secondSymbol}`
+      ? `${firstSymbol}/${secondSymbol} (${found.title})`
       : pool.stable
         ? `sAMM-${firstSymbol}/${secondSymbol}`
         : `vAMM-${firstSymbol}/${secondSymbol}`;
@@ -145,7 +144,7 @@ const getApy = async () => {
   }
 
   // Put all together
-  const aux = pools.map((pool, i) => {
+  const returnData = pools.map((pool, i) => {
     let tvl;
     let rewardsTokens = [olynxAddress];
     let extraRewardsApy = 0
@@ -222,8 +221,7 @@ const getApy = async () => {
     };
 
   });
-  // const returnData = aux.filter((pool) => { return pool.tvlUsd > 500000 })
-  return aux;
+  return returnData;
 };
 
 module.exports = {


### PR DESCRIPTION
PLEASE READ

Despite the fact that the code on DefiLlama yield-server repo master branch isn't adding the strategy between parenthesis on the pool symbol, we need this otherwise pools with the same name (but different strategy) will be shown on DefiLlama. 

Please do not close immediately if you disagree and let's have a discussion at least.