### PR TITLE
fix(uniswap-v3): request token volume fields

### DIFF
--- a/src/adaptors/uniswap-v3/index.js
+++ b/src/adaptors/uniswap-v3/index.js
@@ -41,6 +41,8 @@ const query = gql`
       totalValueLockedToken0
       totalValueLockedToken1
       volumeUSD
+      volumeToken0
+      volumeToken1
       feeTier
       token0 {
         symbol
@@ -61,6 +63,8 @@ const queryPrior = gql`
     pools( first: 1000 orderBy: totalValueLockedUSD orderDirection:desc block: {number: <PLACEHOLDER>}) {
       id 
       volumeUSD 
+      volumeToken0
+      volumeToken1
     }
   }
 `;


### PR DESCRIPTION
## Summary

This adds `volumeToken0` and `volumeToken1` to the Uniswap V3 adapter's current and prior pool subgraph queries.

The shared APY helper already has a generic fallback for pools where `volumeUSD` deltas are zero: it can compute USD volume from token0 volume deltas and `price0`. The Uniswap V3 adapter was only requesting `volumeUSD`, so that fallback path could not run for Uni V3 pools even when token-volume data existed in the subgraph.

## Current symptom

The DeFiLlama Yields API currently lists the Ethereum OHM-SUSDS Uniswap V3 pool, but reports zero APY and zero 1d/7d USD volume even though the underlying Uniswap V3 subgraph shows real 1d/7d token-volume deltas that should produce swap fees and fee APY:

- DeFiLlama pool id: `0cc155d9-0e7f-4bdd-b07e-0a09e34b9af0`
- Uniswap V3 pool address: `0x0858e2b0f9d75f7300b38d64482ac2c8df06a755`
- Project: `uniswap-v3`
- Chain: Ethereum
- Fee tier: 0.3%
- Current TVL: about $10M
- Underlying tokens:
  - OHM: `0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5`
  - sUSDS: `0xa3931d71877c0e7a3148cb7eb4463524fec27fbd`

So the issue is not TVL by itself; it is that real swap volume/fees over the 1d and 7d horizons are not flowing into the adapter's APY calculation when `volumeUSD` is zero.

## Why this is generic

No pool-specific addresses or symbols are special-cased. The patch only supplies the token-volume fields that the existing shared fallback already expects, so any Uniswap V3 pool with zero USD volume deltas but valid token-volume deltas can use the same fallback.

## Verification

- `node --check src/adaptors/uniswap-v3/index.js`
  - Result: passed
- Live Graph gateway query with `GRAPH_API_KEY` set confirmed the OHM-SUSDS pool exposes nonzero `volumeToken0`/`volumeToken1` deltas while `volumeUSD` deltas remain zero:
  - `volumeUSD` delta, 1d: `0`
  - `volumeUSD` delta, 7d: `0`
  - `volumeToken0` delta, 1d: `4128.1526275817305` OHM
  - `volumeToken0` delta, 7d: `326001.0293759983` OHM
  - `volumeToken1` delta, 1d: `81777.20801253617` sUSDS
  - `volumeToken1` delta, 7d: `5731472.142911494` sUSDS
- Focused local script verified both Uni V3 GraphQL query strings include `volumeUSD`, `volumeToken0`, and `volumeToken1`, and that `utils.apy()` converts token0 volume deltas into nonzero 1d/7d USD volume and APY when USD volume deltas are zero:
  - fallback 1d volume: `600`
  - fallback 7d volume: `1800`
  - fallback 1d APY: `0.06570000000000001`
  - fallback 7d APY: `0.02808`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Uniswap V3 data queries to include token-denominated volume metrics (`volumeToken0` and `volumeToken1`) alongside existing USD volume data across all query types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->