### PR TITLE
Corrected APY calculation

### DIFF
--- a/src/adaptors/polynomial-liquidity/index.js
+++ b/src/adaptors/polynomial-liquidity/index.js
@@ -17,7 +17,7 @@ const getApy = async () => {
         project: 'polynomial-liquidity',
         symbol: pool.collateralType === 'fxUSDC' ? 'USDC' : pool.collateralType,
         tvlUsd: pool.tvl,
-        apyBase: pool.apr,
+        apyBase: pool.apr + pool.baseApr,
         apyReward: pool.opRewardsApr,
         rewardTokens: ['0x4200000000000000000000000000000000000042'],
         url: LIQUIDITY_URL


### PR DESCRIPTION
Corrected yield calcuation for Polynomial liquidity, now it shows corrected values. Base apy of deposited tokens weren't calculated. Example: Deposit yield bearing asset and you earn base apy of it, platform fees + rewards token. 