### PR TITLE
chore: Add Usual USD0++ in defillama yield server

### DIFF
--- a/src/adaptors/usual-money/index.js
+++ b/src/adaptors/usual-money/index.js
@@ -27,7 +27,7 @@ const apy = async () => {
 	return [{
 		pool: usd0PP,
 		chain: 'Ethereum',
-		project: 'Usual',
+		project: 'usual-money',
 		symbol: 'USD0++',
 		tvlUsd,
 		apyBase, 

--- a/src/adaptors/usual/index.js
+++ b/src/adaptors/usual/index.js
@@ -23,7 +23,7 @@ const apy = async () => {
 	const price = (await axios.get(`${baseURLLlamaPrice}${priceKey}` )).data.coins[priceKey].price;
 	const tvlUsd = totalSupply * price;
 	const reward = (await axios.get(`${baseURLRewardRate}${symbol}`)).data.rewards.find((e) => usual.toLowerCase() == e.rewardToken.toLowerCase());
-	const apyBase = utils.aprToApy(reward.apr, 52);
+	const apyBase = utils.aprToApy(reward.apr, 52) * 100;
 	return [{
 		pool: usd0PP,
 		chain: 'Ethereum',

--- a/src/adaptors/usual/index.js
+++ b/src/adaptors/usual/index.js
@@ -1,0 +1,43 @@
+const sdk = require('@defillama/sdk');
+const axios = require('axios');
+const utils = require('../utils');
+
+const usd0PP = '0x35D8949372D46B7a3D5A56006AE77B215fc69bC0';
+const usd0   = '0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5';
+const usual  = '0xC4441c2BE5d8fA8126822B9929CA0b81Ea0DE38E';
+
+const symbol = 'USD0++';
+
+const baseURLRewardRate = 'https://app.usual.money/api/rewards/rates/';
+const baseURLLlamaPrice = 'https://coins.llama.fi/prices/current/';
+const scalarOne = 1e18;
+
+const apy = async () => {
+	const totalSupply = 
+		( await sdk.api.abi.call({
+			target: usd0PP,
+			abi: 'erc20:totalSupply',
+		})
+		).output / scalarOne;
+	const priceKey = `ethereum:${usd0PP}`;
+	const price = (await axios.get(`${baseURLLlamaPrice}${priceKey}` )).data.coins[priceKey].price;
+	const tvlUsd = totalSupply * price;
+	const reward = (await axios.get(`${baseURLRewardRate}${symbol}`)).data.rewards.find((e) => usual.toLowerCase() == e.rewardToken.toLowerCase());
+	const apyBase = utils.aprToApy(reward.apr, 52);
+	return [{
+		pool: usd0PP,
+		chain: 'Ethereum',
+		project: 'Usual',
+		symbol: 'USD0++',
+		tvlUsd,
+		apyBase, 
+		rewardTokens: [usual],
+		underlyingTokens: [usd0],
+		},
+	];
+}
+
+module.exports = {
+	apy,
+	url: 'https://app.usual.money/swap?action=stake',
+};


### PR DESCRIPTION
This pull request introduces a new feature to fetch and calculate the APY for the USD0++ token on the Ethereum blockchain. The changes involve integrating several libraries, defining constants, and implementing the `apy` function to return the APY data.

Key changes include:

* **Library Integrations:**
  * Added `@defillama/sdk` and `axios` libraries for API calls and data fetching.

* **Constants Definition:**
  * Defined constants for token addresses (`usd0PP`, `usd0`, `usual`), symbol (`USD0++`), API endpoints (`baseURLRewardRate`, `baseURLLlamaPrice`), and a scalar value (`scalarOne`).

* **APY Calculation:**
  * Implemented the `apy` function to fetch total supply, price, TVL (Total Value Locked), and reward rate, and calculate the APY based on these values.

* **Export Module:**
  * Exported the `apy` function and a URL for staking actions.