### PR TITLE
Add yield support for Nabla Finance swap pools on Berachain

### DIFF
--- a/src/adaptors/nabla-finance/index.js
+++ b/src/adaptors/nabla-finance/index.js
@@ -7,8 +7,10 @@ const WEEKS_IN_YEAR = 52.142;
 
 const graphUrls = {
   arbitrum:
-    'https://subgraph.satsuma-prod.com/9b84d9926bf3/nabla-finance--3958960/nabla-mainnetAlpha/api',
+    'https://subgraph.satsuma-prod.com/9b84d9926bf3/nabla-finance--3958960/nabla-mainnetAlpha-arbitrum/api',
   base: 'https://subgraph.satsuma-prod.com/9b84d9926bf3/nabla-finance--3958960/nabla-mainnetAlpha-base/api',
+  berachain:
+    'https://subgraph.satsuma-prod.com/9b84d9926bf3/nabla-finance--3958960/nabla-mainnetAlpha-berachain-public/api',
 };
 
 const query = gql`

--- a/src/adaptors/nabla-finance/index.js
+++ b/src/adaptors/nabla-finance/index.js
@@ -3,8 +3,6 @@ const utils = require('../utils');
 const superagent = require('superagent');
 const { request, gql } = require('graphql-request');
 
-const WEEKS_IN_YEAR = 52.142;
-
 const graphUrls = {
   arbitrum:
     'https://subgraph.satsuma-prod.com/9b84d9926bf3/nabla-finance--3958960/nabla-mainnetAlpha-arbitrum/api',
@@ -28,6 +26,7 @@ const query = gql`
 
 const getPriceKey = (address, chain) => `${chain}:${address}`;
 
+// APR → APY conversion (7-day APR assumed, converted to daily then compounded yearly)
 const apr7dToApy = (apr) => {
   const aprDay = apr / 365;
   return (1 + aprDay) ** 365 - 1;
@@ -42,19 +41,22 @@ const poolsFunction = async (chain) => {
       return [];
     }
 
-    const tokens = swapPools.map((p) => p.token.id);
+    const tokens = [...new Set(swapPools.map((swapPool) => swapPool.token.id))];
 
-    const priceKeys = [...new Set(tokens)].map((address) =>
-      getPriceKey(address, chain)
-    );
+    const priceKeys = tokens.map((address) => getPriceKey(address, chain));
 
-    const priceResponse = await superagent.get(
-      `https://coins.llama.fi/prices/current/${priceKeys
-        .join(',')
-        .toLowerCase()}`
-    );
-
-    const usdPrices = priceResponse.body.coins || {};
+    let usdPrices = {};
+    try {
+      const priceResponse = await superagent.get(
+        `https://coins.llama.fi/prices/current/${priceKeys
+          .join(',')
+          .toLowerCase()}`
+      );
+      usdPrices = priceResponse.body.coins || {};
+    } catch (err) {
+      console.error(`Failed fetching prices for chain ${chain}:`, err);
+      return [];
+    }
 
     return swapPools
       .map((swapPool) => {
@@ -71,14 +73,21 @@ const poolsFunction = async (chain) => {
 
         const { decimals, symbol, price } = priceData;
 
+        const tvlUsd = BigNumber(tvl)
+          .div(10 ** (decimals || 18))
+          .times(price)
+          .toNumber();
+
+        const aprNormalized = Number(apr7d || 0) / 10 ** (decimals || 18);
+
         return {
           pool: `${pool}-${chain}`,
           chain: utils.formatChain(chain),
           project: 'nabla-finance',
           symbol: utils.formatSymbol(symbol),
           underlyingTokens: [tokenAddress],
-          tvlUsd: (BigNumber(tvl) / 10 ** decimals) * price,
-          apyBase: apr7dToApy(apr7d / 10 ** decimals) * 100,
+          tvlUsd,
+          apyBase: apr7dToApy(aprNormalized) * 100,
         };
       })
       .filter(Boolean);

--- a/src/adaptors/nabla-finance/index.js
+++ b/src/adaptors/nabla-finance/index.js
@@ -73,12 +73,11 @@ const poolsFunction = async (chain) => {
 
         const { decimals, symbol, price } = priceData;
 
-        const tvlUsd = BigNumber(tvl)
-          .div(10 ** (decimals || 18))
-          .times(price)
-          .toNumber();
+        const tvlNormalized = BigNumber(tvl).div(10 ** (decimals || 18));
+        const tvlUsd = tvlNormalized.times(price).toNumber();
 
         const aprNormalized = Number(apr7d || 0) / 10 ** (decimals || 18);
+        const apyBase = apr7dToApy(aprNormalized) * 100;
 
         return {
           pool: `${pool}-${chain}`,
@@ -86,8 +85,8 @@ const poolsFunction = async (chain) => {
           project: 'nabla-finance',
           symbol: utils.formatSymbol(symbol),
           underlyingTokens: [tokenAddress],
-          tvlUsd,
-          apyBase: apr7dToApy(aprNormalized) * 100,
+          tvlUsd: tvlUsd,
+          apyBase: apyBase,
         };
       })
       .filter(Boolean);


### PR DESCRIPTION
#### **Objective**
Add support for Berachain in the Nabla Finance yield adapter.
This ensures swap pool TVL (liabilities) and APY are properly reported, aligned with the logic already in place for Arbitrum and Base.

#### Modifications
- Add subgraph-based fetching for Berachain with same structure