### PR TITLE
fix: disable incentives for Umami vaults

### DIFF
--- a/src/adaptors/umami-finance/umamiGmSynthVaults.js
+++ b/src/adaptors/umami-finance/umamiGmSynthVaults.js
@@ -13,6 +13,8 @@ const {
 const { default: BigNumber } = require('bignumber.js');
 const { formatUnits } = require('ethers/lib/utils.js');
 
+const INCENTIVES_ENABLED = false;
+
 // returns the weights of GMX GM tokens held in the GMI vault
 const getGmiGmMarketsWeights = async (gmiContract) => {
   const weights = await gmiContract.methods.getWeights().call();
@@ -83,7 +85,7 @@ const getUmamiGmSynthsVaultsYield = async (chain, gmMarketsInfos) => {
       url: vault.url,
     };
 
-    if (rewardToken) {
+    if (INCENTIVES_ENABLED) {
       const vaultIncentivesApr = await getIncentivesAprForVault(vault, chain);
       vaultObject = {
         ...vaultObject,

--- a/src/adaptors/umami-finance/umamiGmVaults.js
+++ b/src/adaptors/umami-finance/umamiGmVaults.js
@@ -11,6 +11,8 @@ const {
   getAggregateVaultContractForVault,
 } = require('./umamiContracts.js');
 
+const INCENTIVES_ENABLED = false;
+
 /** ---- GM VAULTS ---- */
 
 const getUmamiGmVaultsYield = async (chain, gmMarketsInfos) => {
@@ -65,7 +67,7 @@ const getUmamiGmVaultsYield = async (chain, gmMarketsInfos) => {
       url: vault.url,
     };
 
-    if (rewardToken) {
+    if (INCENTIVES_ENABLED) {
       const vaultIncentivesApr = await getIncentivesAprForVault(vault, chain);
 
       vaultObject = {


### PR DESCRIPTION
ARB incentives are over for Umami vaults but still returning a value, disable adding them to the object