### PR TITLE
Added Ethereum to Dolomite

### DIFF
--- a/src/adaptors/dolomite/index.js
+++ b/src/adaptors/dolomite/index.js
@@ -201,7 +201,7 @@ async function apy() {
         return range.reduce((acc, i) => {
           if (tokens[i]) {
             acc.push({
-              pool: `${tokens[i]}-${chain}`.toLowerCase(),
+              pool: `${tokens[i]}-dolomite-${chain}`.toLowerCase(),
               symbol: symbols[i],
               chain: chain.charAt(0).toUpperCase() + chain.slice(1),
               project: 'dolomite',

--- a/src/adaptors/dolomite/index.js
+++ b/src/adaptors/dolomite/index.js
@@ -5,6 +5,7 @@ const sdk = require('@defillama/sdk');
 const DOLOMITE_MARGIN_ADDRESS_MAP = {
   arbitrum: '0x6Bd780E7fDf01D77e4d475c821f1e7AE05409072',
   berachain: '0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D',
+  ethereum: '0x003Ca23Fd5F0ca87D01F6eC6CD14A8AE60c2b97D',
 };
 
 async function apy() {


### PR DESCRIPTION
This is not currently passing all tests. We ID the pools as `{tokenAddress}-ethereum`, but several of the pools are already used. Would you prefer doing `{tokenAddress}-dolomite-ethereum` or doing some kind of hash to get a new address?