### PR TITLE
Fix: base apy to reward apy

### DIFF
--- a/src/adaptors/usual-money/index.js
+++ b/src/adaptors/usual-money/index.js
@@ -23,14 +23,14 @@ const apy = async () => {
 	const price = (await axios.get(`${baseURLLlamaPrice}${priceKey}` )).data.coins[priceKey].price;
 	const tvlUsd = totalSupply * price;
 	const reward = (await axios.get(`${baseURLRewardRate}${symbol}`)).data.rewards.find((e) => usual.toLowerCase() == e.rewardToken.toLowerCase());
-	const apyBase = utils.aprToApy(reward.apr, 52) * 100;
+	const apyReward = utils.aprToApy(reward.apr, 52) * 100;
 	return [{
 		pool: usd0PP,
 		chain: 'Ethereum',
 		project: 'usual-money',
 		symbol: 'USD0++',
 		tvlUsd,
-		apyBase, 
+		apyReward, 
 		rewardTokens: [usual],
 		underlyingTokens: [usd0],
 		},


### PR DESCRIPTION
This pull request includes a small but significant change to the `src/adaptors/usual-money/index.js` file. The change involves renaming a variable to better reflect its purpose.

Variable renaming:

* [`src/adaptors/usual-money/index.js`](diffhunk://#diff-0d775a28663551013e1af95283c2b9a9428c2feefd76e1da3080ad6444f0a71bL26-R33): The variable `apyBase` has been renamed to `apyReward` to clarify that it represents the reward-based APY rather than the base APY.