### PR TITLE
fix: Refactor APR calculations to APY for Rezerve's lstRZR

### DIFF
--- a/src/adaptors/rezerve-money/index.js
+++ b/src/adaptors/rezerve-money/index.js
@@ -106,7 +106,7 @@ async function calcErc4626PoolApy(vault, prices) {
     apyBase7d,
     apyReward: 0,
     poolMeta: vaultMeta[vault].name,
-    url: 'https://rezerve.money/stake?tab=vaults',
+    url: 'https://rezerve.money/liquid-staking?utm_source=defillama',
   };
 }
 


### PR DESCRIPTION
We have been tracking the APR and not the APY for the vaults 🙈. This PR fixes that.

Historic APY charts
- Pendle https://app.pendle.finance/trade/pools/0xabfc41b413891c647d0d1cd66bf64bc6ed8fee71/zap/in?chain=sonic
- Spectra https://app.spectra.finance/trade-yield/sonic:0x17cd5228da53f244a96fc6e5415bdcdc06348a46
