### PR TITLE
feat: add HypeZion Finance yield adapter

### DIFF
--- a/src/adaptors/hypezion-finance/index.js
+++ b/src/adaptors/hypezion-finance/index.js
@@ -1,0 +1,66 @@
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+/**
+ * HypeZion Finance — Yield Adapter for DefiLlama
+ *
+ * Exposes the shzUSD staking pool (ERC-4626):
+ *   - Users stake hzUSD → receive shzUSD shares
+ *   - Yield from Kinetiq + Valantis sources is concentrated to shzUSD stakers
+ *   - APY calculated on-chain via 14-day rolling window
+ *
+ * All data fetched via single on-chain call to getProtocolYield().
+ */
+
+// HypeZionExchangeInformation proxy (Hyperliquid Mainnet)
+const EXCHANGE_INFO = '0x9286ABAC7c29e8A183155E961a4E4BBA2E162c7A';
+
+// StakedHzUSD (shzUSD) vault
+const STAKED_HZUSD = '0xce01a9B9bc08f0847fb745044330Eff1181360Cd';
+
+// hzUSD token
+const HZUSD = '0x6E2ade6FFc94d24A81406285c179227dfBFc97CE';
+
+const CHAIN = 'hyperliquid';
+
+const abis = {
+  getProtocolYield:
+    'function getProtocolYield() view returns (tuple(uint256 stabilityPoolAPY, uint256 totalStakedHzUSD, uint256 stakedTVLInUSD))',
+};
+
+const poolsFunction = async () => {
+  const yieldData = (
+    await sdk.api.abi.call({
+      target: EXCHANGE_INFO,
+      abi: abis.getProtocolYield,
+      chain: CHAIN,
+    })
+  ).output;
+
+  const stabilityPoolAPY = Number(yieldData.stabilityPoolAPY);
+  const stakedTVLInUSD = Number(yieldData.stakedTVLInUSD) / 1e18;
+
+  // Convert basis points to percentage (10000 bps = 100%)
+  const apyBase = stabilityPoolAPY / 100;
+
+  const pools = [
+    {
+      pool: `${STAKED_HZUSD}-${CHAIN}`.toLowerCase(),
+      chain: utils.formatChain(CHAIN),
+      project: 'hypezion-finance',
+      symbol: utils.formatSymbol('shzUSD'),
+      tvlUsd: stakedTVLInUSD,
+      apyBase,
+      underlyingTokens: [HZUSD],
+      url: 'https://app.hypezion.com/earn',
+    },
+  ];
+
+  return pools.filter((p) => utils.keepFinite(p));
+};
+
+module.exports = {
+  timetravel: false,
+  apy: poolsFunction,
+  url: 'https://app.hypezion.com',
+};


### PR DESCRIPTION
## HypeZion Finance — Yield Adapter

**Protocol**: Structured product protocol on Hyperliquid L1.
**Chain**: Hyperliquid
**Pool**: shzUSD Staking (ERC-4626 vault)

### How the pool works
- Users stake hzUSD → receive shzUSD shares
- Yield generated organically from protocol reserves deployed across
  Kinetiq kHYPE, Valantis LP pools, and direct stHYPE staking
- All yield concentrated to shzUSD stakers via concentration multiplier
- APY computed on-chain via 14-day rolling share-price window

### Adapter logic
- Single on-chain call to `getProtocolYield()` returns:
  `(stabilityPoolAPY: bps, totalStakedHzUSD, stakedTVLInUSD)`
- `apyBase = bps / 100` (organic protocol yield, not incentive → `apyBase` not `apyReward`)
- `tvlUsd = stakedTVLInUSD / 1e18` (hzUSD is $1-pegged, so USD value = staked amount)

### Local test output
| field | value |
|---|---|
| pool | 0xce01a9b9bc08f0847fb745044330eff1181360cd-hyperliquid |
| chain | Hyperliquid |
| project | hypezion-finance |
| symbol | shzUSD |
| tvlUsd | $909.46 |
| apyBase | 34.3% |
| underlyingTokens | [0x6E2ade6FFc94d24A81406285c179227dfBFc97CE] (hzUSD) |
| url | https://app.hypezion.com/earn |

### Related PRs
- TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/pull/18573
- Price adapter: https://github.com/DefiLlama/defillama-server/pull/11672


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HypeZion Finance protocol support on the Hyperliquid chain with comprehensive yield tracking and monitoring capabilities
  * Enabled real-time tracking of shzUSD staking vault performance metrics, including current APY rates and total value locked (TVL) data
  * Integrated stability pool yield information to help users effectively monitor staked asset valuations and potential earnings from the protocol

<!-- end of auto-generated comment: release notes by coderabbit.ai -->