### PR TITLE
Oxium Vaults on Sei Network

### DIFF
--- a/src/adaptors/oxium/index.js
+++ b/src/adaptors/oxium/index.js
@@ -1,0 +1,42 @@
+const utils = require('../utils');
+
+const CHAIN_MAPPING = {
+  1329: 'Sei',
+};
+
+const TOKEN_ADDRESSES = {
+  1329: {
+    'wsei': '0xE30feDd158A2e3b13e9badaeABaFc5516e95e8C7',
+  },
+};
+
+const poolsFunction = async () => {
+  const vaultsData = await utils.getData(
+    'https://api.mgvinfra.com/registry/whitelist?chainId=1329&version=2'
+  );
+
+  const pools = vaultsData.map(vault => {
+    const wseiAddress = TOKEN_ADDRESSES[vault.chainId]?.wsei;
+    return {
+      pool: `${vault.address}-${CHAIN_MAPPING[vault.chainId] || vault.chainId}`.toLowerCase(),
+      chain: utils.formatChain(CHAIN_MAPPING[vault.chainId] || 'Sei'),
+      project: 'oxium',
+      symbol: utils.formatSymbol(`${vault.market.base.symbol}-${vault.market.quote.symbol}`),
+      tvlUsd: vault.snapshot.TVL.total || 0,
+      apyBase: (vault.snapshot.base?.total || 0) + (vault.snapshot.strategy?.total || 0),
+      apyReward: vault.snapshot.rewards?.total || 0,
+      rewardTokens: vault.snapshot.rewards?.total > 0 ? [wseiAddress] : undefined,
+      underlyingTokens: [vault.market.base.address, vault.market.quote.address],
+      poolMeta: `${vault.strategyType} - ${vault.manager}`,
+      url: `https://app.oxium.xyz/earn/${vault.address}`
+    };
+  });
+
+  return pools.filter(pool => pool.tvlUsd >= 10000);
+};
+
+module.exports = {
+  timetravel: false,
+  apy: poolsFunction,
+  url: 'https://app.oxium.xyz/earn',
+};


### PR DESCRIPTION
Oxium vaults use on-chain orderbook market making strategies, which makes it difficult to calculate APY directly from on-chain data alone. The data is spread across multiple transactions, protocols, and off-chain data over time, so we use our own indexing API to handle this complexity.

Why we use our indexing API
- Vault APY comes from orderbook fills that happen across many transactions over time
- Calculating market making performance requires analyzing historical fill events and computing time-weighted returns
- While liquidity sits in the orderbook, unused funds are deployed to staking protocols for additional yield
- This creates multi-protocol positions that need data from orderbook events, staking positions, reward programs, and off-chain data

We run an hourly snapshot service that:
- Fetches TVL directly from vault contracts
- Analyzes historical orderbook performance
- Aggregates yields from lending positions and reward distributions
- Provides a clean APY breakdown