### PR TITLE
fix benqi lending url

### DIFF
--- a/src/adaptors/benqi-lending/index.js
+++ b/src/adaptors/benqi-lending/index.js
@@ -163,6 +163,7 @@ const getApy = async () => {
   );
 
   const pools = allMarkets.map((market, i) => {
+    const symbol = underlyingSymbols[i] || AVAX.symbol;
     const token = underlyingTokens[i] || AVAX.address;
     const decimals = Number(underlyingDecimals[i]) || AVAX.decimals;
     const totalSupplyUsd =
@@ -215,7 +216,7 @@ const getApy = async () => {
       pool: market,
       chain: utils.formatChain('avalanche'),
       project: 'benqi-lending',
-      symbol: underlyingSymbols[i] || AVAX.symbol,
+      symbol,
       tvlUsd,
       apyBase,
       apyReward: qiApy + avaxApy,
@@ -229,6 +230,7 @@ const getApy = async () => {
       apyBaseBorrow,
       apyRewardBorrow: Number.isFinite(apyRewardBorrow) ? apyRewardBorrow : 0,
       ltv: marketsInfo[i].collateralFactorMantissa / 10 ** 18,
+      url: `https://app.benqi.fi/lending/core/${symbol.toLowerCase()}`,
     };
   });
 
@@ -238,5 +240,5 @@ const getApy = async () => {
 module.exports = {
   timetravel: false,
   apy: getApy,
-  url: 'https://app.benqi.fi/markets',
+  url: 'https://app.benqi.fi/lending',
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Benqi lending module URL endpoint from `/markets` to `/lending` for accurate navigation.

* **New Features**
  * Added dedicated URLs for each individual lending pool, enabling direct links to specific pool pages on the Benqi platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->