### PR TITLE
Revert name change Peapods Finance

### DIFF
--- a/src/adaptors/peapods-finance/index.js
+++ b/src/adaptors/peapods-finance/index.js
@@ -337,7 +337,7 @@ async function main() {
       return {
         pool: lp.lendingPair,
         chain: chainKey,
-        project: 'peapods-options',
+        project: 'peapods-finance',
         symbol: lp.assetSymbol,
         tvlUsd,
         apyBase: supplierApy * 100,


### PR DESCRIPTION
I'm not sure what's the reason for this name change as the protocol hasn't gone through a rebrand or anything and remains to be Peapods Finance.