### PR TITLE
Missing yield data from 2025-05-21 to 2025-06-17 for IPOR Fusion pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,4 @@ module.exports = {
 ```
 
 You can find examples for a bunch of other protocols in the [src/adaptors/](src/adaptors/) folder, and if you have any questions feel free to ask them on [our discord](https://discord.defillama.com/).
+


### PR DESCRIPTION
Regard to already merged PR: https://github.com/DefiLlama/yield-server/pull/1928
with comment: https://github.com/DefiLlama/yield-server/pull/1928#issuecomment-2984667407

Here is the missing yield data from 2025-05-21 to 2025-06-17 for IPOR Fusion pools in JSON file:
[ipop_fusion_yields_missing_data.json](https://github.com/user-attachments/files/20884425/ipop_fusion_yields_missing_data.json)

If data need to be created in different format or structure, just let me know.