### PR TITLE
feat: add Celo network support to Aave V3, Merkl adaptor

### DIFF
--- a/src/adaptors/aave-v3/index.js
+++ b/src/adaptors/aave-v3/index.js
@@ -23,6 +23,7 @@ const protocolDataProviders = {
   etherfi: '0xECdA3F25B73261d1FdFa1E158967660AA29f00cC', // on ethereum
   linea: '0x9eEBf28397D8bECC999472fC8838CBbeF54aebf6',
   sonic: '0x306c124fFba5f2Bc0BcAf40D249cf19D492440b9',
+  celo: '0x33b7d355613110b4E842f5f7057Ccd36fb4cee28'
 };
 
 const getApy = async (market) => {

--- a/src/adaptors/merkl/config.js
+++ b/src/adaptors/merkl/config.js
@@ -10,4 +10,5 @@ exports.networks = {
   43114: 'avax',
   80094: 'berachain',
   56: 'bsc',
+  42220: 'celo',
 };


### PR DESCRIPTION
- Updated data providers for AAVE to add Celo's `AaveProtocolDataProvider`
- Updated Merkl supported chains to add Celo. 