### PR TITLE
fix: rsk, tac, 0g chains

### DIFF
--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -48,7 +48,9 @@ exports.formatChain = (chain) => {
   if (chain && chain.toLowerCase() === 'ripple') return 'XRPL';
   if (chain && chain.toLowerCase() === 'xrplevm') return 'XRPL EVM';
   if (chain && chain.toLowerCase() === 'etlk') return 'Etherlink';
-  if (chain && chain.toLowerCase() === 'rsk') return 'Rootstock';
+  if (chain && chain.toLowerCase() === 'rsk') return 'RSK';
+  if (chain && chain.toLowerCase() === '0g') return '0G';
+  if (chain && chain.toLowerCase() === 'tac') return 'TAC';
   if (
     chain &&
     (chain.toLowerCase() === 'hyperevm' ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated chain name formatting for improved consistency and clarity. The "rsk" chain now displays as "RSK", and explicit mappings have been added for "0g" and "tac" chains to display as "0G" and "TAC" respectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->