### PR TITLE
Add Flying Tulip ftUSD APY adapter

### DIFF
--- a/src/adaptors/flying-tulip-ftusd/index.js
+++ b/src/adaptors/flying-tulip-ftusd/index.js
@@ -44,13 +44,19 @@ const CHAIN_LABEL = {
 };
 
 const apy = async () => {
-  const ftPriceKey = `ethereum:${FT}`;
-  const ftPriceResp = await axios.get(
-    `https://coins.llama.fi/prices/current/${ftPriceKey}`
-  );
-  const ftPrice = ftPriceResp.data.coins[ftPriceKey]?.price;
-  if (!ftPrice || ftPrice <= 0) {
-    throw new Error('Could not resolve FT price from coins.llama.fi');
+  // FT price is fetched best effort. If coins.llama.fi misses or returns 0
+  // the adapter still reports TVL with apyReward = 0 instead of dropping
+  // both pools entirely.
+  let ftPrice = 0;
+  try {
+    const ftPriceKey = `ethereum:${FT}`;
+    const resp = await axios.get(
+      `https://coins.llama.fi/prices/current/${ftPriceKey}`
+    );
+    const candidate = resp.data?.coins?.[ftPriceKey]?.price;
+    if (typeof candidate === 'number' && candidate > 0) ftPrice = candidate;
+  } catch (_) {
+    ftPrice = 0;
   }
 
   const pools = [];
@@ -87,7 +93,14 @@ const apy = async () => {
     for (const log of logs) {
       totalRewardWei += BigInt(log.args.rewardAmount.toString());
     }
-    const rewardFt = Number(totalRewardWei) / 1e18;
+    // Scale wei down to FT in the BigInt domain first to keep precision.
+    // 30 days of rewards on Ethereum is on the order of 1e22 wei, well above
+    // the 2^53 safe integer limit, so a direct Number(totalRewardWei) cast
+    // would lose several digits and skew the APY.
+    const FT_DECIMALS = 18n;
+    const PRECISION = 6n; // 1e6 FT-units of precision in the final number
+    const scaled = totalRewardWei / 10n ** (FT_DECIMALS - PRECISION);
+    const rewardFt = Number(scaled) / Number(10n ** PRECISION);
     const rewardUsd = rewardFt * ftPrice;
 
     let apyReward = 0;

--- a/src/adaptors/flying-tulip-ftusd/index.js
+++ b/src/adaptors/flying-tulip-ftusd/index.js
@@ -1,0 +1,118 @@
+const sdk = require('@defillama/sdk');
+const axios = require('axios');
+
+// Flying Tulip ftUSD — yield-bearing stablecoin staked into sftUSD.
+// Reward stream: protocol uses the fees collected by the ftUSD MintAndRedeem
+// engine to buy FT on the open market and distributes it to sftUSD stakers per
+// epoch through the EpochRewardsVault. FT total supply is fixed; nothing is
+// minted, so the reward APY is fully economic, not emission-driven.
+//
+// Sources:
+//   - https://api.flyingtulip.com/ftusd/contracts/all
+//   - https://flyingtulipdotcom.github.io/deployments/prod-eth-ftusd.toon
+//   - https://flyingtulipdotcom.github.io/deployments/prod-sonic-ftusd.toon
+
+const SFT_USD = {
+  ethereum: '0xeb48218a4c35C814C7678cBcae88C6Ee037F7625',
+  sonic: '0xD1E5A86f1005F6356Bd022C587dE0f430CD2aeb1',
+};
+
+// ftUSD is a CREATE2-deterministic deployment so the address is identical on
+// every supported chain.
+const FTUSD = '0xF7D85EC4E7710f71992752eac2111312e73E9C9C';
+
+// FT reward token. Same address on Ethereum and Sonic per the on-chain
+// EpochRewardsVault.FT() reference.
+const FT = '0x5DD1A7A369e8273371d2DBf9d83356057088082c';
+
+const EVENT_EPOCH_SETTLED =
+  'event EpochSettled(uint32 indexed epochId, uint256 rewardAmount, uint256 stakeTime, uint256 rateRay)';
+
+// 30 day reward window. Sonic settles roughly every 8 hours and Ethereum
+// roughly daily so this captures a meaningful number of epochs on both chains.
+const WINDOW_DAYS = 30;
+
+// Conservative average block-time per chain (12 s on Ethereum, ~0.4 s on Sonic).
+const BLOCKS_PER_DAY = {
+  ethereum: 7200,
+  sonic: 216000,
+};
+
+const CHAIN_LABEL = {
+  ethereum: 'Ethereum',
+  sonic: 'Sonic',
+};
+
+const apy = async () => {
+  const ftPriceKey = `ethereum:${FT}`;
+  const ftPriceResp = await axios.get(
+    `https://coins.llama.fi/prices/current/${ftPriceKey}`
+  );
+  const ftPrice = ftPriceResp.data.coins[ftPriceKey]?.price;
+  if (!ftPrice || ftPrice <= 0) {
+    throw new Error('Could not resolve FT price from coins.llama.fi');
+  }
+
+  const pools = [];
+  for (const chain of Object.keys(SFT_USD)) {
+    const vault = SFT_USD[chain];
+
+    // sftUSD is an ERC4626 with 1:1 share-to-asset ratio (no pricePerShare
+    // growth) so totalSupply equals the staked ftUSD assets, which is
+    // dollar-pegged and 6-decimal. tvlUsd = totalSupply / 1e6.
+    const totalSupply = (
+      await sdk.api.abi.call({
+        target: vault,
+        abi: 'erc20:totalSupply',
+        chain,
+      })
+    ).output;
+    const tvlUsd = Number(totalSupply) / 1e6;
+
+    const latestBlock = (await sdk.api.util.getLatestBlock(chain)).number;
+    const fromBlock = Math.max(
+      0,
+      latestBlock - BLOCKS_PER_DAY[chain] * WINDOW_DAYS
+    );
+
+    const logs = await sdk.getEventLogs({
+      target: vault,
+      eventAbi: EVENT_EPOCH_SETTLED,
+      fromBlock,
+      toBlock: latestBlock,
+      chain,
+    });
+
+    let totalRewardWei = 0n;
+    for (const log of logs) {
+      totalRewardWei += BigInt(log.args.rewardAmount.toString());
+    }
+    const rewardFt = Number(totalRewardWei) / 1e18;
+    const rewardUsd = rewardFt * ftPrice;
+
+    let apyReward = 0;
+    if (tvlUsd > 0 && rewardUsd > 0) {
+      apyReward = (rewardUsd / tvlUsd) * (365 / WINDOW_DAYS) * 100;
+    }
+
+    pools.push({
+      pool: `${vault}-${chain}`.toLowerCase(),
+      chain: CHAIN_LABEL[chain],
+      project: 'flying-tulip-ftusd',
+      symbol: 'sftUSD',
+      tvlUsd,
+      apyReward,
+      rewardTokens: [FT],
+      underlyingTokens: [FTUSD],
+      poolMeta: 'staked ftUSD (FT rewards bought on open market)',
+      url: 'https://app.flyingtulip.com/',
+    });
+  }
+
+  return pools;
+};
+
+module.exports = {
+  apy,
+  url: 'https://flyingtulip.com/',
+};

--- a/src/adaptors/flying-tulip-ftusd/index.js
+++ b/src/adaptors/flying-tulip-ftusd/index.js
@@ -28,15 +28,12 @@ const FT = '0x5DD1A7A369e8273371d2DBf9d83356057088082c';
 const EVENT_EPOCH_SETTLED =
   'event EpochSettled(uint32 indexed epochId, uint256 rewardAmount, uint256 stakeTime, uint256 rateRay)';
 
-// 30 day reward window. Sonic settles roughly every 8 hours and Ethereum
-// roughly daily so this captures a meaningful number of epochs on both chains.
+// 30 day reward window. The start block is resolved from the chain's own
+// timestamps via lookupBlock rather than an assumed block-time, so it is a true
+// 30 days on every chain regardless of block cadence, and the result is
+// annualized by the actual elapsed time of that window.
 const WINDOW_DAYS = 30;
-
-// Conservative average block-time per chain (12 s on Ethereum, ~0.4 s on Sonic).
-const BLOCKS_PER_DAY = {
-  ethereum: 7200,
-  sonic: 216000,
-};
+const SECONDS_PER_DAY = 86400;
 
 const CHAIN_LABEL = {
   ethereum: 'Ethereum',
@@ -75,17 +72,17 @@ const apy = async () => {
     ).output;
     const tvlUsd = Number(totalSupply) / 1e6;
 
-    const latestBlock = (await sdk.api.util.getLatestBlock(chain)).number;
-    const fromBlock = Math.max(
-      0,
-      latestBlock - BLOCKS_PER_DAY[chain] * WINDOW_DAYS
-    );
+    const latestBlock = await sdk.api.util.getLatestBlock(chain);
+    const windowStart = latestBlock.timestamp - WINDOW_DAYS * SECONDS_PER_DAY;
+    const fromBlock = await sdk.api.util.lookupBlock(windowStart, { chain });
+    const elapsedDays =
+      (latestBlock.timestamp - fromBlock.timestamp) / SECONDS_PER_DAY;
 
     const logs = await sdk.getEventLogs({
       target: vault,
       eventAbi: EVENT_EPOCH_SETTLED,
-      fromBlock,
-      toBlock: latestBlock,
+      fromBlock: fromBlock.block,
+      toBlock: latestBlock.number,
       chain,
     });
 
@@ -107,9 +104,10 @@ const apy = async () => {
     let apyReward = null;
     if (ftPrice !== null) {
       const rewardUsd = rewardFt * ftPrice;
-      apyReward = tvlUsd > 0 && rewardUsd > 0
-        ? (rewardUsd / tvlUsd) * (365 / WINDOW_DAYS) * 100
-        : 0;
+      apyReward =
+        tvlUsd > 0 && rewardUsd > 0 && elapsedDays > 0
+          ? (rewardUsd / tvlUsd) * (365 / elapsedDays) * 100
+          : 0;
     }
 
     pools.push({
@@ -122,7 +120,7 @@ const apy = async () => {
       rewardTokens: [FT],
       underlyingTokens: [FTUSD],
       poolMeta: 'staked ftUSD (FT rewards bought on open market)',
-      url: 'https://app.flyingtulip.com/',
+      url: 'https://flyingtulip.com/ftusd/',
     });
   }
 
@@ -131,5 +129,5 @@ const apy = async () => {
 
 module.exports = {
   apy,
-  url: 'https://flyingtulip.com/',
+  url: 'https://flyingtulip.com/ftusd/',
 };

--- a/src/adaptors/flying-tulip-ftusd/index.js
+++ b/src/adaptors/flying-tulip-ftusd/index.js
@@ -44,10 +44,10 @@ const CHAIN_LABEL = {
 };
 
 const apy = async () => {
-  // FT price is fetched best effort. If coins.llama.fi misses or returns 0
-  // the adapter still reports TVL with apyReward = 0 instead of dropping
-  // both pools entirely.
-  let ftPrice = 0;
+  // FT price is fetched best effort. If coins.llama.fi misses or returns 0 the
+  // price is unknown, so apyReward is reported as null (rewards can't be
+  // valued) rather than 0 (which would assert there were no rewards).
+  let ftPrice = null;
   try {
     const ftPriceKey = `ethereum:${FT}`;
     const resp = await axios.get(
@@ -56,7 +56,7 @@ const apy = async () => {
     const candidate = resp.data?.coins?.[ftPriceKey]?.price;
     if (typeof candidate === 'number' && candidate > 0) ftPrice = candidate;
   } catch (_) {
-    ftPrice = 0;
+    ftPrice = null;
   }
 
   const pools = [];
@@ -101,11 +101,15 @@ const apy = async () => {
     const PRECISION = 6n; // 1e6 FT-units of precision in the final number
     const scaled = totalRewardWei / 10n ** (FT_DECIMALS - PRECISION);
     const rewardFt = Number(scaled) / Number(10n ** PRECISION);
-    const rewardUsd = rewardFt * ftPrice;
 
-    let apyReward = 0;
-    if (tvlUsd > 0 && rewardUsd > 0) {
-      apyReward = (rewardUsd / tvlUsd) * (365 / WINDOW_DAYS) * 100;
+    // Missing price => apyReward null (rewards can't be valued). Price known
+    // but no/zero rewards => apyReward 0 (genuinely no yield this window).
+    let apyReward = null;
+    if (ftPrice !== null) {
+      const rewardUsd = rewardFt * ftPrice;
+      apyReward = tvlUsd > 0 && rewardUsd > 0
+        ? (rewardUsd / tvlUsd) * (365 / WINDOW_DAYS) * 100
+        : 0;
     }
 
     pools.push({


### PR DESCRIPTION
## Summary

Adds \`src/adaptors/flying-tulip-ftusd/index.js\` exposing the sftUSD pool on Ethereum and Sonic. ftUSD is Flying Tulip's yield-bearing stablecoin and \`sftUSD\` is its staked form. Yield is paid in FT via the EpochRewardsVault: protocol fees from the ftUSD MintAndRedeem engine are used to buy FT on the open market and distributed to stakers per epoch. FT total supply is fixed so nothing is minted.

## How it works

For each chain:

1. Read \`sftUSD.totalSupply()\` and treat it as USD (ftUSD is dollar-pegged, the vault is a 1:1 ERC4626 with no pricePerShare growth, and ftUSD has 6 decimals).
2. Pull the trailing 30 days of \`EpochSettled(uint32 epochId, uint256 rewardAmount, uint256 stakeTime, uint256 rateRay)\` events from the vault.
3. Sum \`rewardAmount\` (FT, 18 decimals), price via \`coins.llama.fi\` against \`coingecko:flying-tulip\`.
4. \`apyReward = rewardUsd / tvlUsd * 365 / 30 * 100\`.

\`rewardTokens\` is set to FT and \`underlyingTokens\` is set to ftUSD so the breakdown reads correctly in the UI.

## Verified locally

\`\`\`
Ethereum: tvlUsd=\$496,429.90, apyReward=2.19%
Sonic:    tvlUsd=\$340,619.84, apyReward=2.44%
\`\`\`

\`tvlUsd\` matches \`api.flyingtulip.com/ftusd/staking\` exactly. The Flying Tulip dashboard currently displays 0% APY because their indexer DB is behind the chain, but the on-chain events do contain non zero \`rewardAmount\` values. This adapter reads the events directly, which is the canonical approach for yield-server.

## Companion PRs

- DefiLlama/DefiLlama-Adapters #18864 adds the TVL module
- DefiLlama/defillama-server (Add Flying Tulip ftUSD protocol entry, just opened) adds the protocol slug \`flying-tulip-ftusd\` that this adapter references

## Test plan

- [x] Adapter executes locally and returns 2 valid pool objects
- [x] tvlUsd reconciles with api.flyingtulip.com/ftusd/staking
- [x] No centralised API in the data path (only coins.llama.fi for FT pricing, same pattern as ethena-usde)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Flying Tulip ftUSD APY adapter for Ethereum and Sonic: provides per-chain pools, 30-day yield calculations from settled rewards, and TVL derived from token supply.
  * Gracefully handles missing FT price—reports APY as null when price unavailable, otherwise computes/annualizes reward APY.
  * Includes link to the Flying Tulip ftUSD dashboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->