### PR TITLE
remove adapter queue retries and DLQ for fire-and-forget execution

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -60,7 +60,6 @@ functions:
               - AdapterQueue
               - Arn
           batchSize: 4
-          functionResponseType: ReportBatchItemFailures
     environment:
       ALCHEMY_CONNECTION_ARBITRUM: ${file(./env.js):ALCHEMY_CONNECTION_ARBITRUM}
       ALCHEMY_CONNECTION_ETHEREUM: ${file(./env.js):ALCHEMY_CONNECTION_ETHEREUM}
@@ -216,55 +215,12 @@ resources:
         VisibilityTimeout: 960
         # setting this to 9hours
         MessageRetentionPeriod: 32400
-        RedrivePolicy:
-          deadLetterTargetArn:
-            Fn::GetAtt:
-              - DeadLetterQueue
-              - Arn
-          # this params is requried, otherwise cloudformation error
-          # means that after 3 failed runs, the message will be moved from the adaptor queue
-          # to the DLQ
-          maxReceiveCount: 3
-
-    # --- DLQ
-    DeadLetterQueue:
-      Type: AWS::SQS::Queue
-      Properties:
-        QueueName: ${self:service}-${self:custom.stage}-DeadLetterQueue
-        # leaving this at max, 14days, after that msg in there will be deleted
-        MessageRetentionPeriod: 1209600
 
     # --- create bucket
     BucketData:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: ${self:service}-${self:custom.stage}-data
-
-    # --- alarm stuff for DLQ
-    DlqAlarm:
-      Type: AWS::CloudWatch::Alarm
-      Properties:
-        AlarmName: ${self:service}-${self:custom.stage}-AdapterDLQ
-        AlarmDescription: There are failed messages in the dead letter queue.
-        Namespace: AWS/SQS
-        MetricName: ApproximateNumberOfMessagesVisible
-        Dimensions:
-          - Name: QueueName
-            Value: !GetAtt DeadLetterQueue.QueueName
-        Statistic: Sum
-        Period: 60
-        EvaluationPeriods: 1
-        Threshold: 0
-        ComparisonOperator: GreaterThanThreshold
-        AlarmActions:
-          - !Ref DlqAlarmEmail
-
-    DlqAlarmEmail:
-      Type: AWS::SNS::Topic
-      Properties:
-        Subscription:
-          - Endpoint: slasher125@protonmail.com
-            Protocol: email
 
 custom:
   stage: ${opt:stage, self:provider.stage}

--- a/src/handlers/triggerAdaptor.js
+++ b/src/handlers/triggerAdaptor.js
@@ -19,11 +19,6 @@ module.exports.handler = async (event, context) => {
   context.callbackWaitsForEmptyEventLoop = false;
   console.log(event);
 
-  // We return failed msg ids,
-  // so that only failed messages will be retried by SQS in case of min of 1 error init batch
-  // https://www.serverless.com/blog/improved-sqs-batch-error-handling-with-aws-lambda
-  const failedMessageIds = [];
-
   for (const record of event.Records) {
     const startedAt = new Date();
     let body;
@@ -47,16 +42,8 @@ module.exports.handler = async (event, context) => {
         status: 'error',
         error: formatErrorForStorage(err),
       });
-      failedMessageIds.push(record.messageId);
     }
   }
-  return {
-    batchItemFailures: failedMessageIds.map((id) => {
-      return {
-        itemIdentifier: id,
-      };
-    }),
-  };
 };
 
 const recordAdapterStats = async ({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes to Error Handling**
  * Failed messages from queue processing will no longer be automatically queued for retry or tracked in a dead-letter queue.
  
* **Monitoring & Alerts**
  * Removed dead-letter queue monitoring and associated alert notifications for failed messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->