### PR TITLE
feat(test): add some additional checks to help llamas

### DIFF
--- a/src/adaptors/test.js
+++ b/src/adaptors/test.js
@@ -136,4 +136,50 @@ describe(`Running ${process.env.npm_config_adapter} Test`, () => {
       protocolsSlug.includes(apy[0].project) && apy[0].project === adapter
     ).toBe(true);
   });
+
+  describe('Check additional field data rules', () => {
+
+    // All values added here are treated as optional
+    // If they are present, they will be checked against their rules
+    let additionalFieldRules = {
+      totalSupplyUsd: {
+        type: 'number',
+      },
+      totalBorrowUsd: {
+        type: 'number',
+      },
+      ltv: {
+        type: 'number',
+        min: 0,
+        max: 1,
+      },
+    }
+
+    apy.forEach((pool) => {
+      Object.entries(additionalFieldRules).map(([field, rule]) => {
+        console.log({'pool[field]': pool[field]})
+        if(pool[field] !== undefined) {
+          if(rule.type) {
+            test(`${field} field of pool with id ${pool.pool} should be a ${rule.type}`, () => {
+              expect(typeof pool[field]).toBe(rule.type);
+            });
+            if((rule.max !== undefined) && (rule.min !== undefined)) {
+              test(`${field} field of pool with id ${pool.pool} should be in the range of ${rule.min}-${rule.max}`, () => {
+                expect(pool[field]).toBeLessThanOrEqual(rule.max);
+              });
+            } else if((rule.min !== undefined) && (rule.max === undefined)) {
+              test(`${field} field of pool with id ${pool.pool} should be greater than or equal to ${rule.min}`, () => {
+                expect(pool[field]).toBeGreaterThanOrEqual(rule.min);
+              });
+            } else if((rule.max !== undefined) && (rule.min === undefined)) {
+              test(`${field} field of pool with id ${pool.pool} should be less than or equal to ${rule.max}`, () => {
+                expect(pool[field]).toBeLessThanOrEqual(rule.max);
+              });
+            }
+          }
+        }
+      });
+    });
+  })
+
 });

--- a/src/adaptors/test.js
+++ b/src/adaptors/test.js
@@ -149,7 +149,6 @@ describe(`Running ${process.env.npm_config_adapter} Test`, () => {
         type: 'number',
       },
       ltv: {
-        type: 'number',
         min: 0,
         max: 1,
       },

--- a/src/adaptors/test.js
+++ b/src/adaptors/test.js
@@ -139,8 +139,8 @@ describe(`Running ${process.env.npm_config_adapter} Test`, () => {
 
   describe('Check additional field data rules', () => {
 
-    // All values added here are treated as optional
-    // If they are present, they will be checked against their rules
+    // All fields added here are treated as optional
+    // If a field is present, it will be checked against its rules
     let additionalFieldRules = {
       totalSupplyUsd: {
         type: 'number',

--- a/src/adaptors/test.js
+++ b/src/adaptors/test.js
@@ -159,23 +159,23 @@ describe(`Running ${process.env.npm_config_adapter} Test`, () => {
       Object.entries(additionalFieldRules).map(([field, rule]) => {
         console.log({'pool[field]': pool[field]})
         if(pool[field] !== undefined) {
-          if(rule.type) {
+          if(rule.type !== undefined) {
             test(`${field} field of pool with id ${pool.pool} should be a ${rule.type}`, () => {
               expect(typeof pool[field]).toBe(rule.type);
             });
-            if((rule.max !== undefined) && (rule.min !== undefined)) {
-              test(`${field} field of pool with id ${pool.pool} should be in the range of ${rule.min}-${rule.max}`, () => {
-                expect(pool[field]).toBeLessThanOrEqual(rule.max);
-              });
-            } else if((rule.min !== undefined) && (rule.max === undefined)) {
-              test(`${field} field of pool with id ${pool.pool} should be greater than or equal to ${rule.min}`, () => {
-                expect(pool[field]).toBeGreaterThanOrEqual(rule.min);
-              });
-            } else if((rule.max !== undefined) && (rule.min === undefined)) {
-              test(`${field} field of pool with id ${pool.pool} should be less than or equal to ${rule.max}`, () => {
-                expect(pool[field]).toBeLessThanOrEqual(rule.max);
-              });
-            }
+          }
+          if((rule.max !== undefined) && (rule.min !== undefined)) {
+            test(`${field} field of pool with id ${pool.pool} should be in the range of ${rule.min}-${rule.max}`, () => {
+              expect(pool[field]).toBeLessThanOrEqual(rule.max);
+            });
+          } else if((rule.min !== undefined) && (rule.max === undefined)) {
+            test(`${field} field of pool with id ${pool.pool} should be greater than or equal to ${rule.min}`, () => {
+              expect(pool[field]).toBeGreaterThanOrEqual(rule.min);
+            });
+          } else if((rule.max !== undefined) && (rule.min === undefined)) {
+            test(`${field} field of pool with id ${pool.pool} should be less than or equal to ${rule.max}`, () => {
+              expect(pool[field]).toBeLessThanOrEqual(rule.max);
+            });
           }
         }
       });


### PR DESCRIPTION
I thought I'd add some extra test checks in case you find them helpful, inspired by this comment: https://github.com/DefiLlama/yield-server/pull/1695#issuecomment-2601651988

The "rules" can be defined as any combination of `type`, `min` & `max`.

The rules are only checked if there is a value for the field (i.e. it's assumed all fields are optional but we can do checks against the required fields too, like we do with tvl to check that it's in the range of 0-1).