### PR TITLE
Impermax-Finance: Fix incorrect token prices

### DIFF
--- a/src/adaptors/impermax-v3/index.js
+++ b/src/adaptors/impermax-v3/index.js
@@ -362,9 +362,10 @@ const main = async () => {
       getChainVaults(chain),
     ]);
 
+    const chainPools = [...borrowables, ...lendingVaults];
     const prices = await getChainUnderlyingPrices(
       chain,
-      borrowables.map((i) => i.underlying.id)
+      chainPools.map((i) => i.underlying.id)
     );
 
     /**


### PR DESCRIPTION
There was an issue calculating token prices for lending vaults which had no v3 deployed (as there were no borrowables).