### PR TITLE
fix: adjust apr for staked tvl

### DIFF
--- a/src/adaptors/aerodrome-v1/index.js
+++ b/src/adaptors/aerodrome-v1/index.js
@@ -75,6 +75,15 @@ const getApy = async () => {
     })
   ).output.map((o) => o.output);
 
+  const poolSupply = (
+    await sdk.api.abi.multiCall({
+      calls: allPools.map((i) => ({ target: i })),
+      chain: 'base',
+      abi: 'erc20:totalSupply',
+      permitFailure: true,
+    })
+  ).output.map((o) => o.output);
+
   const totalSupply = (
     await sdk.api.abi.multiCall({
       calls: gauges.map((i) => ({
@@ -129,9 +138,16 @@ const getApy = async () => {
     const s = symbols[i];
 
     const pairPrice = (tvlUsd * 1e18) / totalSupply[i];
+
+    // Only staked supply is eligible for the rewardRate's emissions
+    let stakedSupplyRatio = 1;
+    if (totalSupply[i] !== 0) {
+      stakedSupplyRatio = poolSupply[i] / totalSupply[i];
+    }
+
     const apyReward =
       (((rewardRate[i] / 1e18) * 86400 * 365 * prices[`base:${AERO}`]?.price) /
-        tvlUsd) *
+        tvlUsd) * stakedSupplyRatio *
       100;
 
     return {


### PR DESCRIPTION
Only the staked TVL in Velodrome v2 style pools is eligible for the `rewardRate` emissions. This PR adjusts the final APR to account for the ratio of total liquidity:staked liquidity (non-negligible impact on most pools because all LPs are generally incentivized to stake. This is mostly to fix the APR for pools that have nontrivial amounts of unstaked TVL, e.g. burned POL). The staked TVL methodology is already implemented for the Velo/Aero concentrated LP adaptors