### PR TITLE
 Add ZKP2P Yield to DefiLlama

### DIFF
--- a/src/adaptors/zkp2p/index.js
+++ b/src/adaptors/zkp2p/index.js
@@ -45,6 +45,7 @@ const getApy = async () => {
       tvlUsd: Number(latestData.tvl),
       apy: Number(latestData.protocol_apr_pct),
       url: 'https://zkp2p.xyz',
+      poolMeta: 'APR is a TVL-weighted median across payment rail pools (e.g., Venmo, Zelle). Details: https://docs.zkp2p.xyz/user-guides/for-sellers/calculating-apr',
     };
 
     console.log('ZKP2P: Fetched fresh data from Dune');


### PR DESCRIPTION
**_Reopened with Dune API Key as variable to pass test_**

We currently have all our data publicly available in Dune, so it was easier to use this than rebuild the wheel. I mentioned this in the discord and it seems okay.

It caches the data so that if it is less than 24 hours old, we do not recall the API. I kept it to the latest day of data available, but if we need historical I can change the script.

Our Methodology is :

Our APR is calculated using a TVL-weighted median of pool-level APRs. Each pool represents a payment rail (e.g., Venmo, Zelle, Wise). Our APR calculatiuon can be found here https://docs.zkp2p.xyz/user-guides/for-sellers/calculating-apr.

This is then rolled up and should give the Median APY as suggested by your docs.

Let me know if you need more info.