### PR TITLE
Yield of SIR LPers

### DIFF
--- a/src/adaptors/sir/index.js
+++ b/src/adaptors/sir/index.js
@@ -163,6 +163,10 @@ async function fetchVaultsForChain(chainCfg) {
           symbol
           decimals
         }
+        debtToken {
+          symbol
+        }
+        leverageTier
         lockedLiquidity
         teaSupply
         reserveLPers
@@ -390,19 +394,21 @@ async function apy() {
 
     const vaultIdDecimal = parseInt(vault.id, 16);
     const poolId = `${sirAddress}-${vaultIdDecimal}-${chainKey}`;
+    const symbol = `${utils.formatSymbol(vault.collateralToken.symbol || "UNKNOWN")}-${utils.formatSymbol(vault.debtToken.symbol || "UNKNOWN")}`;
+    const poolMeta = `Leverage ratio: ${1+2**(Number(vault.leverageTier))}`;
     const url = `${chainCfg.urlPrefix}${vault.id}`;
 
     pools.push({
       pool: poolId,
       chain: chainName, // "Ethereum" or "Hyperliquid L1"
       project: "sir",
-      symbol: utils.formatSymbol(vault.collateralToken.symbol || "UNKNOWN"),
+      symbol,
       tvlUsd,
       apyBase: feesApy || 0,
       apyReward: sirRewardsApy || 0,
       rewardTokens: [sirAddress],
       underlyingTokens: [collateralAddress],
-      poolMeta: undefined,
+      poolMeta,
       url,
     });
   }


### PR DESCRIPTION
SIR pays large fees to LPers at a sparse cadence. If we use a 24h-window, it will result in 0% APY and some days spike to like 500% APY. Would it be Ok to use a 30-day window instead?

The name of the pools follows
${pool_address}-{pool-id}-{network}
because all pools and their LP token live in the same address as ERC1155 tokens.