### PR TITLE
Add Harvest Finance vault meta info

### DIFF
--- a/src/adaptors/harvest-finance/index.js
+++ b/src/adaptors/harvest-finance/index.js
@@ -16,6 +16,13 @@ const chains = {
   base: 'base',
   zksync: 'era',
 };
+const url_config = {
+  eth: 'ethereum',
+  matic: 'polygon',
+  arbitrum: 'arbitrum',
+  base: 'base',
+  zksync: 'zksync',
+}
 
 function aggregateBaseApys(farm, poolsResponse) {
   const farmApy = farm.estimatedApy;
@@ -119,6 +126,8 @@ async function apy() {
         apyBase,
         apyReward: aggregateRewardApys(v, poolsResponse[chain]),
         rewardTokens,
+        poolMeta: v.platform ? `${v.platform[0]}` : null,
+        url: `https://app.harvest.finance/${url_config[chain]}/${v.vaultAddress}`,
       };
     });
 
@@ -144,5 +153,4 @@ async function apy() {
 module.exports = {
   timetravel: false,
   apy,
-  url: 'https://app.harvest.finance/',
 };


### PR DESCRIPTION
Updated the Harvest Finance adaptor to include url and relevant meta per vault.