### PR TITLE
fix: add risk profile to cbbtc vault

### DIFF
--- a/src/adaptors/impermax-finance/index.js
+++ b/src/adaptors/impermax-finance/index.js
@@ -215,6 +215,10 @@ const lendingVaultProfiles = {
       address: '0x683cc7cbb8b8c5b3c5fae85a4ae70e887217883b'.toLowerCase(),
       risk: 'Aggressive',
     }, // ETH (high)
+    {
+      address: '0xc68c47085D2B53A0A782c168D1b54a913A668cB5'.toLowerCase(),
+      risk: 'Conservative',
+    }, // cbBTC (low)
   ],
 };
 


### PR DESCRIPTION
Adding metadata for the cbBTC vault on base for `impermax-finance`