### PR TITLE
fix:  increase the pagination limit to display all markets

### DIFF
--- a/src/adaptors/liqwid/index.js
+++ b/src/adaptors/liqwid/index.js
@@ -8,7 +8,7 @@ const apy = async () => {
     query {
       liqwid {
         data {
-          markets {
+          markets (input: { perPage: 100 }) {
             page
             results {
               id


### PR DESCRIPTION
The default pagination was set to 20, and we now have more than 20 markets, so some were hidden