### PR TITLE
add: Cadabra Finance yields

### DIFF
--- a/src/adaptors/cadabra-finance/index.js
+++ b/src/adaptors/cadabra-finance/index.js
@@ -1,0 +1,66 @@
+const utils = require('../utils');
+
+const networkMapping = {
+  1: 'ethereum',
+  10: 'optimism',
+  25: 'cronos',
+  56: 'bsc',
+  100: 'gnosis',
+  122: 'fuse',
+  128: 'heco',
+  137: 'polygon',
+  169: 'manta',
+  250: 'fantom',
+  252: 'fraxtal',
+  324: 'zksync',
+  1088: 'metis',
+  1101: 'polygon_zkevm',
+  1284: 'moonbeam',
+  1285: 'moonriver',
+  2222: 'kava',
+  5000: 'mantle',
+  7700: 'canto',
+  8453: 'base',
+  34443: 'mode',
+  42161: 'arbitrum',
+  42220: 'celo',
+  42262: 'oasis',
+  43114: 'avalanche',
+  59144: 'linea',
+  1313161554: 'aurora',
+  1666600000: 'harmony',
+};
+
+const main = async () => {
+  const contracts = await utils.getData(
+    'https://app.cadabra.finance/api/system/contract'
+  );
+  const strategies = await utils.getData(
+    'https://app.cadabra.finance/api/system/strategies'
+  );
+
+  return Object.values(strategies).filter(pool => !pool.isTestStrategy).map((pool) => {
+    const apyReward = Number(pool.apr) * 100;
+    const chain = networkMapping[pool.chainId]
+
+    const tokens = pool.tokens.map(p => p.address)
+    const tokensSymbol = pool.tokens.map(p => p.symbol)
+
+    return {
+      pool: `cadabra-${pool.id}-${chain}`.toLowerCase(),
+      chain: chain,
+      project: 'cadabra-finance',
+      symbol: tokensSymbol.join('-'),
+      tvlUsd: Number(pool.tvl),
+      apyReward,
+      url: `https://app.cadabra.finance/strategies/${pool.id.toLowerCase()}/${pool.chainId}`,
+      rewardTokens: [contracts.abra[pool.chainId]],
+      underlyingTokens: tokens,
+    };
+  });
+};
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+};

--- a/src/adaptors/cadabra-finance/index.js
+++ b/src/adaptors/cadabra-finance/index.js
@@ -1,4 +1,23 @@
 const utils = require('../utils');
+const sdk = require('@defillama/sdk');
+const ethers = require('ethers');
+const axios = require('axios');
+
+const cadabraConfig = [
+  {
+    chain: 'bsc',
+    abra: '0xcA1c644704feBf4ab81f85daca488d1623C28e63',
+    vault: '0x6f24f5EB8f50DE36C1D1FEcD31c423e1fc8ba4ae',
+    fromBlock: 45524968,
+    lens: '0x2A479CFf64574Ed192f42509a205e3eb94Dc258C',
+  },
+  {
+    chain: 'arbitrum',
+    abra: '0x65114046C6e73AF794308547124aD5C8dcE3be6F',
+    vault: '0x31206FFb663651aBe29cCb72aD213d5F95BdaC45',
+    fromBlock: 293021794,
+  },
+]
 
 const networkMapping = {
   1: 'ethereum',
@@ -32,12 +51,76 @@ const networkMapping = {
 };
 
 const main = async () => {
-  const contracts = await utils.getData(
-    'https://app.cadabra.finance/api/system/contract'
-  );
+  let allTokens = new Set();
+  let wrapperInfoByChain = new Map();
+
+  for (const config of cadabraConfig) {
+    let wrappers = await collectWrappers(config.vault, config.fromBlock, config.chain)
+    const result = (
+      await sdk.api.abi.multiCall({
+        abi: 'function reserves() view returns(address[] memory, uint256[] memory)',
+        calls: wrappers.map((w) => ({target:w})),
+        chain: config.chain
+      })
+    ).output
+
+    result.forEach((out )=> {
+        let tokens = out.output[0].map((t) => chainToken(config.chain, t))
+        tokens.forEach(t => allTokens.add(t))
+        wrapperInfoByChain[chainToken(config.chain, out.input.target)] = {
+          tokens: tokens,
+          amounts: out.output[1],
+        }
+    })
+
+    if (typeof config.lens !== 'undefined') {
+      let token0 = (await sdk.api.abi.call({
+        abi: 'function token0() view returns(address)',
+        target: config.lens,
+        chain: config.chain
+      })).output
+      token0 =  chainToken(config.chain, token0)
+      let token1 = (await sdk.api.abi.call({
+        abi: 'function token1() view returns(address)',
+        target: config.lens,
+        chain: config.chain
+      })).output
+      token1 =  chainToken(config.chain, token1)
+      const frp = (await sdk.api.abi.call({
+        abi: 'function fullRangePair() view returns(address)',
+        target: config.lens,
+        chain: config.chain
+      })).output;
+
+      const [frpReserve0, frpReserve1] = (await sdk.api.abi.call({
+        abi: 'function fullRangePairReserves()\n' +
+          '    view\n' +
+          '    returns (uint256 reserve0, uint256 reserve1)',
+        target: config.lens,
+        chain: config.chain
+      })).output;
+
+      allTokens.add(token0)
+      allTokens.add(token1)
+
+      wrapperInfoByChain[chainToken(config.chain, frp)] = {
+        tokens: [token0, token1],
+        amounts: [frpReserve0, frpReserve1],
+      }
+    }
+  }
+
+  let prices = await getPrices(Array.from(allTokens));
+  return await collectFinalInfo(wrapperInfoByChain, prices)
+};
+
+async function collectFinalInfo(wrapperInfoByChain, prices){
   const strategies = await utils.getData(
     'https://app.cadabra.finance/api/system/strategies'
   );
+
+  const abraByChain = new Map()
+  cadabraConfig.forEach(config => abraByChain[config.chain] = config.abra)
 
   return Object.values(strategies).filter(pool => !pool.isTestStrategy).map((pool) => {
     const apyReward = Number(pool.apr) * 100;
@@ -51,14 +134,89 @@ const main = async () => {
       chain: chain,
       project: 'cadabra-finance',
       symbol: tokensSymbol.join('-'),
-      tvlUsd: Number(pool.tvl),
+      tvlUsd: calculateTvl(chain, pool.adapters, wrapperInfoByChain, prices),
       apyReward,
       url: `https://app.cadabra.finance/strategies/${pool.id.toLowerCase()}/${pool.chainId}`,
-      rewardTokens: [contracts.abra[pool.chainId]],
+      rewardTokens: [abraByChain[chain]],
       underlyingTokens: tokens,
     };
   });
-};
+}
+
+function calculateTvl(chain, adapters, wrapperInfoByChain, prices) {
+  let totalTvl = 0
+
+  for (let adapter of adapters) {
+    let address = chainToken(chain, adapter.address);
+    let info = wrapperInfoByChain[address]
+
+    for (let i = 0; i < info.tokens.length; i++) {
+      let token = info.tokens[i]
+      let amount = info.amounts[i]
+      let price = prices[token]
+
+      totalTvl += amount / 10 ** price.decimals * price.price
+    }
+  }
+
+  return totalTvl
+}
+
+async function getPrices(allTokens){
+  let results = {};
+  if (allTokens.length > 0) {
+    for (let i = 0; i < allTokens.length; i += 100) {
+      const {
+        data: { coins },
+      } = await axios.get(
+        `https://coins.llama.fi/prices/current/${allTokens.slice(i, i + 100)}`
+      );
+      for (const key of Object.keys(coins)) {
+        results[key] = coins[key];
+      }
+    }
+  }
+  return results;
+}
+
+function chainToken(chain, token) {
+  return (chain + ':' + token).toLowerCase()
+}
+
+async function collectWrappers(vault, fromBlock, chain) {
+  const blockNow = await sdk.api.util.getLatestBlock(chain)
+
+  const ifacePoolRegistered = new ethers.utils.Interface(['event PoolRegistered(bytes32 indexed poolId, address indexed poolAddress, uint8 specialization)'])
+  const ifaceTokensRegistered = new ethers.utils.Interface(['event TokensRegistered(bytes32 indexed poolId, address[] tokens, address[] assetManagers)'])
+
+  const logs = (
+    await sdk.api.util.getLogs({
+    target: vault,
+    topic: '',
+    fromBlock: fromBlock,
+    toBlock: blockNow.number,
+    keys: [],
+    topics: [ifacePoolRegistered.getEventTopic('PoolRegistered')],
+    chain: chain,
+  })).output
+    .filter((ev) => !ev.removed)
+    .map((ev) => ifacePoolRegistered.parseLog(ev).args)
+  const logs2 = (await sdk.api.util.getLogs({
+    target: vault,
+    topic: '',
+    fromBlock: fromBlock,
+    toBlock: blockNow.number,
+    keys: [],
+    topics: [ifaceTokensRegistered.getEventTopic('TokensRegistered')],
+    chain: chain,
+  })).output
+    .filter((ev) => !ev.removed)
+    .map((ev) => ifaceTokensRegistered.parseLog(ev).args)
+
+  let tokens =  logs2.map(ev => ev.tokens).flat();
+  let blacklistedTokens =  new Set(logs.flatMap((ev, idx) => ev.poolAddress));
+  return tokens.filter(t => !blacklistedTokens.has(t))
+}
 
 module.exports = {
   timetravel: false,


### PR DESCRIPTION
We use off-chain API for the following reasons:
- some of our vault types are created without factories, that would mean we have to constantly update this repo, whereas making a single request would be more convenient.
- Difficulties in calculating TVL on-chain, because it's stateful: we have no built-in methods to get emission rates per each vault, so we have to rely on the chain of events in our backend calculations, it's kind of possible to calculate on-chain though but it would require changes to the audited contracts, which isn't optimal.