### PR TITLE
Add more blend pool yields

### DIFF
--- a/src/adaptors/blend-pools/index.js
+++ b/src/adaptors/blend-pools/index.js
@@ -48,7 +48,7 @@ const getApy = async (poolId, backstop) => {
       let totalSupply = reserve.totalSupplyFloat() * price;
       let totalBorrow = reserve.totalLiabilitiesFloat() * price;
 
-      const url = `https://mainnet.blend.capital/dashboard/?poolId=${poolId}&assetId=${reserve.assetId}`;
+      const url = `https://mainnet.blend.capital/dashboard/?poolId=${poolId}`;
 
       pools.push({
         pool: `${pool.id}-${reserve.assetId}-stellar`.toLowerCase(),

--- a/src/adaptors/blend-pools/index.js
+++ b/src/adaptors/blend-pools/index.js
@@ -43,7 +43,7 @@ const getApy = async (poolId, backstop) => {
       if (borrowEmissionsPerAsset > 0) {
         borrowEmissionsAPR = (borrowEmissionsPerAsset * usdcPerBlnd) / price;
       }
-      // Estimate borrow APY compoumded daily
+      // Estimate borrow APY compounded daily
       const borrowApy = (1 + reserve.borrowApr / 365) ** 365 - 1;
       let totalSupply = reserve.totalSupplyFloat() * price;
       let totalBorrow = reserve.totalLiabilitiesFloat() * price;

--- a/src/adaptors/blend-pools/index.js
+++ b/src/adaptors/blend-pools/index.js
@@ -80,18 +80,7 @@ const apy = async () => {
 
   for (const poolId of BLEND_POOLS) {
     let poolApys = await getApy(poolId, backstop);
-    for (const poolApy of poolApys) {
-      if (poolApy) {
-        let index = pools.findIndex((pool) => pool.pool == poolApy.pool);
-        if (index !== -1) {
-          if (poolApy.apyReward > pools[index].apyReward) {
-            pools[index] = poolApy;
-          }
-        } else {
-          pools.push(poolApy);
-        }
-      }
-    }
+    pools.push(...poolApys)
   }
   return pools;
 };

--- a/src/adaptors/blend-pools/index.js
+++ b/src/adaptors/blend-pools/index.js
@@ -48,10 +48,10 @@ const getApy = async (poolId, backstop) => {
       let totalSupply = reserve.totalSupplyFloat() * price;
       let totalBorrow = reserve.totalLiabilitiesFloat() * price;
 
-      const url = `https://mainnet.blend.capital/dashboard/?poolId=${poolId}`;
+      const url = `https://mainnet.blend.capital/dashboard/?poolId=${poolId}&assetId=${reserve.assetId}`;
 
       pools.push({
-        pool: `${reserve.assetId}-stellar`.toLowerCase(),
+        pool: `${pool.id}-${reserve.assetId}-stellar`.toLowerCase(),
         chain: formatChain('stellar'),
         project: 'blend-pools',
         symbol: reserve.tokenMetadata.symbol,
@@ -66,7 +66,7 @@ const getApy = async (poolId, backstop) => {
         apyBaseBorrow: borrowApy * 100,
         apyRewardBorrow: borrowEmissionsAPR * 100,
         ltv: totalBorrow / totalSupply,
-        poolMeta: `Pool ID: ${pool.id}`,
+        poolMeta: `${pool.config.name} Pool`,
         url,
       });
     }


### PR DESCRIPTION
Since Blend doesn't utilize a token with a unique address to represent a user's position (like Aave's `aToken`), the token's address can overlap from one pool to the next. This change makes each pool ID a unique one based on the pool address and the token address.