### PR TITLE
Add yields for Wasabi Protocol

### DIFF
--- a/src/adaptors/wasabi/index.js
+++ b/src/adaptors/wasabi/index.js
@@ -1,0 +1,31 @@
+const utils = require('../utils')
+
+const apy = async () => {
+  const vaultsData = await utils.getData('https://gateway.wasabi.xyz/vaults')
+  return vaultsData.items.map(data => {
+    const vault = data.vault;
+    const token = data.token;
+    const poolState = data.poolState;
+    const totalBorrowUsd = data.tvlUsd * data.utilizationRate;
+    const isRewardAPY = vault.chain === 'berachain' && token.symbol === 'WBERA';
+    return {
+      pool: `wasabi-${vault.chain}-${vault.symbol}`,
+      chain: vault.chain === "mainnet" ? "Ethereum" : utils.formatChain(vault.chain),
+      project: 'wasabi',
+      symbol: token.symbol,
+      tvlUsd: data.tvlUsd,
+      apyBase: isRewardAPY ? 0 : data.apr * 100,
+      apyReward: isRewardAPY ? data.apr * 100 : 0,
+      underlyingTokens: [vault.tokenAddress],
+      rewardTokens: isRewardAPY ? ["0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b"] : [],
+      totalSupplyUsd: data.tvlUsd,
+      totalBorrowUsd,
+      url: `https://app.wasabi.xyz/earn?vault=${vault.symbol}&network=${vault.chain}`,
+    }
+  })
+}
+
+module.exports = {
+  timetravel: false,
+  apy
+}

--- a/src/adaptors/wasabi/index.js
+++ b/src/adaptors/wasabi/index.js
@@ -1,14 +1,12 @@
 const utils = require('../utils')
 const sdk = require('@defillama/sdk');
 
-const apy = async (timestamp) => {
+const apy = async () => {
   const vaultsData = await utils.getData('https://gateway.wasabi.xyz/vaults')
-  return vaultsData.items.map(async (data) => {
+  return vaultsData.items.map(data => {
     const vault = data.vault;
     const token = data.token;
-    const { tvl } = await utils.getERC4626Info(vault.address, vault.chain, timestamp);
-    const tvlUsd = tvl * utils.getPrices([vault.tokenAddress], vault.chain).pricesByAddress[vault.tokenAddress];
-    const totalBorrowUsd = tvlUsd * data.utilizationRate;
+    const totalBorrowUsd = data.tvlUsd * data.utilizationRate;
     const isRewardAPY = vault.chain === 'berachain' && token.symbol === 'WBERA';
     const isDeprecated = vault.deprecated;
     return {
@@ -16,12 +14,12 @@ const apy = async (timestamp) => {
       chain: vault.chain === "mainnet" ? "Ethereum" : utils.formatChain(vault.chain),
       project: 'wasabi',
       symbol: token.symbol,
-      tvlUsd: isDeprecated ? 0 : tvlUsd,
+      tvlUsd: isDeprecated ? 0 : data.tvlUsd,
       apyBase: isRewardAPY ? 0 : data.apr * 100,
       apyReward: isRewardAPY ? data.apr * 100 : 0,
       underlyingTokens: [vault.tokenAddress],
       rewardTokens: isRewardAPY ? ["0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b"] : [],
-      totalSupplyUsd: tvlUsd,
+      totalSupplyUsd: data.tvlUsd,
       totalBorrowUsd,
       url: `https://app.wasabi.xyz/earn?vault=${vault.symbol}&network=${vault.chain}`,
     }

--- a/src/adaptors/wasabi/index.js
+++ b/src/adaptors/wasabi/index.js
@@ -1,12 +1,15 @@
 const utils = require('../utils')
+const sdk = require('@defillama/sdk');
 
-const apy = async () => {
+const apy = async (timestamp) => {
   const vaultsData = await utils.getData('https://gateway.wasabi.xyz/vaults')
-  return vaultsData.items.map(data => {
+  return vaultsData.items.map(async (data) => {
     const vault = data.vault;
     const token = data.token;
     const poolState = data.poolState;
-    const totalBorrowUsd = data.tvlUsd * data.utilizationRate;
+    const { tvl } = await utils.getERC4626Info(vault.address, vault.chain, timestamp);
+    const tvlUsd = tvl * utils.getPrices([vault.tokenAddress], vault.chain).pricesByAddress[vault.tokenAddress];
+    const totalBorrowUsd = tvlUsd * data.utilizationRate;
     const isRewardAPY = vault.chain === 'berachain' && token.symbol === 'WBERA';
     const isDeprecated = vault.deprecated;
     return {
@@ -14,12 +17,12 @@ const apy = async () => {
       chain: vault.chain === "mainnet" ? "Ethereum" : utils.formatChain(vault.chain),
       project: 'wasabi',
       symbol: token.symbol,
-      tvlUsd: isDeprecated ? 0 : data.tvlUsd,
+      tvlUsd: isDeprecated ? 0 : tvlUsd,
       apyBase: isRewardAPY ? 0 : data.apr * 100,
       apyReward: isRewardAPY ? data.apr * 100 : 0,
       underlyingTokens: [vault.tokenAddress],
       rewardTokens: isRewardAPY ? ["0xac03CABA51e17c86c921E1f6CBFBdC91F8BB2E6b"] : [],
-      totalSupplyUsd: data.tvlUsd,
+      totalSupplyUsd: tvlUsd,
       totalBorrowUsd,
       url: `https://app.wasabi.xyz/earn?vault=${vault.symbol}&network=${vault.chain}`,
     }

--- a/src/adaptors/wasabi/index.js
+++ b/src/adaptors/wasabi/index.js
@@ -8,12 +8,13 @@ const apy = async () => {
     const poolState = data.poolState;
     const totalBorrowUsd = data.tvlUsd * data.utilizationRate;
     const isRewardAPY = vault.chain === 'berachain' && token.symbol === 'WBERA';
+    const isDeprecated = vault.deprecated;
     return {
       pool: `wasabi-${vault.chain}-${vault.symbol}`,
       chain: vault.chain === "mainnet" ? "Ethereum" : utils.formatChain(vault.chain),
       project: 'wasabi',
       symbol: token.symbol,
-      tvlUsd: data.tvlUsd,
+      tvlUsd: isDeprecated ? 0 : data.tvlUsd,
       apyBase: isRewardAPY ? 0 : data.apr * 100,
       apyReward: isRewardAPY ? data.apr * 100 : 0,
       underlyingTokens: [vault.tokenAddress],

--- a/src/adaptors/wasabi/index.js
+++ b/src/adaptors/wasabi/index.js
@@ -6,7 +6,6 @@ const apy = async (timestamp) => {
   return vaultsData.items.map(async (data) => {
     const vault = data.vault;
     const token = data.token;
-    const poolState = data.poolState;
     const { tvl } = await utils.getERC4626Info(vault.address, vault.chain, timestamp);
     const tvlUsd = tvl * utils.getPrices([vault.tokenAddress], vault.chain).pricesByAddress[vault.tokenAddress];
     const totalBorrowUsd = tvlUsd * data.utilizationRate;


### PR DESCRIPTION
We need to use our API endpoint to fetch the APYs for our vaults, since there is no clean way to calculate them using only onchain data, and we don't have a subgraph.