### PR TITLE
Add Arche (arUSD) yield adapter

### DIFF
--- a/src/adaptors/arche/index.js
+++ b/src/adaptors/arche/index.js
@@ -1,0 +1,36 @@
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+const VAULT = '0x33FfC177A7278FF84aaB314A036bC7b799B7Cc15';
+const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const CHAIN = 'ethereum';
+
+const getApy = async () => {
+  const { output: totalAssets } = await sdk.api.abi.call({
+    target: VAULT,
+    abi: 'uint256:totalAssets',
+    chain: CHAIN,
+  });
+
+  const { apr } = await utils.getData('https://arche.money/api/apy');
+
+  return [
+    {
+      pool: `${VAULT}-${CHAIN}`.toLowerCase(),
+      chain: utils.formatChain(CHAIN),
+      project: 'arche',
+      symbol: utils.formatSymbol('arUSD'),
+      tvlUsd: Number(totalAssets) / 1e6,
+      apyBase: (apr ?? 0) * 100,
+      underlyingTokens: [USDC],
+      token: VAULT.toLowerCase(),
+      url: 'https://arche.money',
+    },
+  ];
+};
+
+module.exports = {
+  timetravel: false,
+  apy: getApy,
+  url: 'https://arche.money',
+};

--- a/src/adaptors/arche/index.js
+++ b/src/adaptors/arche/index.js
@@ -1,20 +1,64 @@
 const sdk = require('@defillama/sdk');
+const axios = require('axios');
 const utils = require('../utils');
 
 const VAULT = '0x33FfC177A7278FF84aaB314A036bC7b799B7Cc15';
+const STRATEGY = '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204'; // yvUSDC-1
 const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const CHAIN = 'ethereum';
+const DAY = 24 * 3600;
+
+// Yearn v3 vaults book strategy yield only when process_report() runs (lazy
+// accounting). Reading vault.totalAssets() / convertToAssets() between reports
+// therefore lags real underlying yield. To get an honest on-chain rate we
+// mark-to-market the strategy holdings:
+//   real_assets = totalIdle + yvUSDC.convertToAssets(yvUSDC.balanceOf(vault))
+//   real_pps    = real_assets / vault.totalSupply()
+async function realPricePerShare(block) {
+  const [idle, supply, stratBal] = await Promise.all([
+    sdk.api.abi.call({ target: VAULT, abi: 'uint256:totalIdle', chain: CHAIN, block }),
+    sdk.api.abi.call({ target: VAULT, abi: 'uint256:totalSupply', chain: CHAIN, block }),
+    sdk.api.abi.call({
+      target: STRATEGY,
+      abi: 'function balanceOf(address) view returns (uint256)',
+      params: [VAULT],
+      chain: CHAIN,
+      block,
+    }),
+  ]);
+  const { output: stratValue } = await sdk.api.abi.call({
+    target: STRATEGY,
+    abi: 'function convertToAssets(uint256 shares) view returns (uint256)',
+    params: [stratBal.output],
+    chain: CHAIN,
+    block,
+  });
+  return (Number(idle.output) + Number(stratValue)) / Number(supply.output);
+}
 
 const getApy = async () => {
-  const { output: totalAssets } = await sdk.api.abi.call({
-    target: VAULT,
-    abi: 'uint256:totalAssets',
-    chain: CHAIN,
-  });
+  const now = Math.floor(Date.now() / 1e3);
+  const sevenDaysAgo = now - 7 * DAY;
 
-  const { apr } = await utils.getData('https://arche.money/api/apy');
-  if (!Number.isFinite(apr)) {
-    throw new Error(`arche.money/api/apy returned non-finite apr: ${apr}`);
+  const [blockNow, block7d] = await Promise.all([
+    axios.get(`https://coins.llama.fi/block/${CHAIN}/${now}`).then((r) => r.data.height),
+    axios.get(`https://coins.llama.fi/block/${CHAIN}/${sevenDaysAgo}`).then((r) => r.data.height),
+  ]);
+
+  const [ppsNow, pps7d, totalAssets] = await Promise.all([
+    realPricePerShare(blockNow),
+    realPricePerShare(block7d),
+    sdk.api.abi.call({
+      target: VAULT,
+      abi: 'uint256:totalAssets',
+      chain: CHAIN,
+      block: blockNow,
+    }),
+  ]);
+
+  const apyBase = ((ppsNow / pps7d) ** (365 / 7) - 1) * 100;
+  if (!Number.isFinite(apyBase)) {
+    throw new Error(`arche apyBase non-finite: ${apyBase}`);
   }
 
   return [
@@ -23,8 +67,9 @@ const getApy = async () => {
       chain: utils.formatChain(CHAIN),
       project: 'arche',
       symbol: utils.formatSymbol('arUSD'),
-      tvlUsd: Number(totalAssets) / 1e6,
-      apyBase: apr * 100,
+      tvlUsd: Number(totalAssets.output) / 1e6,
+      apyBase,
+      pricePerShare: ppsNow,
       underlyingTokens: [utils.formatAddress(USDC)],
       token: utils.formatAddress(VAULT),
       url: 'https://arche.money',

--- a/src/adaptors/arche/index.js
+++ b/src/adaptors/arche/index.js
@@ -13,6 +13,9 @@ const getApy = async () => {
   });
 
   const { apr } = await utils.getData('https://arche.money/api/apy');
+  if (!Number.isFinite(apr)) {
+    throw new Error(`arche.money/api/apy returned non-finite apr: ${apr}`);
+  }
 
   return [
     {
@@ -21,9 +24,9 @@ const getApy = async () => {
       project: 'arche',
       symbol: utils.formatSymbol('arUSD'),
       tvlUsd: Number(totalAssets) / 1e6,
-      apyBase: (apr ?? 0) * 100,
-      underlyingTokens: [USDC],
-      token: VAULT.toLowerCase(),
+      apyBase: apr * 100,
+      underlyingTokens: [utils.formatAddress(USDC)],
+      token: utils.formatAddress(VAULT),
       url: 'https://arche.money',
     },
   ];


### PR DESCRIPTION
## Protocol

- **Name:** Arche
- **Slug:** `arche` (protocol id 7740 on DefiLlama)
- **Website:** https://arche.money
- **Category:** Yield
- **Chain:** Ethereum

## What this adapter does

Reports a single pool — the Arche arUSD ERC-4626 vault at `0x33FfC177A7278FF84aaB314A036bC7b799B7Cc15` on Ethereum. Depositors provide USDC, receive arUSD shares, and earn a yield aggregated from DeFi strategies.

## Data sources

- **TVL:** `totalAssets()` on the arUSD vault (on-chain).
- **APY:** net APR from the protocol's public endpoint `https://arche.money/api/apy`. Returns a rolling 7d-average APR derived from vault share-price growth; DefiLlama's existing TVL adapter (`registries/erc4626.js`, `arche-money` entry) uses the same vault.

## APY methodology notes

- Currently only `apyBase` is reported. No `apyReward` component at this time.
- APR is reported as-is from the project endpoint (no boosted or pre-mined rewards included).

## Checklist

- [x] Adapter returns a valid `Pool` array (verified locally: `pool`, `chain`, `project`, `symbol`, `tvlUsd`, `apyBase`, `underlyingTokens`, `token`, `url` all populated)
- [x] `project` slug (`arche`) matches `https://api.llama.fi/protocols`
- [x] `pool` ID follows `${receiptToken}-${chain}`.toLowerCase() convention
- [x] `token` field set to the vault's receipt token address
- [x] No centralised API dependencies beyond the project's own endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Arche protocol integration for enhanced DeFi coverage.
  * Real-time APY for Arche pools computed from on-chain price-per-share data.
  * Arche pool TVL, price-per-share, and token details displayed (USDC-backed arUSD pools).
  * Users can monitor and compare Arche pool yields alongside other protocols.
  * Direct link to Arche's site provided for each pool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->