### PR TITLE
Add sendit.fun pools and vaults to yield-server

### DIFF
--- a/src/adaptors/sendit/index.js
+++ b/src/adaptors/sendit/index.js
@@ -1,0 +1,185 @@
+const axios = require('axios');
+const utils = require('../utils');
+
+const API_BASE = 'https://backend.sendit.fun/api';
+const WSOL_MINT = 'So11111111111111111111111111111111111111112';
+
+const fetchAllVerifiedMarketPools = async () => {
+  try {
+    const response = await axios.get(`${API_BASE}/accounts/verified-markets/pools`);
+    return response.data?.data?.pools || [];
+  } catch (error) {
+    return [];
+  }
+};
+
+const fetchSolVaults = async () => {
+  try {
+    const response = await axios.get(`${API_BASE}/sol-vaults`);
+    const vaults = response.data?.vaults || [];
+    return Array.isArray(vaults) ? vaults : [];
+  } catch (error) {
+    return [];
+  }
+};
+
+const fetchSingleSidedVaults = async () => {
+  try {
+    const response = await axios.get(`${API_BASE}/single-sided-vaults`);
+    const vaults = response.data?.vaults || [];
+    return Array.isArray(vaults) ? vaults : [];
+  } catch (error) {
+    return [];
+  }
+};
+
+const formatSolReservePool = (market, poolData) => {
+  const solReserve = poolData.solReserve;
+  const nonSolReserve = poolData.nonSolReserve;
+  const tokenSymbol = nonSolReserve?.metadata?.symbol || 'UNKNOWN';
+  
+  // Use supplyInterest which is already in decimal format (e.g., 0.469 = 46.9%)
+  const supplyApr = Number(solReserve?.supplyInterest || 0) * 100;
+  
+  // Extract incentive APR from the object structure
+  let apyReward = 0;
+  if (poolData.incentiveApr && poolData.incentiveApr.currentAPR) {
+    apyReward = Number(poolData.incentiveApr.currentAPR) * 100;
+  }
+  
+  return {
+    pool: `${market.lendingMarketId}-solana`.toLowerCase(),
+    chain: utils.formatChain('solana'),
+    project: 'sendit',
+    symbol: 'SOL',
+    poolMeta: `SOL in ${tokenSymbol} market`,
+    tvlUsd: Number(solReserve?.totalSupplyUsd || 0),
+    apyBase: supplyApr,
+    apyReward: apyReward > 0 ? apyReward : null,
+    rewardTokens: nonSolReserve?.mintAddress ? [nonSolReserve.mintAddress] : [],
+    underlyingTokens: [WSOL_MINT],
+    url: `https://sendit.fun/market/${market.lendingMarketId}`
+  };
+};
+
+const getVaultCategoryName = (vaultAddress) => {
+  const categories = {
+    'bluechip': 'Blue Chip Vault',
+    'midcap': 'Mid Cap Vault',
+    'smallcap': 'Small Cap Vault'
+  };
+  
+  return 'SOL Vault';
+};
+
+const formatSolVaultPool = (vault) => {
+  // Calculate average APR from deployed positions
+  let avgApr = 0;
+  if (vault?.deployedPositions && vault.deployedPositions.length > 0) {
+    const totalValue = vault.deployedPositions.reduce((sum, pos) => sum + (pos.depositedValueSol || 0), 0);
+    avgApr = vault.deployedPositions.reduce((sum, pos) => 
+      sum + ((pos.apr || 0) * (pos.depositedValueSol || 0) / totalValue), 0
+    );
+  }
+  
+  // Assume SOL price of ~$195 (should ideally fetch this from an API)
+  const solPrice = 195;
+  const tvlUsd = Number(vault?.totalValueLockedSol || 0) * solPrice;
+  const vaultName = getVaultCategoryName(vault?.vaultAddress);
+  
+  return {
+    pool: `${vault?.vaultAddress}-solana`.toLowerCase(),
+    chain: utils.formatChain('solana'),
+    project: 'sendit',
+    symbol: 'SOL',
+    poolMeta: vaultName,
+    tvlUsd: tvlUsd,
+    apyBase: avgApr * 100, // Convert to percentage
+    underlyingTokens: [WSOL_MINT],
+    url: 'https://sendit.fun/earn'
+  };
+};
+
+const formatSingleSidedVaultPool = (vault) => {
+  const tokenSymbol = vault?.tokenSymbol || 'UNKNOWN';
+  
+  return {
+    pool: `${vault?.vaultAddress}-solana`.toLowerCase(),
+    chain: utils.formatChain('solana'),
+    project: 'sendit',
+    symbol: tokenSymbol,
+    poolMeta: `${tokenSymbol} Vault`,
+    tvlUsd: Number(vault?.tvlBreakdown?.usd?.totalAssets || 0),
+    apyBase: vault?.apr ? Number(vault.apr) : 0,  // apr is already in percentage
+    underlyingTokens: vault?.depositTokenMint ? [vault.depositTokenMint] : [],
+    url: 'https://sendit.fun/earn'
+  };
+};
+
+const poolsFunction = async () => {
+  const pools = [];
+  
+  try {
+    const [verifiedMarketPools, solVaults, singleSidedVaults] = await Promise.all([
+      fetchAllVerifiedMarketPools(),
+      fetchSolVaults(),
+      fetchSingleSidedVaults()
+    ]);
+    
+    // Process verified market pools
+    verifiedMarketPools.forEach(poolData => {
+      if (poolData && poolData.solReserve) {
+        try {
+          const pool = formatSolReservePool(
+            { lendingMarketId: poolData.marketAddress }, 
+            poolData
+          );
+          if (pool && pool.tvlUsd > 10000) {
+            pools.push(pool);
+          }
+        } catch (err) {
+          // Silently skip pools that fail to format
+        }
+      }
+    });
+    
+    solVaults.forEach(vault => {
+      try {
+        const pool = formatSolVaultPool(vault);
+        if (pool && pool.tvlUsd > 10000) {
+          pools.push(pool);
+        }
+      } catch (err) {
+        // Silently skip vaults that fail to format
+      }
+    });
+    
+    singleSidedVaults.forEach(vault => {
+      try {
+        const pool = formatSingleSidedVaultPool(vault);
+        if (pool && pool.tvlUsd > 10000) {
+          pools.push(pool);
+        }
+      } catch (err) {
+        // Silently skip vaults that fail to format
+      }
+    });
+  } catch (error) {
+    // Return whatever pools we were able to collect
+  }
+  
+  const validPools = pools.filter(pool => 
+    pool && 
+    pool.project === 'sendit' && 
+    typeof pool.tvlUsd === 'number' &&
+    !isNaN(pool.tvlUsd)
+  );
+  
+  return validPools;
+};
+
+module.exports = {
+  timetravel: false,
+  apy: poolsFunction,
+  url: 'https://sendit.fun'
+};


### PR DESCRIPTION
Add sendit.fun pools and vaults to yield-server.

Tests run successfully with the expected values:

```
yield-server % npm run test --adapter=sendit
npm warn Unknown cli config "--adapter". This will stop working in the next major version of npm.

> defillama-apy-server@1.0.0 test
> jest

 PASS  src/adaptors/test.js
  Running sendit Test
    ✓ Check if link to the pool's page exist
    ✓ Check for unique pool ids (1 ms)
    ✓ Check project field is constant in all pools and if folder name and project field in pool objects matches the information in /protocols slug
    Check for allowed field names
      ✓ Expects pool id 8pq2bafbr9hdydhl2x8zobpznlrtf7r2y5xrbqg1jclg-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,apyReward,rewardTokens,underlyingTokens,url (1 ms)
      ✓ Expects pool id 5mt6jfgvts46q836fzy1qnpftpbsj4c8khnbtpdqagnd-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,apyReward,rewardTokens,underlyingTokens,url
      ✓ Expects pool id 7lszpwgyicvrqowbfnynwlzlwyrt3ptaopxbwq3j5xaa-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,underlyingTokens,url
      ✓ Expects pool id gq3kq6sctha3sncidfapve2d8sd27glm5qgzm5wegvzi-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,apyReward,rewardTokens,underlyingTokens,url
      ✓ Expects pool id 6nvhk1wcg7hjvalct7a5kjtjgi5xhsrgefbqvoagthbq-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,underlyingTokens,url
      ✓ Expects pool id 5inq4ub73mjkjkru7g9fsxk3bia2jnvp6mcyn6bezazt-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,underlyingTokens,url
      ✓ Expects pool id ucmugwsq37r5ivrqhbnxkvetcdg2rosn7xz3saimyqu-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,apyReward,rewardTokens,underlyingTokens,url
      ✓ Expects pool id 7eybhsxnluwtj5wkwmegdddjxcwrxiua2yufbwcqrnh2-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,underlyingTokens,url
      ✓ Expects pool id e7yyztr3uvdwnejnbsx8eoihfa8siqhhzwhvxdht7wov-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,apyReward,rewardTokens,underlyingTokens,url
      ✓ Expects pool id aqh7yg8kypxuhmdczqphkypkmitemy56glu5f8adgvd8-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,apyReward,rewardTokens,underlyingTokens,url
      ✓ Expects pool id 6dscjmdsagua1rf3j3ie4e977kbady8vcy8udzttj71i-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,apyReward,rewardTokens,underlyingTokens,url
      ✓ Expects pool id 4ej7jeo6ranuvwffuiatsagmyeo8ssyij8fi4kd7qhpw-solana to contain only allowed keys: pool,chain,project,symbol,apy,apyBase,apyReward,underlyingTokens,rewardTokens,poolMeta,url,apyBaseBorrow,apyRewardBorrow,totalSupplyUsd,totalBorrowUsd,ltv,borrowable,borrowFactor,debtCeilingUsd,mintedCoin,apyBase7d,apyRewardFake,apyRewardBorrowFake,il7d,volumeUsd1d,volumeUsd7d,apyBaseInception,tvlUsd and has: pool,chain,project,symbol,poolMeta,tvlUsd,apyBase,apyReward,rewardTokens,underlyingTokens,url
    Check apy data types
      ✓ Expects pool with id 8pq2bafbr9hdydhl2x8zobpznlrtf7r2y5xrbqg1jclg-solana to have at least one number apy field
      ✓ Expects pool with id 5mt6jfgvts46q836fzy1qnpftpbsj4c8khnbtpdqagnd-solana to have at least one number apy field
      ✓ Expects pool with id 7lszpwgyicvrqowbfnynwlzlwyrt3ptaopxbwq3j5xaa-solana to have at least one number apy field
      ✓ Expects pool with id gq3kq6sctha3sncidfapve2d8sd27glm5qgzm5wegvzi-solana to have at least one number apy field
      ✓ Expects pool with id 6nvhk1wcg7hjvalct7a5kjtjgi5xhsrgefbqvoagthbq-solana to have at least one number apy field
      ✓ Expects pool with id 5inq4ub73mjkjkru7g9fsxk3bia2jnvp6mcyn6bezazt-solana to have at least one number apy field
      ✓ Expects pool with id ucmugwsq37r5ivrqhbnxkvetcdg2rosn7xz3saimyqu-solana to have at least one number apy field
      ✓ Expects pool with id 7eybhsxnluwtj5wkwmegdddjxcwrxiua2yufbwcqrnh2-solana to have at least one number apy field (1 ms)
      ✓ Expects pool with id e7yyztr3uvdwnejnbsx8eoihfa8siqhhzwhvxdht7wov-solana to have at least one number apy field
      ✓ Expects pool with id aqh7yg8kypxuhmdczqphkypkmitemy56glu5f8adgvd8-solana to have at least one number apy field
      ✓ Expects pool with id 6dscjmdsagua1rf3j3ie4e977kbady8vcy8udzttj71i-solana to have at least one number apy field
      ✓ Expects pool with id 4ej7jeo6ranuvwffuiatsagmyeo8ssyij8fi4kd7qhpw-solana to have at least one number apy field
    Check tvl data type
      ✓ tvlUsd field of pool with id 8pq2bafbr9hdydhl2x8zobpznlrtf7r2y5xrbqg1jclg-solana should be number 
      ✓ tvlUsd field of pool with id 5mt6jfgvts46q836fzy1qnpftpbsj4c8khnbtpdqagnd-solana should be number 
      ✓ tvlUsd field of pool with id 7lszpwgyicvrqowbfnynwlzlwyrt3ptaopxbwq3j5xaa-solana should be number 
      ✓ tvlUsd field of pool with id gq3kq6sctha3sncidfapve2d8sd27glm5qgzm5wegvzi-solana should be number 
      ✓ tvlUsd field of pool with id 6nvhk1wcg7hjvalct7a5kjtjgi5xhsrgefbqvoagthbq-solana should be number 
      ✓ tvlUsd field of pool with id 5inq4ub73mjkjkru7g9fsxk3bia2jnvp6mcyn6bezazt-solana should be number 
      ✓ tvlUsd field of pool with id ucmugwsq37r5ivrqhbnxkvetcdg2rosn7xz3saimyqu-solana should be number 
      ✓ tvlUsd field of pool with id 7eybhsxnluwtj5wkwmegdddjxcwrxiua2yufbwcqrnh2-solana should be number 
      ✓ tvlUsd field of pool with id e7yyztr3uvdwnejnbsx8eoihfa8siqhhzwhvxdht7wov-solana should be number 
      ✓ tvlUsd field of pool with id aqh7yg8kypxuhmdczqphkypkmitemy56glu5f8adgvd8-solana should be number 
      ✓ tvlUsd field of pool with id 6dscjmdsagua1rf3j3ie4e977kbady8vcy8udzttj71i-solana should be number 
      ✓ tvlUsd field of pool with id 4ej7jeo6ranuvwffuiatsagmyeo8ssyij8fi4kd7qhpw-solana should be number 
    Check tokens data types
      ✓ rewardTokens field of pool with id 8pq2bafbr9hdydhl2x8zobpznlrtf7r2y5xrbqg1jclg-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id 8pq2bafbr9hdydhl2x8zobpznlrtf7r2y5xrbqg1jclg-solana should be an Array of strings
      ✓ rewardTokens field of pool with id 5mt6jfgvts46q836fzy1qnpftpbsj4c8khnbtpdqagnd-solana should be an Array of strings (1 ms)
      ✓ underlyingTokens field of pool with id 5mt6jfgvts46q836fzy1qnpftpbsj4c8khnbtpdqagnd-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id 7lszpwgyicvrqowbfnynwlzlwyrt3ptaopxbwq3j5xaa-solana should be an Array of strings
      ✓ rewardTokens field of pool with id gq3kq6sctha3sncidfapve2d8sd27glm5qgzm5wegvzi-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id gq3kq6sctha3sncidfapve2d8sd27glm5qgzm5wegvzi-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id 6nvhk1wcg7hjvalct7a5kjtjgi5xhsrgefbqvoagthbq-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id 5inq4ub73mjkjkru7g9fsxk3bia2jnvp6mcyn6bezazt-solana should be an Array of strings
      ✓ rewardTokens field of pool with id ucmugwsq37r5ivrqhbnxkvetcdg2rosn7xz3saimyqu-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id ucmugwsq37r5ivrqhbnxkvetcdg2rosn7xz3saimyqu-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id 7eybhsxnluwtj5wkwmegdddjxcwrxiua2yufbwcqrnh2-solana should be an Array of strings (1 ms)
      ✓ rewardTokens field of pool with id e7yyztr3uvdwnejnbsx8eoihfa8siqhhzwhvxdht7wov-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id e7yyztr3uvdwnejnbsx8eoihfa8siqhhzwhvxdht7wov-solana should be an Array of strings
      ✓ rewardTokens field of pool with id aqh7yg8kypxuhmdczqphkypkmitemy56glu5f8adgvd8-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id aqh7yg8kypxuhmdczqphkypkmitemy56glu5f8adgvd8-solana should be an Array of strings
      ✓ rewardTokens field of pool with id 6dscjmdsagua1rf3j3ie4e977kbady8vcy8udzttj71i-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id 6dscjmdsagua1rf3j3ie4e977kbady8vcy8udzttj71i-solana should be an Array of strings
      ✓ rewardTokens field of pool with id 4ej7jeo6ranuvwffuiatsagmyeo8ssyij8fi4kd7qhpw-solana should be an Array of strings
      ✓ underlyingTokens field of pool with id 4ej7jeo6ranuvwffuiatsagmyeo8ssyij8fi4kd7qhpw-solana should be an Array of strings
    Check other fields data types
      ✓ Expect other fields of pool with id 8pq2bafbr9hdydhl2x8zobpznlrtf7r2y5xrbqg1jclg-solana to match thier data types
      ✓ Expect other fields of pool with id 5mt6jfgvts46q836fzy1qnpftpbsj4c8khnbtpdqagnd-solana to match thier data types
      ✓ Expect other fields of pool with id 7lszpwgyicvrqowbfnynwlzlwyrt3ptaopxbwq3j5xaa-solana to match thier data types
      ✓ Expect other fields of pool with id gq3kq6sctha3sncidfapve2d8sd27glm5qgzm5wegvzi-solana to match thier data types
      ✓ Expect other fields of pool with id 6nvhk1wcg7hjvalct7a5kjtjgi5xhsrgefbqvoagthbq-solana to match thier data types
      ✓ Expect other fields of pool with id 5inq4ub73mjkjkru7g9fsxk3bia2jnvp6mcyn6bezazt-solana to match thier data types
      ✓ Expect other fields of pool with id ucmugwsq37r5ivrqhbnxkvetcdg2rosn7xz3saimyqu-solana to match thier data types
      ✓ Expect other fields of pool with id 7eybhsxnluwtj5wkwmegdddjxcwrxiua2yufbwcqrnh2-solana to match thier data types
      ✓ Expect other fields of pool with id e7yyztr3uvdwnejnbsx8eoihfa8siqhhzwhvxdht7wov-solana to match thier data types
      ✓ Expect other fields of pool with id aqh7yg8kypxuhmdczqphkypkmitemy56glu5f8adgvd8-solana to match thier data types
      ✓ Expect other fields of pool with id 6dscjmdsagua1rf3j3ie4e977kbady8vcy8udzttj71i-solana to match thier data types
      ✓ Expect other fields of pool with id 4ej7jeo6ranuvwffuiatsagmyeo8ssyij8fi4kd7qhpw-solana to match thier data types
    Check if pool has a rewardApy then rewardTokens must also exist
      ✓ The pool 8pq2bafbr9hdydhl2x8zobpznlrtf7r2y5xrbqg1jclg-solana is expected to have a rewardTokens field (1 ms)
      ✓ The pool 5mt6jfgvts46q836fzy1qnpftpbsj4c8khnbtpdqagnd-solana is expected to have a rewardTokens field
      ✓ The pool 7lszpwgyicvrqowbfnynwlzlwyrt3ptaopxbwq3j5xaa-solana is expected to have a rewardTokens field
      ✓ The pool gq3kq6sctha3sncidfapve2d8sd27glm5qgzm5wegvzi-solana is expected to have a rewardTokens field
      ✓ The pool 6nvhk1wcg7hjvalct7a5kjtjgi5xhsrgefbqvoagthbq-solana is expected to have a rewardTokens field
      ✓ The pool 5inq4ub73mjkjkru7g9fsxk3bia2jnvp6mcyn6bezazt-solana is expected to have a rewardTokens field
      ✓ The pool ucmugwsq37r5ivrqhbnxkvetcdg2rosn7xz3saimyqu-solana is expected to have a rewardTokens field
      ✓ The pool 7eybhsxnluwtj5wkwmegdddjxcwrxiua2yufbwcqrnh2-solana is expected to have a rewardTokens field
      ✓ The pool e7yyztr3uvdwnejnbsx8eoihfa8siqhhzwhvxdht7wov-solana is expected to have a rewardTokens field
      ✓ The pool aqh7yg8kypxuhmdczqphkypkmitemy56glu5f8adgvd8-solana is expected to have a rewardTokens field
      ✓ The pool 6dscjmdsagua1rf3j3ie4e977kbady8vcy8udzttj71i-solana is expected to have a rewardTokens field
      ✓ The pool 4ej7jeo6ranuvwffuiatsagmyeo8ssyij8fi4kd7qhpw-solana is expected to have a rewardTokens field
    Check if pool id already used by other project
      ✓ Print duplicated pool IDs and their existing projects

Test Suites: 1 passed, 1 total
Tests:       84 passed, 84 total
Snapshots:   0 total
Time:        0.194 s, estimated 1 s
Ran all test suites.

Nb of pools: 12
 

Sample pools: [
  {
    pool: '8pq2bafbr9hdydhl2x8zobpznlrtf7r2y5xrbqg1jclg-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'SOL',
    poolMeta: 'SOL in NOBODY market',
    tvlUsd: 1305091.5998409572,
    apyBase: 44.88339931633689,
    apyReward: 51.810849209551435,
    rewardTokens: [ 'C29ebrgYjYoJPMGPnPSGY1q3mMGk4iDSqnQeQQA7moon' ],
    underlyingTokens: [ 'So11111111111111111111111111111111111111112' ],
    url: 'https://sendit.fun/market/8pQ2BAfBr9hdYdhL2x8ZobpZnLRTf7r2y5XrBqg1JCLG'
  },
  {
    pool: '5mt6jfgvts46q836fzy1qnpftpbsj4c8khnbtpdqagnd-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'SOL',
    poolMeta: 'SOL in USELESS market',
    tvlUsd: 1109191.4621479423,
    apyBase: 99.71872558398357,
    apyReward: null,
    rewardTokens: [ 'Dz9mQ9NzkBcCsuGPFJ3r1bS4wgqKMHBPiVuniW8Mbonk' ],
    underlyingTokens: [ 'So11111111111111111111111111111111111111112' ],
    url: 'https://sendit.fun/market/5mT6JFgVtS46q836FzY1QnPFtpBsj4c8khNBtPDqAGND'
  },
  {
    pool: '7lszpwgyicvrqowbfnynwlzlwyrt3ptaopxbwq3j5xaa-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'NOBODY',
    poolMeta: 'NOBODY Vault',
    tvlUsd: 695404.7038581613,
    apyBase: 29.374280925721415,
    underlyingTokens: [ 'C29ebrgYjYoJPMGPnPSGY1q3mMGk4iDSqnQeQQA7moon' ],
    url: 'https://sendit.fun/earn'
  },
  {
    pool: 'gq3kq6sctha3sncidfapve2d8sd27glm5qgzm5wegvzi-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'SOL',
    poolMeta: 'SOL in Fartcoin  market',
    tvlUsd: 162426.05897085703,
    apyBase: 55.813233292910326,
    apyReward: null,
    rewardTokens: [ '9BB6NFEcjBCtnNLFko2FqVQBq8HHM13kCyYcdQbgpump' ],
    underlyingTokens: [ 'So11111111111111111111111111111111111111112' ],
    url: 'https://sendit.fun/market/GQ3kQ6sCthA3sNcidfAPvE2D8Sd27gLm5qGzM5wEGVzi'
  },
  {
    pool: '6nvhk1wcg7hjvalct7a5kjtjgi5xhsrgefbqvoagthbq-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'SOL',
    poolMeta: 'SOL Vault',
    tvlUsd: 55942.25561663484,
    apyBase: 63.70285696392865,
    underlyingTokens: [ 'So11111111111111111111111111111111111111112' ],
    url: 'https://sendit.fun/earn'
  },
  {
    pool: '5inq4ub73mjkjkru7g9fsxk3bia2jnvp6mcyn6bezazt-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'SOL',
    poolMeta: 'SOL Vault',
    tvlUsd: 38726.81713876932,
    apyBase: 49.769089843431416,
    underlyingTokens: [ 'So11111111111111111111111111111111111111112' ],
    url: 'https://sendit.fun/earn'
  },
  {
    pool: 'ucmugwsq37r5ivrqhbnxkvetcdg2rosn7xz3saimyqu-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'SOL',
    poolMeta: 'SOL in KORI market',
    tvlUsd: 34448.59175119424,
    apyBase: 13.187095973746333,
    apyReward: null,
    rewardTokens: [ 'HtTYHz1Kf3rrQo6AqDLmss7gq5WrkWAaXn3tupUZbonk' ],
    underlyingTokens: [ 'So11111111111111111111111111111111111111112' ],
    url: 'https://sendit.fun/market/uCMugWSq37R5iVRqhbNXkvETcDG2rosn7xz3saiMyqU'
  },
  {
    pool: '7eybhsxnluwtj5wkwmegdddjxcwrxiua2yufbwcqrnh2-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'SOL',
    poolMeta: 'SOL Vault',
    tvlUsd: 22754.77512935224,
    apyBase: 34.96397344020017,
    underlyingTokens: [ 'So11111111111111111111111111111111111111112' ],
    url: 'https://sendit.fun/earn'
  },
  {
    pool: 'e7yyztr3uvdwnejnbsx8eoihfa8siqhhzwhvxdht7wov-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'SOL',
    poolMeta: 'SOL in PUMP market',
    tvlUsd: 19667.891704404956,
    apyBase: 19.33707629652216,
    apyReward: null,
    rewardTokens: [ 'pumpCmXqMfrsAkQ5r49WcJnRayYRqmXz6ae8H7H9Dfn' ],
    underlyingTokens: [ 'So11111111111111111111111111111111111111112' ],
    url: 'https://sendit.fun/market/E7yYztR3uVDWNejNbSX8Eoihfa8siqhhzWHvxdHT7woV'
  },
  {
    pool: 'aqh7yg8kypxuhmdczqphkypkmitemy56glu5f8adgvd8-solana',
    chain: 'Solana',
    project: 'sendit',
    symbol: 'SOL',
    poolMeta: 'SOL in TRUMP market',
    tvlUsd: 11517.25548668189,
    apyBase: 0.05900340578602123,
    apyReward: null,
    rewardTokens: [ '6p6xgHyF7AeE6TZkSmFsko444wqoP15icUSqi2jfGiPN' ],
    underlyingTokens: [ 'So11111111111111111111111111111111111111112' ],
    url: 'https://sendit.fun/market/AqH7YG8kyPxUhmdczqphKYpkMiTemY56GLU5f8ADGvd8'
  }
]
```