### PR TITLE
add lagoon yield source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8263,7 +8263,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "devOptionnal": true
+      "devOptional": true
     },
     "node_modules/crc-32": {
       "version": "1.2.2",


### PR DESCRIPTION
I create this pull request in order to add the tracking of Lagoon vaults on various chain.

Methodology:
In order to track the performance of vaults we compare the evolution of the price per share between two updates submitted by an oracle, compute the evolution and then annualize it. 

We can do this computation other various of time but we are limited by the frequency of updates done by the oracle.
Some of our curators propose a valuation every 2-3 days some are more consistent with a daily update.

That's why we chose to display the weekly APR. It is a long enough period to include a decent amount of vaults and it is short enough to represent their current performance.

We also only select vault that we already reviewed ourselves and allow to be displayed on our front, hence the `isVisible` filter in the query.

For the reward APR, only the vaults that we reviewed can have an extra APR based on incentives or rewards.

I am happy to explain more if anything is unclear.
