### PR TITLE
feat(metrom-adapter): add support for megaeth and pool meta information

### DIFF
--- a/src/adaptors/metrom/index.ts
+++ b/src/adaptors/metrom/index.ts
@@ -1,4 +1,4 @@
-const { getData, formatChain, formatSymbol, keepFinite } = require('../utils');
+const { getData, formatChain, keepFinite } = require('../utils');
 
 const PROJECT = 'metrom';
 const METROM_REWARDS_URL = 'https://app.metrom.xyz/en?type=rewards';
@@ -247,7 +247,7 @@ async function processCampaign(
     }
     case 'liquity-v2-debt': {
       return {
-        symbol: formatSymbol(campaign.target.collateral.symbol),
+        symbol: campaign.target.collateral.symbol,
         underlyingTokens: [campaign.target.collateral.address],
         poolMeta: humanizeTargetProtocol('Borrow on', campaign.target.brand),
       };
@@ -269,14 +269,14 @@ async function processCampaign(
     }
     case 'aave-v3-supply': {
       return {
-        symbol: formatSymbol(campaign.target.collateral.symbol),
+        symbol: campaign.target.collateral.symbol,
         underlyingTokens: [campaign.target.collateral.address],
         poolMeta: humanizeTargetProtocol('Lend on', campaign.target.brand),
       };
     }
     case 'aave-v3-borrow': {
       return {
-        symbol: formatSymbol(campaign.target.collateral.symbol),
+        symbol: campaign.target.collateral.symbol,
         underlyingTokens: [campaign.target.collateral.address],
         poolMeta: humanizeTargetProtocol('Borrow on', campaign.target.brand),
       };
@@ -315,7 +315,7 @@ async function processCampaign(
     }
     case 'erc4626-vault': {
       return {
-        symbol: formatSymbol(campaign.target.vault.symbol),
+        symbol: campaign.target.vault.symbol,
         underlyingTokens: [campaign.target.vault.asset],
         poolMeta: humanizeTargetProtocol(
           'Deposit to',

--- a/src/adaptors/metrom/index.ts
+++ b/src/adaptors/metrom/index.ts
@@ -257,7 +257,7 @@ async function processCampaign(
         symbol: campaign.target.collateral.symbol,
         underlyingTokens: [campaign.target.collateral.address],
         poolMeta: humanizeTargetProtocol(
-          'Deposit to stability pool on',
+          'Stability pool on',
           campaign.target.brand
         ),
       };

--- a/src/adaptors/metrom/index.ts
+++ b/src/adaptors/metrom/index.ts
@@ -1,3 +1,5 @@
+import { formatSymbol } from '../utils';
+
 const { getData, formatChain, keepFinite } = require('../utils');
 
 const PROJECT = 'metrom';
@@ -26,8 +28,8 @@ const CHAIN_TYPE_AND_NAMES: ByChainTypeAndId<string> = {
     42_161: 'Arbitrum',
     9_745: 'Plasma',
     5_464: 'Saga',
-    56: 'Bsc',
     747_474: 'Katana',
+    4_326: 'MegaETH',
   },
   aptos: {
     1: 'Aptos',
@@ -50,6 +52,7 @@ interface BaseTarget {
 interface AmmPoolLiquidityTarget extends BaseTarget {
   type: 'amm-pool-liquidity';
   id: string;
+  dex: string;
   tokens: Token[];
   usdTvl: number;
 }
@@ -218,6 +221,7 @@ interface ProcessedCampaign {
   apyBase?: number;
   apyReward?: number;
   rewardTokens?: string[];
+  poolMeta: string;
 }
 
 async function processCampaign(
@@ -228,13 +232,24 @@ async function processCampaign(
       return {
         symbol: campaign.target.tokens.map((token) => token.symbol).join(' - '),
         underlyingTokens: campaign.target.tokens.map((token) => token.address),
+        poolMeta: humanizeTargetProtocol('Pool on', campaign.target.dex),
       };
     }
-    case 'liquity-v2-debt':
+    case 'liquity-v2-debt': {
+      return {
+        symbol: formatSymbol(campaign.target.collateral.symbol),
+        underlyingTokens: [campaign.target.collateral.address],
+        poolMeta: humanizeTargetProtocol('Borrow on', campaign.target.brand),
+      };
+    }
     case 'liquity-v2-stability-pool': {
       return {
         symbol: campaign.target.collateral.symbol,
         underlyingTokens: [campaign.target.collateral.address],
+        poolMeta: humanizeTargetProtocol(
+          'Deposit to stability pool on',
+          campaign.target.brand
+        ),
       };
     }
     case 'gmx-v1-liquidity': {
@@ -242,12 +257,25 @@ async function processCampaign(
       // campaigns, address this later on
       return null;
     }
-    case 'aave-v3-supply':
-    case 'aave-v3-borrow':
+    case 'aave-v3-supply': {
+      return {
+        symbol: formatSymbol(campaign.target.collateral.symbol),
+        underlyingTokens: [campaign.target.collateral.address],
+        poolMeta: humanizeTargetProtocol('Lend on', campaign.target.brand),
+      };
+    }
+    case 'aave-v3-borrow': {
+      return {
+        symbol: formatSymbol(campaign.target.collateral.symbol),
+        underlyingTokens: [campaign.target.collateral.address],
+        poolMeta: humanizeTargetProtocol('Borrow on', campaign.target.brand),
+      };
+    }
     case 'aave-v3-net-supply': {
       return {
         symbol: campaign.target.collateral.symbol,
         underlyingTokens: [campaign.target.collateral.address],
+        poolMeta: humanizeTargetProtocol('Net lend on', campaign.target.brand),
       };
     }
     case 'turtle': {
@@ -265,12 +293,14 @@ async function processCampaign(
         underlyingTokens: getTurtleUnderlyingTokens(opportunity),
         url: opportunity?.url,
         ...getTurtleApyFields(incentives, campaign.apr),
+        poolMeta: humanizeTargetProtocol('Deposit to', campaign.target.name),
       };
     }
     case 'yield-seeker': {
       return {
         symbol: 'USDC',
         underlyingTokens: [BASE_USDC],
+        poolMeta: 'Deposit',
       };
     }
     default: {
@@ -364,4 +394,11 @@ function getCampaignApyFields(
         rewardTokens: rewards.map((reward) => reward.address),
       }
     : { apy: campaign.apr };
+}
+
+function humanizeTargetProtocol(action: string, protocolSlug: string): string {
+  return `${action} ${protocolSlug
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')}`;
 }

--- a/src/adaptors/metrom/index.ts
+++ b/src/adaptors/metrom/index.ts
@@ -26,7 +26,7 @@ const CHAIN_TYPE_AND_NAMES: ByChainTypeAndId<string> = {
     42_161: 'Arbitrum',
     9_745: 'Plasma',
     5_464: 'Saga',
-    56: 'BSC',
+    56: 'Bsc',
     747_474: 'Katana',
   },
   aptos: {
@@ -258,7 +258,10 @@ async function processCampaign(
         opportunity?.incentives || campaign.target.incentives || [];
 
       return {
-        symbol: (opportunity?.name || campaign.target.name).replace(/^Katana\s+/i, ''),
+        symbol: (opportunity?.name || campaign.target.name).replace(
+          /^Katana\s+/i,
+          ''
+        ),
         underlyingTokens: getTurtleUnderlyingTokens(opportunity),
         url: opportunity?.url,
         ...getTurtleApyFields(incentives, campaign.apr),

--- a/src/adaptors/metrom/index.ts
+++ b/src/adaptors/metrom/index.ts
@@ -1,6 +1,4 @@
-import { formatSymbol } from '../utils';
-
-const { getData, formatChain, keepFinite } = require('../utils');
+const { getData, formatChain, formatSymbol, keepFinite } = require('../utils');
 
 const PROJECT = 'metrom';
 const METROM_REWARDS_URL = 'https://app.metrom.xyz/en?type=rewards';

--- a/src/adaptors/metrom/index.ts
+++ b/src/adaptors/metrom/index.ts
@@ -30,6 +30,7 @@ const CHAIN_TYPE_AND_NAMES: ByChainTypeAndId<string> = {
     5_464: 'Saga',
     747_474: 'Katana',
     4_326: 'MegaETH',
+    1: 'Ethereum',
   },
   aptos: {
     1: 'Aptos',
@@ -111,6 +112,16 @@ interface YieldSeekerTarget extends BaseTarget {
   type: 'yield-seeker';
 }
 
+interface Erc4626Target extends BaseTarget {
+  type: 'erc4626-vault';
+  brand: string;
+  vault: {
+    name: string;
+    symbol: string;
+    asset: string;
+  };
+}
+
 interface Reward extends Token {
   amount: string;
   remaining: string;
@@ -133,7 +144,8 @@ interface Campaign {
     | AaveV3BorrowTarget
     | AaveV3NetSupplyTarget
     | TurtleTarget
-    | YieldSeekerTarget;
+    | YieldSeekerTarget
+    | Erc4626Target;
   rewards?: Rewards;
   usdTvl?: number;
   apr?: number;
@@ -301,6 +313,16 @@ async function processCampaign(
         symbol: 'USDC',
         underlyingTokens: [BASE_USDC],
         poolMeta: 'Deposit',
+      };
+    }
+    case 'erc4626-vault': {
+      return {
+        symbol: formatSymbol(campaign.target.vault.symbol),
+        underlyingTokens: [campaign.target.vault.asset],
+        poolMeta: humanizeTargetProtocol(
+          'Deposit to',
+          campaign.target.vault.name
+        ),
       };
     }
     default: {

--- a/src/adaptors/metrom/index.ts
+++ b/src/adaptors/metrom/index.ts
@@ -416,9 +416,12 @@ function getCampaignApyFields(
     : { apy: campaign.apr };
 }
 
-function humanizeTargetProtocol(action: string, protocolSlug: string): string {
-  return `${action} ${protocolSlug
-    .split('-')
+function humanizeTargetProtocol(action: string, protocolSlug?: string): string {
+  const normalizedSlug = protocolSlug?.trim();
+  if (!normalizedSlug) return action;
+
+  return `${action} ${normalizedSlug
+    .split(/[-_]/)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ')}`;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the MegaETH blockchain.
  * Campaigns now include a visible "pool" metadata field for better context.
  * Display support for ERC‑4626 vaults, showing vault name and underlying asset.
  * Improved protocol/action labels for Aave, Liquity v2, DEX pools, Turtle, and yield-seeker campaigns.
  * Normalized token symbol display (removes redundant prefixes) and standardized protocol naming for display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->