### PR TITLE
Fix nest-credit adaptor: add APY fallback logic and required fields

### DIFF
--- a/src/adaptors/nest-credit/index.js
+++ b/src/adaptors/nest-credit/index.js
@@ -1,0 +1,66 @@
+// adapters/nest-vaults.js
+const utils = require('../utils');
+
+const DETAILS_URL = 'https://api.nest.credit/v1/vaults/details?live=true';
+const PLUME_CHAIN_KEY = 'plume';
+const PLUME_CHAIN_ID = 98866;
+
+const poolsFunction = async () => {
+  const res = await utils.getData(DETAILS_URL);
+  const vaults = Array.isArray(res?.data) ? res.data : [];
+
+  const pools = vaults.map((v) => {
+    const address = (v.vaultAddress || '').toLowerCase();
+
+    // Calculate APY with fallback: try 7-day first, then 30-day, then 0
+    const apy7dSrc = v?.apy?.rolling7d;
+    const apy30dSrc = v?.apy?.rolling30d;
+    let apyBase = 0; // Default to 0 if both are empty
+    
+    // Try 7-day APY first
+    if (apy7dSrc !== undefined && apy7dSrc !== null && apy7dSrc !== '') {
+      const apy7day = Number(apy7dSrc) * 100;
+      if (Number.isFinite(apy7day)) {
+        apyBase = apy7day;
+      }
+    }
+    // Fallback to 30-day APY if 7-day is empty
+    else if (apy30dSrc !== undefined && apy30dSrc !== null && apy30dSrc !== '') {
+      const apy30day = Number(apy30dSrc) * 100;
+      if (Number.isFinite(apy30day)) {
+        apyBase = apy30day;
+      }
+    }
+
+    // Prefer Plume-native underlying tokens
+    const underlyingTokens = (v.liquidAssets || [])
+      .filter((a) => a?.chainId === PLUME_CHAIN_ID && a?.contractAddress)
+      .map((a) => a.contractAddress.toLowerCase());
+
+    const pool = {
+      // ✅ pool = vault address (lowercased)
+      pool: address,
+      chain: utils.formatChain(PLUME_CHAIN_KEY),
+      project: 'nest-credit',
+      symbol: utils.formatSymbol(v.symbol || 'NEST'),
+      tvlUsd: Number(v.tvl || 0),
+      apyBase: apyBase,
+      url: `https://app.nest.credit/vault/${v.slug}`,
+    };
+    
+    // Set underlying tokens if available
+    if (underlyingTokens.length) {
+      pool.underlyingTokens = [...new Set(underlyingTokens)];
+    }
+
+    return pool;
+  });
+
+  return pools.filter((p) => p.pool && p.chain && Number.isFinite(p.tvlUsd));
+};
+
+module.exports = {
+  timetravel: false,
+  apy: poolsFunction,
+  url: 'https://app.nest.credit',
+};


### PR DESCRIPTION
- Set apyBase to 7-day APY with fallback to 30-day APY if empty
- Default apyBase to 0 only if both 7-day and 30-day APY are empty
- Add required 'project' field set to 'nest-credit'
- Remove invalid field names (apy30day, apy7day)
- Add live=true parameter to API URL
- Handle empty/missing APY values gracefully