### PR TITLE
feat: allow negative apy via per-adapter flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ module.exports = {
   timetravel: false,
   apy: apy, // Main function, returns pools
   url: 'https://example.com/pools', // Link to page with pools (Only required if you do not provide url's for each pool)
+  allowNegativeApy: false, // optional, set to true if pool can legitimately have negative apy (eg loss-bearing strategies, options writing)
 };
 ```
 

--- a/src/handlers/triggerAdaptor.js
+++ b/src/handlers/triggerAdaptor.js
@@ -147,18 +147,17 @@ const main = async (body) => {
 
   // in case of negative apy values (cause of bug, or else we set those to 0)
   // note: for options apyBase can be negative
+  // adapters can also opt-in via `module.exports.allowNegativeApy = true`
+  const allowNegativeApy =
+    protocolConfig[body.adaptor]?.category === 'Options' ||
+    project.allowNegativeApy === true ||
+    ['mellow-protocol', 'sommelier', 'abracadabra', 'resolv'].includes(
+      body.adaptor
+    );
   data = data.map((p) => ({
     ...p,
-    apy: p.apy < 0 ? 0 : p.apy,
-    apyBase:
-      protocolConfig[body.adaptor]?.category === 'Options' ||
-      ['mellow-protocol', 'sommelier', 'abracadabra', 'resolv'].includes(
-        body.adaptor
-      )
-        ? p.apyBase
-        : p.apyBase < 0
-        ? 0
-        : p.apyBase,
+    apy: allowNegativeApy ? p.apy : p.apy < 0 ? 0 : p.apy,
+    apyBase: allowNegativeApy ? p.apyBase : p.apyBase < 0 ? 0 : p.apyBase,
     apyReward: p.apyReward < 0 ? 0 : p.apyReward,
     apyBaseBorrow: p.apyBaseBorrow < 0 ? 0 : p.apyBaseBorrow,
     apyRewardBorrow: p.apyRewardBorrow < 0 ? 0 : p.apyRewardBorrow,

--- a/src/utils/exclude.js
+++ b/src/utils/exclude.js
@@ -2246,7 +2246,8 @@ const boundaries = {
   // we only get pools for the UI with a tvlUsd of minimum $10k and max ($20 billion)
   tvlUsdUI: { lb: 10000, ub: 2e10 },
   // we only get pools for the UI with a maximum apy of 1million %
-  apy: { lb: 0, ub: 1e6 },
+  // lb is symmetric so opt-in adapters (eg options, restaking depegs) with negative apy survive the filter
+  apy: { lb: -1e6, ub: 1e6 },
   // reading from database returns only pools which is max 7 days old
   age: 7,
 };


### PR DESCRIPTION
closes #2409
adds an opt-in `allowNegativeApy` flag on adapter modules so loss-bearing pools (eg liquid restaking depegs, leveraged stable strategies) can report real negative apy instead of being clamped to 0. existing options-category and hardcoded-list behaviour is preserved, so no current adapter changes output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration flag enabling adapters to report and retain negative APY values when explicitly enabled
  * Expanded APY filtering range to include negative yields, allowing pools with negative returns to be recognized and displayed
  * Updated documentation for the new negative APY configuration option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->