### PR TITLE
Simplify pair name display by using tokenSymbols joined with hyphen

### DIFF
--- a/src/adaptors/berancia/index.ts
+++ b/src/adaptors/berancia/index.ts
@@ -42,6 +42,7 @@ interface BeranciaResponse {
       total: string | null;
       base: string | null;
     };
+    tokenSymbols: string[];
   }[];
 }
 
@@ -154,7 +155,7 @@ const transformVaultToPool = (
     pool: vault.address,
     tvlUsd: parseAndFormatNumeric(vault.tvl.total),
     apyBase: parseAndFormatNumeric(apyValue),
-    symbol: vault.symbol,
+    symbol: vault.tokenSymbols.join('-'),
     poolMeta: isLeveraged ? CONFIG.poolMetaLeveraged : CONFIG.poolMeta,
   };
 };


### PR DESCRIPTION
Changed symbol display to use `tokenSymbols` joined with hyphen instead of the API's `symbol` field. This removes unnecessary prefixes and focuses on clean pair name display.

**Before:** Uses API's symbol field (e.g., "cia KODI..WBERA-iBGT.")
**After:** Uses tokenSymbols joined with "-" (e.g., "WBERA-iBGT")