### PR TITLE
Add Circuit protocol yield/APY adapter

### DIFF
--- a/src/adaptors/circuit/index.js
+++ b/src/adaptors/circuit/index.js
@@ -16,13 +16,13 @@
  *   - XCH values: mojos; divide by 1e12 to get XCH
  */
 
-const { get } = require("../utils");
+const { getData } = require("../utils");
 
 const STATS_API = "https://api.circuitdao.com/protocol/stats";
 const MCAT = 1000;   // mBYC → BYC (= USD)
 
 async function apy() {
-  const data = await get(STATS_API);
+  const data = await getData(STATS_API);
   if (!Array.isArray(data?.stats) || data.stats.length === 0) {
     throw new Error("Circuit stats API returned empty or invalid data");
   }

--- a/src/adaptors/circuit/index.js
+++ b/src/adaptors/circuit/index.js
@@ -77,7 +77,7 @@ async function apy() {
   return [
     // XCH collateral vault — borrow market
     {
-      pool: "circuit-xch-vault",
+      pool: "circuit-collateral-vault",
       project: "circuit",
       chain: "Chia",
       symbol: "XCH",
@@ -94,7 +94,7 @@ async function apy() {
     },
     // BYC savings vault — supply market
     {
-      pool: "circuit-byc-savings",
+      pool: "circuit-savings-vault",
       project: "circuit",
       chain: "Chia",
       symbol: "BYC",

--- a/src/adaptors/circuit/index.js
+++ b/src/adaptors/circuit/index.js
@@ -30,23 +30,31 @@ async function apy() {
   // stats is oldest-first; take the most recent entry
   const s = data.stats[data.stats.length - 1];
 
-  const collateralUsd = s.collateral_usd ?? 0;
-  const borrowedBYC = s.byc_in_circulation / MCAT;      // total BYC minted (USD)
-  const savingsBalanceBYC = s.savings_balance / MCAT;   // BYC in savings vaults (USD)
+  const toNum = (v) => {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : 0;
+  };
+
+  const collateralUsd = toNum(s.collateral_usd);
+  const borrowedBYC = toNum(s.byc_in_circulation) / MCAT;      // total BYC minted (USD)
+  const savingsBalanceBYC = toNum(s.savings_balance) / MCAT;   // BYC in savings vaults (USD)
 
   // Stability fee APY: annualised fee income / outstanding principal
   // projected_revenue = undiscounted_principal * annual_rate (in mBYC)
+  const undiscountedPrincipal = toNum(s.undiscounted_principal);
+  const projectedRevenue = toNum(s.projected_revenue);
   const stabilityFeeApy =
-    s.undiscounted_principal > 0
-      ? (s.projected_revenue / s.undiscounted_principal) * 100
+    undiscountedPrincipal > 0
+      ? (projectedRevenue / undiscountedPrincipal) * 100
       : 0;
 
   // Savings APY: annualised interest cost / undiscounted savings balance
   // undiscounted_savings_balance = savings_balance + accrued_interest (both in mBYC)
-  const undiscountedSavings = s.savings_balance + s.accrued_interest;
+  const undiscountedSavings = toNum(s.savings_balance) + toNum(s.accrued_interest);
+  const projectedCost = toNum(s.projected_cost);
   const savingsApy =
     undiscountedSavings > 0
-      ? (s.projected_cost / undiscountedSavings) * 100
+      ? (projectedCost / undiscountedSavings) * 100
       : 0;
 
   return [

--- a/src/adaptors/circuit/index.js
+++ b/src/adaptors/circuit/index.js
@@ -59,6 +59,8 @@ async function apy() {
       tvlUsd: collateralUsd,
       totalSupplyUsd: collateralUsd,
       totalBorrowUsd: borrowedBYC,
+      apyBase: 0,
+      apyReward: 0,
       apyBaseBorrow: stabilityFeeApy,
       mintedCoin: "BYC",
       poolMeta: "XCH collateral vault",

--- a/src/adaptors/circuit/index.js
+++ b/src/adaptors/circuit/index.js
@@ -26,9 +26,11 @@ const MCAT = 1000;   // mBYC → BYC (= USD)
 async function apy() {
   const [data, statutesResp] = await Promise.all([
     getData(STATS_API),
-    axios.post(STATUTES_API, { full: false }),
+    axios
+      .post(STATUTES_API, { full: false }, { timeout: 10_000 })
+      .catch(() => null),
   ]);
-  const statutesData = statutesResp.data;
+  const statutesData = statutesResp?.data ?? {};
   if (!Array.isArray(data?.stats) || data.stats.length === 0) {
     throw new Error("Circuit stats API returned empty or invalid data");
   }
@@ -60,7 +62,8 @@ async function apy() {
   const liquidationRatioPct = toNum(
     statutesData?.implemented_statutes?.VAULT_LIQUIDATION_RATIO_PCT
   );
-  const ltv = liquidationRatioPct > 0 ? 100 / liquidationRatioPct : null;
+  const rawLtv = liquidationRatioPct > 0 ? 100 / liquidationRatioPct : null;
+  const ltv = rawLtv !== null && rawLtv >= 0 && rawLtv <= 1 ? rawLtv : null;
 
   // Savings APY: annualised interest cost / undiscounted savings balance
   // undiscounted_savings_balance = savings_balance + accrued_interest (both in mBYC)

--- a/src/adaptors/circuit/index.js
+++ b/src/adaptors/circuit/index.js
@@ -16,7 +16,7 @@
  *   - XCH values: mojos; divide by 1e12 to get XCH
  */
 
-const { get } = require("../helper/http");
+const { get } = require("../utils");
 
 const STATS_API = "https://api.circuitdao.com/protocol/stats";
 const MCAT = 1000;   // mBYC → BYC (= USD)

--- a/src/adaptors/circuit/index.js
+++ b/src/adaptors/circuit/index.js
@@ -17,12 +17,18 @@
  */
 
 const { getData } = require("../utils");
+const axios = require("axios");
 
 const STATS_API = "https://api.circuitdao.com/protocol/stats";
+const STATUTES_API = "https://api.circuitdao.com/statutes";
 const MCAT = 1000;   // mBYC → BYC (= USD)
 
 async function apy() {
-  const data = await getData(STATS_API);
+  const [data, statutesResp] = await Promise.all([
+    getData(STATS_API),
+    axios.post(STATUTES_API, { full: false }),
+  ]);
+  const statutesData = statutesResp.data;
   if (!Array.isArray(data?.stats) || data.stats.length === 0) {
     throw new Error("Circuit stats API returned empty or invalid data");
   }
@@ -48,6 +54,14 @@ async function apy() {
       ? (projectedRevenue / undiscountedPrincipal) * 100
       : 0;
 
+  // LTV: derived from the on-chain VAULT_LIQUIDATION_RATIO_PCT statute
+  // liquidation_ratio_pct is the minimum collateral ratio (e.g. 166 means 166% collateral required)
+  // LTV = 100 / liquidation_ratio_pct
+  const liquidationRatioPct = toNum(
+    statutesData?.implemented_statutes?.VAULT_LIQUIDATION_RATIO_PCT
+  );
+  const ltv = liquidationRatioPct > 0 ? 100 / liquidationRatioPct : null;
+
   // Savings APY: annualised interest cost / undiscounted savings balance
   // undiscounted_savings_balance = savings_balance + accrued_interest (both in mBYC)
   const undiscountedSavings = toNum(s.savings_balance) + toNum(s.accrued_interest);
@@ -71,6 +85,7 @@ async function apy() {
       apyReward: 0,
       apyBaseBorrow: stabilityFeeApy,
       mintedCoin: "BYC",
+      ltv,
       poolMeta: "XCH collateral vault",
       url: "https://circuitdao.com/borrow",
     },

--- a/src/adaptors/circuit/index.js
+++ b/src/adaptors/circuit/index.js
@@ -1,0 +1,85 @@
+/**
+ * DefiLlama yield/APY adapter for Circuit protocol.
+ *
+ * Place this directory at src/adaptors/circuit/ in the DefiLlama/yield-server repo.
+ *
+ * Pools:
+ *   1. XCH collateral vault — shows the stability fee (borrow rate) and collateral stats.
+ *   2. BYC savings vault   — shows the savings interest rate depositors earn.
+ *
+ * Data source: https://api.circuitdao.com/protocol/stats
+ * The values reported here can be independently verified by running the Circuit block scanner:
+ * https://github.com/circuitdao/circuit-analytics
+ *
+ * Units in the API:
+ *   - BYC values: mBYC (milli-BYC); divide by 1000 to get BYC = USD (1 BYC = $1)
+ *   - XCH values: mojos; divide by 1e12 to get XCH
+ */
+
+const { get } = require("../helper/http");
+
+const STATS_API = "https://api.circuitdao.com/protocol/stats";
+const MCAT = 1000;   // mBYC → BYC (= USD)
+
+async function apy() {
+  const data = await get(STATS_API);
+  if (!Array.isArray(data?.stats) || data.stats.length === 0) {
+    throw new Error("Circuit stats API returned empty or invalid data");
+  }
+
+  // stats is oldest-first; take the most recent entry
+  const s = data.stats[data.stats.length - 1];
+
+  const collateralUsd = s.collateral_usd ?? 0;
+  const borrowedBYC = s.byc_in_circulation / MCAT;      // total BYC minted (USD)
+  const savingsBalanceBYC = s.savings_balance / MCAT;   // BYC in savings vaults (USD)
+
+  // Stability fee APY: annualised fee income / outstanding principal
+  // projected_revenue = undiscounted_principal * annual_rate (in mBYC)
+  const stabilityFeeApy =
+    s.undiscounted_principal > 0
+      ? (s.projected_revenue / s.undiscounted_principal) * 100
+      : 0;
+
+  // Savings APY: annualised interest cost / undiscounted savings balance
+  // undiscounted_savings_balance = savings_balance + accrued_interest (both in mBYC)
+  const undiscountedSavings = s.savings_balance + s.accrued_interest;
+  const savingsApy =
+    undiscountedSavings > 0
+      ? (s.projected_cost / undiscountedSavings) * 100
+      : 0;
+
+  return [
+    // XCH collateral vault — borrow market
+    {
+      pool: "circuit-xch-vault",
+      project: "circuit",
+      chain: "Chia",
+      symbol: "XCH",
+      tvlUsd: collateralUsd,
+      totalSupplyUsd: collateralUsd,
+      totalBorrowUsd: borrowedBYC,
+      apyBaseBorrow: stabilityFeeApy,
+      mintedCoin: "BYC",
+      poolMeta: "XCH collateral vault",
+      url: "https://circuitdao.com/borrow",
+    },
+    // BYC savings vault — supply market
+    {
+      pool: "circuit-byc-savings",
+      project: "circuit",
+      chain: "Chia",
+      symbol: "BYC",
+      tvlUsd: savingsBalanceBYC,
+      apyBase: savingsApy,
+      poolMeta: "BYC savings vault",
+      url: "https://circuitdao.com/earn",
+    },
+  ];
+}
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: "https://circuitdao.com",
+};


### PR DESCRIPTION
## Circuit Protocol — Yield/APY Adapter

[Circuit](https://circuitdao.com) is a CDP protocol on the Chia blockchain. Users deposit XCH as collateral to borrow Bytecash (BYC), a USD-pegged stablecoin.

### Pools

**XCH collateral vault** (`circuit-xch-vault`): borrow market showing the stability fee (borrow rate) APR, total collateral, and net BYC minted amount (BYC in circulation).

**BYC savings vault** (`circuit-byc-savings`): supply market showing the savings interest APY earned by savings vault depositors.

### Data source

`https://api.circuitdao.com/protocol/stats` — latest entry used for all values.

- Stability fee APY: `projected_revenue / undiscounted_principal * 100`
- Savings APY: `projected_cost / (savings_balance + accrued_interest) * 100`

BYC amounts are in mBYC (1 BYC = 1000 mBYC = $1 USD).

### Verification

Statistics can be independently verified by running the open-source Circuit block scanner: https://github.com/circuitdao/circuit-analytics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Circuit protocol yield support: view APY and USD-denominated TVL for two Circuit markets (XCH borrow vault and BYC savings supply).
  * Displays annualized APY figures, pool-level TVL/borrow/supply data, and direct links to each pool's protocol and stats pages for easy reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->