### PR TITLE
fix: re-enable jones-dao adapter (deposits resumed)

### DIFF
--- a/src/adaptors/jones-dao/index.js
+++ b/src/adaptors/jones-dao/index.js
@@ -100,21 +100,19 @@ async function pools() {
     }
   }
 
-  // jGLP vault (Arbitrum) - only include if TVL > 0
+  // jGLP vault (Arbitrum)
   if (jglpRes?.result?.data?.json?.leveragedVaults) {
     const vaults = jglpRes.result.data.json.leveragedVaults;
     for (const vault of vaults) {
-      if (vault.tvl > 0) {
-        pools.push({
-          pool: `${jglpVault}-arbitrum`.toLowerCase(),
-          chain: 'Arbitrum',
-          project: 'jones-dao',
-          symbol: 'jGLP',
-          underlyingTokens: [glp],
-          tvlUsd: vault.tvl,
-          apyBase: vault.apy?.apy || 0,
-        });
-      }
+      pools.push({
+        pool: `${jglpVault}-arbitrum`.toLowerCase(),
+        chain: 'Arbitrum',
+        project: 'jones-dao',
+        symbol: 'jGLP',
+        underlyingTokens: [glp],
+        tvlUsd: vault.tvl,
+        apyBase: vault.apy?.apy || 0,
+      });
     }
   }
 

--- a/src/utils/exclude.js
+++ b/src/utils/exclude.js
@@ -187,7 +187,6 @@ const excludeAdaptors = [
   'mm-finance-polygon',
   'maia-cl',
   'molecular',
-  'jones-dao', //disabled deposits
   'zkp2p',
   'dyson',
   'opyn-squeeth',


### PR DESCRIPTION
## Summary

The `jones-dao` adapter was excluded in #2348 (Feb 2026) with the reason `//disabled deposits`. That's no longer accurate — Jones vaults are open, accruing TVL, and the adapter is producing valid pool data. This PR re-enables it and ensures jGLP's historical chart stays visible while that vault winds down.

Live state pulled from Jones APIs at PR time:

| Pool      | Chain    | TVL       | APY     |
| --------- | -------- | --------- | ------- |
| jAURA     | Ethereum | ~$18k     | ~66%    |
| jUSDC     | Arbitrum | ~$749k    | ~1.6%   |
| jGLP      | Arbitrum | $0        | ~3.2%   |
| smart-lp  | 7 chains | hundreds of strategies w/ active TVL | — |

Running the adapter locally now emits 167 pools, all of which were silently dropped at the enrichment layer because of the project-level exclusion.

## Changes

1. **`src/utils/exclude.js`** — remove `'jones-dao', //disabled deposits`. The reason no longer applies; deposits are open across jAURA, jUSDC, and smart-lp.
2. **`src/adaptors/jones-dao/index.js`** — remove the `vault.tvl > 0` guard on jGLP. The vault is winding down so live TVL is 0, but the upstream API still reports a valid APY for residual positions, and we want DefiLlama's historical chart for jGLP to remain visible rather than disappearing once the project is un-excluded.

## Test plan

- [x] `node -e "require('./src/adaptors/jones-dao').apy().then(p => console.log(p.length))"` — returns 167 pools
- [x] jAURA, jUSDC, jGLP each emit one pool with sensible `tvlUsd` / `apyBase`
- [x] No duplicate pool IDs across the smart-lp set
- [ ] Reviewer to confirm enrichment pipeline picks up the project once exclusion is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded jGLP vault pool availability - all pools now displayed instead of filtered selection

* **Updates**
  * Removed hardcoded exclusion of jones-dao adaptor, enabling broader vault integration and access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->