### PR TITLE
Add Project 0 yield adapter

### DIFF
--- a/src/adaptors/project-0/index.js
+++ b/src/adaptors/project-0/index.js
@@ -1,0 +1,89 @@
+const axios = require('axios');
+const utils = require('../utils');
+
+const BASE_URL = 'https://base-api-public.mrgn.app';
+const API_ENDPOINT = `${BASE_URL}/v1/bank/metrics`;
+
+// API key provided by Project 0 team for DefiLlama
+// This will be set by the DefiLlama team
+const API_KEY = process.env.PROJECT_0_API_KEY;
+
+const getApy = async () => {
+
+  if (!API_KEY) {
+    console.error('project-0 adapter: PROJECT_0_API_KEY is required');
+    return [];
+  }
+
+  // Get current time in ISO 8601 format
+  const startTime = new Date().toISOString();
+  const endTime = '9999-12-31T23:59:59.999Z';
+  const groupAddress = '4qp6Fx6tnZkY5Wropq9wUYgtFxXKwE6viZxFHg3rdAG8';
+  const venue = 'P0';
+
+  let response;
+  try {
+    response = await axios.get(API_ENDPOINT, {
+      headers: {
+        'X-API-KEY': API_KEY,
+        'Content-Type': 'application/json',
+      },
+      params: {
+        start_time: startTime,
+        end_time: endTime,
+        group_address: groupAddress,
+        venue: venue,
+      },
+    });
+  } catch (e) {
+    console.error('project-0 adapter: failed to fetch bank metrics from API', e);
+    // Fail soft with empty list so the rest of the pipeline keeps working
+    return [];
+  }
+
+  // The API returns { success: true, data: [...], metadata: {...} }
+  if (!response.data || !response.data.success || !Array.isArray(response.data.data)) {
+    console.warn('project-0 adapter: unexpected API response shape', response.data);
+    return [];
+  }
+
+  const banks = response.data.data;
+
+  const bankApys = banks.map((bank) => {
+    // Use _current suffix fields for current USD valuations
+    const bankAddress = bank.bank_address;
+    const symbol = bank.symbol || 'UNKNOWN';
+    const mint = bank.mint;
+    const tvlUsd = Number(bank.tvl_usd_current) || 0;
+    const totalDepositsUsd = Number(bank.total_deposits_usd_current) || 0;
+    const totalBorrowsUsd = Number(bank.total_borrows_usd_current) || 0;
+    
+    // deposit_rate and borrow_rate are in decimal form (e.g., 0.05 for 5%)
+    // Convert to percentage by multiplying by 100
+    const depositRate = Number(bank.deposit_rate) || 0;
+    const borrowRate = Number(bank.borrow_rate) || 0;
+    const apyBase = depositRate * 100;
+    const apyBaseBorrow = borrowRate * 100;
+
+    return {
+      pool: `project-0-${bankAddress}`,
+      chain: 'Solana',
+      project: 'project-0',
+      symbol: utils.formatSymbol(symbol),
+      underlyingTokens: mint ? [mint] : [],
+      tvlUsd: tvlUsd,
+      url: mint ? `https://app.0.xyz/markets/${mint}` : 'https://app.0.xyz/',
+      apyBase: apyBase,
+      totalSupplyUsd: totalDepositsUsd,
+      totalBorrowUsd: totalBorrowsUsd,
+      apyBaseBorrow: apyBaseBorrow,
+    };
+  });
+
+  return bankApys;
+};
+
+module.exports = {
+  apy: getApy,
+  url: 'https://app.0.xyz/',
+};


### PR DESCRIPTION
Implement the project-0 adapter to fetch bank metrics from API. Please collect the api key from the telegram chat.


This PR adds a Project 0 yield adapter that fetches bank-level metrics
(deposit APY, borrow APY, and TVL in USD) from the Project 0 API.

Notes:
- Adapter fetches current metrics via the bank metrics endpoint
- TVL is calculated as available liquidity (deposits − borrows)
- API key is expected to be provided via environment variables

Environment variable:
- PROJECT_0_API_KEY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integration with a new Solana-based lending protocol. Users can now view comprehensive yield metrics, including APY rates, total supply amounts, and borrowing statistics from an additional data source. This expansion enhances platform functionality by providing access to more diversified financial information and detailed yield data across the broader blockchain ecosystem.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->