### PR TITLE
fix: bug with aerodrome-v1 staked supply ratio

### DIFF
--- a/src/adaptors/aerodrome-v1/index.js
+++ b/src/adaptors/aerodrome-v1/index.js
@@ -232,7 +232,7 @@ const getGaugeApy = async () => {
     // Only staked supply is eligible for the rewardRate's emissions
     let stakedSupplyRatio = 1;
     if (totalSupply[i] !== 0) {
-      stakedSupplyRatio = poolSupply[i] / totalSupply[i];
+      stakedSupplyRatio = totalSupply[i] / poolSupply[i];
     }
 
     const apyReward =


### PR DESCRIPTION
## Overview
there's a possible error with Aerodrome V1's rewards APY calculation. the `stakedSupplyRatio` is actually inverted because `totalSupply` is the gauges supply of LP tokens and `poolSupply` is the aerodrome pool.

this could be an issue because if half of the LPs have staked, it actually doubles the yield. the discrepancy is less obvious as more LPs stake, but there is a visible overestimation of the APY for the newer pools. and since there's no point of being an unstaked LP, the bug disappears very quickly as the ratio nears 1.