### PR TITLE
bakerfi: change `.xyz` to `.ai` domain

### DIFF
--- a/src/adaptors/bakerfi/index.js
+++ b/src/adaptors/bakerfi/index.js
@@ -2,7 +2,7 @@ const sdk = require('@defillama/sdk');
 const utils = require('../utils');
 const axios = require('axios');
 
-const API_URL = 'https://api-v1.bakerfi.xyz/api';
+const API_URL = 'https://api-v1.bakerfi.ai/api';
 
 const oracles = {
   ethereum: {
@@ -103,5 +103,5 @@ async function readVaultsInfo(args) {
 module.exports = {
   timetravel: false,
   apy: readVaultsInfo,
-  url: 'https://bakerfi.xyz/app',
+  url: 'https://bakerfi.ai/app',
 };


### PR DESCRIPTION
gm gm 👋  
just a small update on BakerFi's domain:  
-  move from `.xyz` to `.ai` domain  

note: pr for `defillama-server` repo here https://github.com/DefiLlama/defillama-server/pull/9309