### PR TITLE
show merkl rewards too

### DIFF
--- a/src/adaptors/balancer-v3/index.ts
+++ b/src/adaptors/balancer-v3/index.ts
@@ -38,11 +38,13 @@ const getV3Pools = async (backendChain, chainString) => {
       const aprItems = pool.dynamicData.aprItems || [];
 
       const baseApr = aprItems
-        .filter((item) => item.type === 'SWAP_FEE' || item.type === 'IB_YIELD')
+        .filter(
+          (item) => item.type === 'SWAP_FEE_24H' || item.type === 'IB_YIELD'
+        )
         .reduce((sum, item) => sum + Number(item.apr), 0);
 
       const stakingApr = aprItems
-        .filter((item) => item.type === 'STAKING')
+        .filter((item) => item.type === 'STAKING' || item.type === 'MERKL')
         .reduce((sum, item) => sum + Number(item.apr), 0);
 
       const rewardTokens = aprItems


### PR DESCRIPTION
Merkl rewards on pools should also be shown as yield

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated APY calculations for Balancer v3 pools to reflect additional reward sources and more current fee metrics in yield computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->