### PR TITLE
fix: add balancer v3 correct type for base APR

### DIFF
--- a/src/adaptors/balancer-v3/index.ts
+++ b/src/adaptors/balancer-v3/index.ts
@@ -38,7 +38,9 @@ const getV3Pools = async (backendChain, chainString) => {
       const aprItems = pool.dynamicData.aprItems || [];
 
       const baseApr = aprItems
-        .filter((item) => item.type === 'SWAP_FEE' || item.type === 'IB_YIELD')
+        .filter(
+          (item) => item.type === 'IB_YIELD' || item.type === 'SWAP_FEE_24H'
+        )
         .reduce((sum, item) => sum + Number(item.apr), 0);
 
       const stakingApr = aprItems


### PR DESCRIPTION
## Description
This PR fixes the base APR calculation for **Balancer V3**, now using the correct type as parameter.

## Changes
- Updated the type from `SWAP_FEE` → `SWAP_FEE_24H`, as suggested in the Balancer V3 documentation.

## Additional Content
**Balancer V3 Documentation — Swap Fees:**
- [Balancer V3 Subgraph Docs: `swapFee24h`](https://docs.balancer.fi/concepts/protocol/swap-fees)
- The correct field to use for daily swap fee APR is `SWAP_FEE_24H`, which represents the 24h rolling fee capture, rather than the cumulative `SWAP_FEE`.
