### PR TITLE
Decimal bug fix

### DIFF
--- a/src/adaptors/mainstreet/index.js
+++ b/src/adaptors/mainstreet/index.js
@@ -26,7 +26,7 @@ const poolsFunction = async () => {
     })
     .then((result) => result.output);
 
-  const apy = (Math.pow(1 + (apr/1e18) / 365, 365) - 1);
+  const apy = (Math.pow(1 + (apr/1e18) / 365, 365) - 1) * 100;
 
   const msUSDPool = {
     pool: msUSD.address,


### PR DESCRIPTION
Moved the decimal over to give us the accurate APY.

apy before:

0.4116926753388426 -> .4117%

apy after (correct apy):

41.16926753388426 -> 41.17%

We were under the impression DL would auto-convert. Our mistake.