### PR TITLE
Add stakeTHENA erc4626 vault on BSC

### DIFF
--- a/src/adaptors/guru-network-classic/index.js
+++ b/src/adaptors/guru-network-classic/index.js
@@ -13,29 +13,37 @@ const wrappers = [
   },
 ];
 
-const main = async () => {
-  const prices = (
-    await axios.get(
-      `https://coins.llama.fi/prices/current/${wrappers.map((w) => `${w.underlyingChain}:${w.underlyingToken}`).join(',')}`
-    )
-  ).data.coins;
-  const infos = await Promise.all(
-    wrappers.map((w) => utils.getERC4626Info(w.address, w.underlyingChain))
+const main = async (timestamp = null) => {
+  const priceKeys = wrappers
+    .map((w) => `${w.underlyingChain}:${w.underlyingToken}`)
+    .join(',');
+  const { data } = await axios.get(
+    `https://coins.llama.fi/prices/current/${priceKeys}`,
+    { timeout: 10_000 }
   );
-  return infos.map((info, i) => {
-    const token = `${wrappers[i].underlyingChain}:${wrappers[i].underlyingToken}`;
-    return {
-      pool: info.pool,
-      chain: wrappers[i].underlyingChain,
-      project: PROJECT,
-      symbol: wrappers[i].symbol,
-      tvlUsd: (info.tvl / 10 ** prices[token].decimals) * prices[token].price,
-      apyBase: info.apyBase,
-      underlyingTokens: [wrappers[i].underlyingToken],
-      url: wrappers[i].poolUrl
-    };
-  });
-};
+  const prices = data?.coins ?? {};
+   const infos = await Promise.all(
+     wrappers.map((w) => utils.getERC4626Info(w.address, w.underlyingChain))
+   );
+  return infos
+    .map((info, i) => {
+     const token = `${wrappers[i].underlyingChain}:${wrappers[i].underlyingToken}`;
+    const priceEntry = prices[token];
+    if (!priceEntry || priceEntry.price == null || priceEntry.decimals == null) {
+      return null;
+    }
+     return {
+       pool: info.pool,
+       chain: wrappers[i].underlyingChain,
+       project: PROJECT,
+       symbol: wrappers[i].symbol,
+      tvlUsd: (Number(info.tvl) / 10 ** priceEntry.decimals) * priceEntry.price,
+       apyBase: info.apyBase,
+       underlyingTokens: [wrappers[i].underlyingToken],
+       url: wrappers[i].poolUrl
+     };
+  }).filter(Boolean);
+ };
 
 module.exports = {
   timetravel: true,

--- a/src/adaptors/guru-network-classic/index.js
+++ b/src/adaptors/guru-network-classic/index.js
@@ -38,7 +38,7 @@ const main = async () => {
 };
 
 module.exports = {
-  timetravel: false,
+  timetravel: true,
   apy: main,
   // url: 'https://example.com/pools', // Link to page with pools (Only required if you do not provide url's for each pool),
 };

--- a/src/adaptors/guru-network-classic/index.js
+++ b/src/adaptors/guru-network-classic/index.js
@@ -1,0 +1,44 @@
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+const { default: axios } = require('axios');
+
+const PROJECT = 'guru-network-classic'
+const wrappers = [
+  {
+    address: '0x5b8ce6d591c914a56cb019b3decb63ede22708c8',
+    symbol: 'stakeTHENA',
+    underlyingToken: '0xafbe3b8b0939a5538de32f7752a78e08c8492295',
+    underlyingChain: 'bsc',
+    poolUrl: 'https://eliteness.network/ethena'
+  },
+];
+
+const main = async () => {
+  const prices = (
+    await axios.get(
+      `https://coins.llama.fi/prices/current/${wrappers.map((w) => `${w.underlyingChain}:${w.underlyingToken}`).join(',')}`
+    )
+  ).data.coins;
+  const infos = await Promise.all(
+    wrappers.map((w) => utils.getERC4626Info(w.address, w.underlyingChain))
+  );
+  return infos.map((info, i) => {
+    const token = `${wrappers[i].underlyingChain}:${wrappers[i].underlyingToken}`;
+    return {
+      pool: info.pool,
+      chain: wrappers[i].underlyingChain,
+      project: PROJECT,
+      symbol: wrappers[i].symbol,
+      tvlUsd: (info.tvl / 10 ** prices[token].decimals) * prices[token].price,
+      apyBase: info.apyBase,
+      underlyingTokens: [wrappers[i].underlyingToken],
+      url: wrappers[i].poolUrl
+    };
+  });
+};
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+  // url: 'https://example.com/pools', // Link to page with pools (Only required if you do not provide url's for each pool),
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Guru Network Classic vaults: the app now discovers ERC-4626-based vault wrappers, displays per-vault APY and TVL (priced in USD using live token prices), lists underlying token addresses, and links to each vault's details page. Timetravel-enabled historical APY/TVL queries supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->