### PR TITLE
Ensuro: removes deprecated pools + simplifies APY computation

### DIFF
--- a/src/adaptors/ensuro/index.js
+++ b/src/adaptors/ensuro/index.js
@@ -13,31 +13,20 @@ const extractKey = (alchemy_full_url) => {
 
 const addressBook = {
   polygon: {
-    usdc: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+    usdc: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
     eTokens: [
       // eTokens
-      {
-        name: 'Koala Jr Pool',
-        address: '0xBC33c283A37d46ABA17BC5F8C27b27242688DeC6',
-        symbol: 'eUSDCKoBMAJr',
-      },
       {
         name: 'Senior Pool',
         address: '0xF383eF2D31E1d4a19B3e04ca2937DB6A8DA9f229',
         symbol: 'eUSDCBMASr',
       },
-      {
-        name: 'Spot Jr Pool',
-        address: '0x6229D78658305a301E177f9dAEa3a0799fd1528C',
-        symbol: 'eUSDCGSJr',
-      },
     ],
   },
 };
 
-const abiTransfer = [
-  'event Transfer(address indexed from, address indexed to, uint256 value)',
-];
+const abiGetCurrentScale =
+  'function getCurrentScale(bool updated) public view returns (uint256)';
 
 const getApy = async () => {
   const timestamp1dayAgo = Math.floor(Date.now() / 1000) - 86400;
@@ -55,36 +44,24 @@ const getApy = async () => {
 
   return await Promise.all(
     addressBook.polygon.eTokens.map(async (etk) => {
-      const [tsNow, tsOneDayAgo] = await Promise.all([
+      const [tsNow, csNow, csOneDayAgo] = await Promise.all([
         sdk.api.erc20.totalSupply({ target: etk.address, chain: 'polygon' }),
-        sdk.api.erc20.totalSupply({
+        sdk.api.abi.call({
           target: etk.address,
           chain: 'polygon',
+          params: [true],
+          abi: abiGetCurrentScale,
+        }),
+        sdk.api.abi.call({
+          target: etk.address,
+          chain: 'polygon',
+          abi: abiGetCurrentScale,
+          params: [true],
           block: block1dayAgo,
         }),
       ]);
 
-      const contract = new ethers.Contract(etk.address, abiTransfer, provider);
-      const transfers = await contract.queryFilter(
-        contract.filters.Transfer(),
-        block1dayAgo
-      );
-      const netDeposits = transfers
-        .filter(
-          (evt) =>
-            evt.args.from === ethers.constants.AddressZero ||
-            evt.args.to === ethers.constants.AddressZero
-        )
-        .reduce(
-          (accumulator, evt) =>
-            evt.args.from === ethers.constants.AddressZero
-              ? accumulator.add(evt.args.value)
-              : accumulator.sub(evt.args.value),
-          ethers.BigNumber.from(0)
-        )
-        .toNumber();
-      const dailyApr =
-        (tsNow.output - tsOneDayAgo.output - netDeposits) / tsOneDayAgo.output;
+      const dailyApr = csNow.output / csOneDayAgo.output - 1;
       // Using apr to apy formula from https://www.aprtoapy.com/
       const apy = (Math.pow(1 + dailyApr, 365) - 1) * 100;
       return {


### PR DESCRIPTION
Removed old pools and added our main pool: https://app.ensuro.co/eTokens/0xF383eF2D31E1d4a19B3e04ca2937DB6A8DA9f229

Also, I changed the APY calculation. Since Ensuro Tokens are rebasing tokens, the division between the current scale and the scale one day ago gives the APY.