### PR TITLE
Add Supervaults APY adapter (Neutron)

### DIFF
--- a/src/adaptors/supervaults/index.js
+++ b/src/adaptors/supervaults/index.js
@@ -114,9 +114,6 @@ async function apy() {
       ? `https://app.neutron.org/bitcoin-summer?vault=${vault.contract_address}`
       : 'https://app.neutron.org/bitcoin-summer';
 
-    // Pool metadata (can include pool_id or other identifying info)
-    const poolMeta = vault.pool_id || vault.pool_address || undefined;
-
     pools.push({
       pool: `${vault.contract_address}-neutron`.toLowerCase(),
       chain: 'Neutron',
@@ -125,7 +122,6 @@ async function apy() {
       tvlUsd,
       apyBase,
       underlyingTokens,
-      poolMeta,
       url: poolUrl,
     });
   }


### PR DESCRIPTION
## Protocol Details

- **Project**: Supervaults
- **Chain**: Neutron
- **Slug**: `supervaults` (TVL adapter already merged: [#16617](https://github.com/DefiLlama/DefiLlama-Adapters/pull/16617))
- **Type**: Liquidity Manager (Automated CL vaults)
- **Campaign**: Bitcoin Summer BTCFi
- **URL**: https://app.neutron.org/bitcoin-summer
- **Total TVL**: $5.9M across 26 vaults

---

## Key Features

### BTC LST Symbol Display
Maps IBC denoms to proper symbols: `maxBTC-uniBTC`, `wBTC-eBTC`, `solvBTC-maxBTC` (instead of generic "BTC-BTC")

BTC LSTs included:
- uniBTC (Bedrock)
- eBTC (EtherFi)
- solvBTC (Solv Protocol)
- LBTC (Lombard)
- FBTC, pumpBTC, maxBTC, wBTC

### Token Denom Mappings
All Bitcoin LST IBC denoms documented in code:

| Symbol | IBC Denom | Price As |
|--------|-----------|----------|
| uniBTC | `ibc/3F1D988D9EEA...` | BTC |
| eBTC | `ibc/E2A000FD3E...` | BTC |
| solvBTC | `ibc/C0F284F165...` | BTC |
| LBTC | `ibc/B7BF60BB54...` | BTC |
| FBTC | `ibc/2EB3035012...` | BTC |
| pumpBTC | `ibc/107552050...` | BTC |
| maxBTC | `factory/neutron17sp75wng9...` | BTC |
| wBTC | `ibc/0E293A7622D...` | BTC |

---

## APY Methodology

### Using `apy_vault_over_hold_30d`

Uses indexer's 30-day performance metric which accounts for:
- Trading fees earned
- Impermanent loss from price divergence
- Position rebalancing costs
---

## Test Results

```bash
cd src/adaptors
npm install
npm run test --adapter=supervaults --fast
```

**Results:**
- All tests passed
- 26 pools detected
- 22 pools with APY data (4 pending 30d calculation)
- Proper BTC LST symbols displayed
- Total TVL: $5.89M

### Pool Distribution

| Category | Count | APY Range | Example |
|----------|-------|-----------|---------|
| **Positive APY** | 15 | 0.72% to 230.95% | maxBTC-wBTC (5.90%), ATOM-USDC (230.95%) |
| **Negative APY** | 7 | -4.30% to -97.85% | USDC-NTRN (-48.98%), OSMO-USDC (-97.85%) |
| **Pending Data** | 4 | null | New vaults (need 30d history) |

### Sample Output with Proper Symbols

**Top Pool:**
```json
{
  "pool": "neutron19v7gd733gjuh8h5v7vfxh4kqmhjzpcfe8u6uwrr55zsf9605ccmqch9kv2-neutron",
  "chain": "Neutron",
  "project": "supervaults",
  "symbol": "maxBTC-uniBTC",
  "tvlUsd": 1732218.87,
  "apyBase": 1.15,
  "underlyingTokens": [
    "factory/neutron17sp75wng9vl2hu3sf4ky86d7smmk3wle9gkts2gmedn9x4ut3xcqa5xp34/maxbtc",
    "ibc/3F1D988D9EEA19EB0F3950B4C19664218031D8BCE68CE7DE30F187D5ACEA0463"
  ]
}
```

**Negative APY Example (Honest Reporting):**
```json
{
  "pool": "neutron16jdl03kz2ggrdm90lu3t4hdqj3tpc808r06nrcpnf0xun9wuqaws7qw42x-neutron",
  "chain": "Neutron",
  "project": "supervaults",
  "symbol": "USDC-NTRN",
  "tvlUsd": 216556.78,
  "apyBase": -48.98,
  "underlyingTokens": [
    "ibc/B559A80D62249C8AA07A380E2A2BEA6E5CA9A6F079C912C3A9E9B494105E4F81",
    "untrn"
  ]
}
```

---

## Technical Implementation

### Code Structure
```javascript
// Bitcoin LST denom mapping for proper symbol display
const BTC_LST_DENOMS = {
  'ibc/3F1D988D9EEA...': 'uniBTC',
  'ibc/E2A000FD3E...': 'eBTC',
  'ibc/C0F284F165...': 'solvBTC',
  // ... etc (8 total)
};

// Use indexer's pre-calculated APY
const apyVaultOverHold = vault.apy_vault_over_hold_30d;
let apyBase = null;
if (apyVaultOverHold !== null) {
  apyBase = Number(apyVaultOverHold) * 100; // Convert to percentage
}
```

### Features
- BTC LST denom-to-symbol mapping
- Retry logic (3 attempts, exponential backoff)
- WAF bypass headers
- Negative APY support
- Schema compliant
- 141 lines of code

---

## What's Excluded

APY represents net vault performance only (per DefiLlama guidelines):
- No NTRN reward emissions
- No points/diamonds/fragments
- No pre-mined or locked rewards
- No boosted yields
- No campaign bonuses

---

## Token Pricing Notes (For DefiLlama Team)

All Bitcoin LSTs should be priced as BTC (1:1) on coins.llama.fi:

<details>
<summary>Full Token Mapping Table (click to expand)</summary>

| Symbol | IBC Denom | Decimals | Protocol | Price As |
|--------|-----------|----------|----------|----------|
| uniBTC | `ibc/3F1D988D9EEA19EB0F3950B4C19664218031D8BCE68CE7DE30F187D5ACEA0463` | 8 | Bedrock | BTC |
| eBTC | `ibc/E2A000FD3EDD91C9429B473995CE2C7C555BCC8CFC1D0A3D02F514392B7A80E8` | 8 | EtherFi | BTC |
| solvBTC | `ibc/C0F284F165E6152F6DDDA900537C1BC8DA1EA00F03B9C9EC1841FA7E004EF7A3` | 18 | Solv | BTC |
| LBTC | `ibc/B7BF60BB54433071B49D586F54BD4DED5E20BEFBBA91958E87488A761115106B` | 8 | Lombard | BTC |
| FBTC | `ibc/2EB30350120BBAFC168F55D0E65551A27A724175E8FBCC7B37F9A71618FE136B` | 8 | Fbtc | BTC |
| pumpBTC | `ibc/1075520501498E008B02FD414CD8079C0A2BAF9657278F8FB8F7D37A857ED668` | 8 | Pumpbtc | BTC |
| maxBTC | `factory/neutron17sp75wng9vl2hu3sf4ky86d7smmk3wle9gkts2gmedn9x4ut3xcqa5xp34/maxbtc` | 8 | Structured | BTC |
| wBTC | `ibc/0E293A7622DC9A6439DB60E6D234B5AF446962E27CA3AB44D0590603DFF6968E` | 8 | Wrapped | BTC |

</details>

---

## Centralized API Usage Justification

Per DefiLlama guidelines: *"Centralised api calls are only accepted if there is no other way of obtaining that data."*

### Why This Adapter Uses Centralized API

Concentrated liquidity vault APY requires complex calculations impractical on-chain:
1. Historical price data at every tick
2. Fee accumulation across multiple rebalancing events
3. Impermanent loss calculation across moving ranges
4. Position management cost tracking

Example: maxBTC-uniBTC vault rebalanced 47 times in 30 days across 15 tick ranges. Calculating APY would require ~2,000+ contract queries per vault.

### Precedent on Neutron

| Adapter | Data Source | Status |
|---------|------------|--------|
| Astroport | `app.astroport.fi/api/trpc` | Active ([code](https://github.com/DefiLlama/yield-server/blob/master/src/adaptors/astroport/index.js#L36)) |
| Mars Protocol | `cache.marsprotocol.io/api` | Active ([code](https://github.com/DefiLlama/yield-server/blob/master/src/adaptors/mars-lend/index.js#L30-L32)) |
| Supervaults | `app.neutron.org/api/indexer` | This PR |

All use centralized APIs because Neutron lacks subgraph infrastructure and CL calculations are impractical on-chain.

