### PR TITLE
add lagoon yield source

### DIFF
--- a/src/adaptors/lagoon/index.js
+++ b/src/adaptors/lagoon/index.js
@@ -37,6 +37,9 @@ const gqlQueries = {
           }
           state {
             totalAssetsUsd
+            weeklyApr {
+              linearNetAprWithoutExtraYields
+            }
           }
         }
       }


### PR DESCRIPTION
I create this pull request in order to track Lagoon vaults.

Methodology: In order to track the performance of vaults we compute the price per share evolution between two updates submitted by an oracle and then annualize it.

To do this computation we are limited by the frequency of updates done by the oracle. Some of our curators propose a valuation every 2-3 days some are more consistent with a daily update.

That's why we chose to display the weekly APR. It is a long enough period to include a decent amount of vaults and it is short enough to represent their current performance.

We also only select vault that we already reviewed ourselves and allow to be displayed on our front, hence the isVisible filter in the query.

I am happy to explain more if anything is unclear.


I created a new PR to make it cleaner.