### PR TITLE
Merkl: remove past and uniswap pools

### DIFF
--- a/src/adaptors/merkl/index.js
+++ b/src/adaptors/merkl/index.js
@@ -5,7 +5,7 @@ const { networks } = require('./config');
 
 // Protocols that should not be listed under Merkl
 // as they already have their own adapters.
-const protocolsBlacklist = ['euler', 'crosscurve', 'aerodrome', 'gamma'];
+const protocolsBlacklist = ['euler', 'crosscurve', 'aerodrome', 'gamma', 'uniswap'];
 
 // Allow specific pools from blacklisted protocols
 const poolsWhitelist = [
@@ -72,6 +72,7 @@ const main = async () => {
           pool: `${poolAddress}-merkl`,
           chain: chain,
           project: project,
+          poolMeta: pool.status === 'PAST' ? 'past' : undefined,
           symbol: symbol,
           tvlUsd: tvlUsd ?? 0,
           apyReward: apyReward ?? 0,

--- a/src/handlers/triggerEnrichment.js
+++ b/src/handlers/triggerEnrichment.js
@@ -40,6 +40,9 @@ const main = async () => {
     return !isNaN(date) && date > new Date(); // keep if valid future date
   });
 
+  // remove past Merkl pools
+  data = data.filter((p) => !(p.project === 'merkl' && p.poolMeta === 'past'));
+
   // ---------- add additional fields
   // for each project we get 3 offsets (1D, 7D, 30D) and calculate absolute apy pct-change
   console.log('\nadding pct-change fields');


### PR DESCRIPTION
Uniswap is handled by https://github.com/DefiLlama/yield-server/pull/1827
I added past pools earlier in https://github.com/DefiLlama/yield-server/pull/1845