### PR TITLE
Fix incorrect pool addresses

### DIFF
--- a/src/adaptors/dinero-(pxeth)/index.js
+++ b/src/adaptors/dinero-(pxeth)/index.js
@@ -1,7 +1,7 @@
 const sdk = require('@defillama/sdk');
 const axios = require('axios');
 
-const token = '0x04C154b66CB340F3Ae24111CC767e0184Ed00Cc6';
+const token = '0x9ba021b0a9b958b5e75ce9f6dff97c7ee52cb3e6';
 const weth = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 
 const getApy = async () => {


### PR DESCRIPTION
- correct addresses for sfrxETH and apxETH
- previous addresses were for frxETH and pxETH which are the non-yield bearing base tokens