### PR TITLE
apys should be % not decimal format

### DIFF
--- a/src/adaptors/the-standard/index.js
+++ b/src/adaptors/the-standard/index.js
@@ -60,8 +60,8 @@ const getApy = async () => {
         project: 'the-standard',
         symbol: `${token0Symbol}-${token1Symbol}`,
         tvlUsd: token0TVLUSD + token1TVLUSD,
-        apyBase: pool.feeApr,
-        apyReward: pool.rewardApr,
+        apyBase: parseFloat(pool.feeApr) * 100,
+        apyReward: parseFloat(pool.rewardApr) * 100,
         rewardTokens: poolRewardTokens,
         underlyingTokens: [token0, token1]
       };


### PR DESCRIPTION
the yields i submitted last week listed the apys as decimal (e.g. 0.01 for 1%) but defi llama requires %