### PR TITLE
✨ Add DeFindex protocol adaptor

### DIFF
--- a/src/adaptors/defindex/index.js
+++ b/src/adaptors/defindex/index.js
@@ -1,0 +1,59 @@
+const { default: axios } = require('axios');
+
+const API_BASE_URL = new URL('https://api.defindex.io/');
+const DISCOVER_URL = new URL(`${API_BASE_URL}vault/discover?network=mainnet`);
+const STELLAR_DECIMALS = 7;
+
+async function fetchCoinData(assets) {
+  const keys = assets.map(a => `stellar:${a.toLowerCase()}`).join(',');
+  const { data } = await axios.get(`https://coins.llama.fi/prices/current/${keys}`);
+  // Returns { address_lower: { price, symbol, decimals, ... } }
+  return Object.entries(data.coins ?? {}).reduce((acc, [key, coin]) => {
+    const address = key.split(':')[1];
+    acc[address] = { price: coin.price ?? 0, symbol: coin.symbol ?? address.slice(0, 6) };
+    return acc;
+  }, {});
+}
+
+async function apy() {
+  const { data } = await axios.get(DISCOVER_URL);
+  const vaults = (data?.vaults ?? []).filter(
+    v => v.apy != null && v.totalManagedFunds?.length > 0
+  );
+
+  if (vaults.length === 0) return [];
+
+  const allAssets = [...new Set(vaults.flatMap(v => v.totalManagedFunds.map(f => f.asset)))];
+  const coinData = await fetchCoinData(allAssets);
+
+  return vaults.map(vault => {
+    const underlyingTokens = vault.totalManagedFunds.map(f => f.asset);
+
+    const tvlUsd = vault.totalManagedFunds.reduce((sum, fund) => {
+      const price = coinData[fund.asset.toLowerCase()]?.price ?? 0;
+      const amount = Number(fund.total_amount) / 10 ** STELLAR_DECIMALS;
+      return sum + amount * price;
+    }, 0);
+
+    const symbol = vault.totalManagedFunds
+      .map(f => coinData[f.asset.toLowerCase()]?.symbol ?? f.asset.slice(0, 6))
+      .join('-');
+
+    return {
+      pool: `${vault.address}-stellar`.toLowerCase(),
+      chain: 'Stellar',
+      project: 'defindex',
+      symbol,
+      tvlUsd,
+      apyBase: vault.apy,
+      underlyingTokens,
+      url: `${API_BASE_URL}/vault/${vault.address}`,
+    };
+  });
+}
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: API_BASE_URL,
+};

--- a/src/adaptors/defindex/index.js
+++ b/src/adaptors/defindex/index.js
@@ -1,13 +1,12 @@
 const { default: axios } = require('axios');
 
 const API_BASE_URL = 'https://api.defindex.io';
-const DISCOVER_URL = `${API_BASE_URL}/vault/discover?network=mainnet`;
 const STELLAR_DECIMALS = 7;
+const START_TIMESTAMP = 1747281600;
 
 async function fetchCoinData(assets) {
   const keys = assets.map(a => `stellar:${a.toLowerCase()}`).join(',');
   const { data } = await axios.get(`https://coins.llama.fi/prices/current/${keys}`);
-  // Returns { address_lower: { price, symbol, decimals, ... } }
   return Object.entries(data.coins ?? {}).reduce((acc, [key, coin]) => {
     const address = key.split(':')[1];
     acc[address] = {
@@ -19,47 +18,43 @@ async function fetchCoinData(assets) {
   }, {});
 }
 
-async function apy() {
-  const { data } = await axios.get(DISCOVER_URL);
-  const vaults = (data?.vaults ?? []).filter(
-    v => v.apy != null && v.totalManagedFunds?.length > 0
+async function apy(timestamp = null) {
+  const ts = timestamp ?? Math.floor(Date.now() / 1000);
+
+  const { data: strategies } = await axios.get(
+    `${API_BASE_URL}/strategies/apy?timestamp=${ts}&network=mainnet`,
   );
 
-  if (vaults.length === 0) return [];
+  if (!strategies.length) return [];
 
-  const allAssets = [...new Set(vaults.flatMap(v => v.totalManagedFunds.map(f => f.asset)))];
+  const allAssets = [...new Set(strategies.map(s => s.asset))];
   const coinData = await fetchCoinData(allAssets);
 
-  return vaults.map(vault => {
-    const underlyingTokens = vault.totalManagedFunds.map(f => f.asset);
+  return strategies.flatMap(strategy => {
+    const coin = coinData[strategy.asset.toLowerCase()];
+    const decimals = coin?.decimals ?? strategy.assetDecimals ?? STELLAR_DECIMALS;
+    const price = coin?.price ?? 0;
+    const tvlUsd = Math.max(0, (Number(strategy.tvl) / 10 ** decimals) * price);
+    if (tvlUsd < 1) return [];
 
-    const tvlUsd = vault.totalManagedFunds.reduce((sum, fund) => {
-      const coin = coinData[fund.asset.toLowerCase()];
-      const price = coin?.price ?? 0;
-      const decimals = coin?.decimals ?? STELLAR_DECIMALS;
-      const amount = Number(fund.total_amount) / 10 ** decimals;
-      return sum + amount * price;
-    }, 0);
+    const symbol = coin?.symbol ?? strategy.assetSymbol ?? strategy.asset.slice(0, 6);
 
-    const symbol = vault.totalManagedFunds
-      .map(f => coinData[f.asset.toLowerCase()]?.symbol ?? f.asset.slice(0, 6))
-      .join('-');
-
-    return {
-      pool: `${vault.address}-stellar`.toLowerCase(),
+    return [{
+      pool: `${strategy.address}-stellar`.toLowerCase(),
       chain: 'Stellar',
       project: 'defindex',
       symbol,
       tvlUsd,
-      apyBase: vault.apy,
-      underlyingTokens,
-      url: `${API_BASE_URL}/vault/${vault.address}`,
-    };
+      apyBase: strategy.apy7d,
+      underlyingTokens: [strategy.asset],
+      url: `https://stellar.expert/explorer/public/contract/${strategy.address}`,
+    }];
   });
 }
 
 module.exports = {
-  timetravel: false,
+  timetravel: true,
+  start: START_TIMESTAMP,
   apy,
-  url: API_BASE_URL,
+  url: "https://www.defindex.io/strategies",
 };

--- a/src/adaptors/defindex/index.js
+++ b/src/adaptors/defindex/index.js
@@ -1,7 +1,7 @@
 const { default: axios } = require('axios');
 
-const API_BASE_URL = new URL('https://api.defindex.io/');
-const DISCOVER_URL = new URL(`${API_BASE_URL}vault/discover?network=mainnet`);
+const API_BASE_URL = 'https://api.defindex.io';
+const DISCOVER_URL = `${API_BASE_URL}/vault/discover?network=mainnet`;
 const STELLAR_DECIMALS = 7;
 
 async function fetchCoinData(assets) {
@@ -10,7 +10,11 @@ async function fetchCoinData(assets) {
   // Returns { address_lower: { price, symbol, decimals, ... } }
   return Object.entries(data.coins ?? {}).reduce((acc, [key, coin]) => {
     const address = key.split(':')[1];
-    acc[address] = { price: coin.price ?? 0, symbol: coin.symbol ?? address.slice(0, 6) };
+    acc[address] = {
+      price: coin.price ?? 0,
+      symbol: coin.symbol ?? address.slice(0, 6),
+      decimals: coin.decimals ?? STELLAR_DECIMALS,
+    };
     return acc;
   }, {});
 }
@@ -30,8 +34,10 @@ async function apy() {
     const underlyingTokens = vault.totalManagedFunds.map(f => f.asset);
 
     const tvlUsd = vault.totalManagedFunds.reduce((sum, fund) => {
-      const price = coinData[fund.asset.toLowerCase()]?.price ?? 0;
-      const amount = Number(fund.total_amount) / 10 ** STELLAR_DECIMALS;
+      const coin = coinData[fund.asset.toLowerCase()];
+      const price = coin?.price ?? 0;
+      const decimals = coin?.decimals ?? STELLAR_DECIMALS;
+      const amount = Number(fund.total_amount) / 10 ** decimals;
       return sum + amount * price;
     }, 0);
 

--- a/src/adaptors/defindex/index.js
+++ b/src/adaptors/defindex/index.js
@@ -1,4 +1,5 @@
 const { default: axios } = require('axios');
+const utils = require('../utils');
 
 const API_BASE_URL = 'https://api.defindex.io';
 const STELLAR_DECIMALS = 7;
@@ -49,7 +50,7 @@ async function apy(timestamp = null) {
       underlyingTokens: [strategy.asset],
       url: `https://stellar.expert/explorer/public/contract/${strategy.address}`,
     }];
-  });
+  }).filter(p => utils.keepFinite(p));
 }
 
 module.exports = {

--- a/src/adaptors/defindex/index.js
+++ b/src/adaptors/defindex/index.js
@@ -5,9 +5,21 @@ const API_BASE_URL = 'https://api.defindex.io';
 const STELLAR_DECIMALS = 7;
 const START_TIMESTAMP = 1747281600;
 
+async function getWithRetry(url, retries = 3) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await axios.get(url);
+    } catch (e) {
+      if (attempt === retries) throw e;
+      await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, attempt)));
+    }
+  }
+}
+
 async function fetchCoinData(assets) {
+  if (!assets.length) return {};
   const keys = assets.map(a => `stellar:${a.toLowerCase()}`).join(',');
-  const { data } = await axios.get(`https://coins.llama.fi/prices/current/${keys}`);
+  const { data } = await getWithRetry(`https://coins.llama.fi/prices/current/${keys}`);
   return Object.entries(data.coins ?? {}).reduce((acc, [key, coin]) => {
     const address = key.split(':')[1];
     acc[address] = {
@@ -22,7 +34,7 @@ async function fetchCoinData(assets) {
 async function apy(timestamp = null) {
   const ts = timestamp ?? Math.floor(Date.now() / 1000);
 
-  const { data: strategies } = await axios.get(
+  const { data: strategies } = await getWithRetry(
     `${API_BASE_URL}/strategies/apy?timestamp=${ts}&network=mainnet`,
   );
 
@@ -48,7 +60,7 @@ async function apy(timestamp = null) {
       tvlUsd,
       apyBase: strategy.apy7d,
       underlyingTokens: [strategy.asset],
-      url: `https://stellar.expert/explorer/public/contract/${strategy.address}`,
+      url: `https://www.defindex.io/strategies`,
     }];
   }).filter(p => utils.keepFinite(p));
 }
@@ -57,5 +69,5 @@ module.exports = {
   timetravel: true,
   start: START_TIMESTAMP,
   apy,
-  url: "https://www.defindex.io/strategies",
+  url: 'https://www.defindex.io/strategies',
 };


### PR DESCRIPTION
## Summary

- Adds yield adaptor for [DeFindex](https://defindex.io), a yield aggregator built on Stellar
- Fetches strategy data from the DeFindex API (`/strategies/apy?timestamp=<ts>&network=mainnet`)
- Computes TVL in USD using DefiLlama's coin price API for Stellar assets
- Returns APY (7d), TVL, underlying tokens, and pool metadata per strategy
- Enables timetravel support with `start` timestamp (`2025-05-15`)
- Filters out pools with `tvlUsd < 1`

## Test plan

- [x] Run `npm run test --adapter=defindex` and verify strategy data is returned
- [x] Confirm `tvlUsd` and `apyBase` are non-zero for active strategies
- [x] Confirm `chain` is `"Stellar"` and `pool` IDs are unique
- [x] Confirm timetravel works by passing a historical timestamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Defindex strategies on Stellar — view 7-day APY, underlying asset symbols, and TVL in USD with direct links to each strategy.
  * Historical (time-travel) APY retrieval enabled so past rates can be queried.
  * Very small pools (TVL < $1) are omitted to keep listings relevant and clean.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2479)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->