### PR TITLE
feat: add gmtrade yield adapter

### DIFF
--- a/src/adaptors/gmtrade/index.js
+++ b/src/adaptors/gmtrade/index.js
@@ -1,0 +1,35 @@
+const utils = require('../utils');
+
+const POOLS_URL = 'https://market-info-mainnet-prod.gmtrade.xyz/defillama/pools';
+
+const apy = async () => {
+  const data = await utils.getData(POOLS_URL);
+  if (!Array.isArray(data)) throw new Error('gmtrade api response is not an array');
+
+  return data
+    .map((p) => {
+      const chain = utils.formatChain((p.chain ?? 'solana').toString());
+      const poolAddress = p.pool;
+      if (!poolAddress) return null;
+
+      const pool = poolAddress.toLowerCase();
+
+      return {
+        pool,
+        chain,
+        project: 'gmtrade',
+        symbol: p.symbol,
+        tvlUsd: Number(p.tvl_usd),
+        apyBase: Number(p.apy_base),
+        token: poolAddress,
+      };
+    })
+    .filter(Boolean)
+    .filter((p) => utils.keepFinite(p));
+};
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: 'https://gmtrade.xyz',
+};

--- a/src/adaptors/gmtrade/index.js
+++ b/src/adaptors/gmtrade/index.js
@@ -12,7 +12,7 @@ const parseUnderlyingTokens = (p) => {
   const longToken = String(p?.long_token ?? '').trim();
   const shortToken = String(p?.short_token ?? '').trim();
 
-  const tokens = [longToken, shortToken].filter(Boolean);
+  const tokens = [...new Set([longToken, shortToken].filter(Boolean))];
   return tokens.length ? tokens : null;
 };
 

--- a/src/adaptors/gmtrade/index.js
+++ b/src/adaptors/gmtrade/index.js
@@ -8,6 +8,14 @@ const parseNumberOrNaN = (v) => {
   return Number.isFinite(n) ? n : NaN;
 };
 
+const parseUnderlyingTokens = (p) => {
+  const longToken = String(p?.long_token ?? '').trim();
+  const shortToken = String(p?.short_token ?? '').trim();
+
+  const tokens = [longToken, shortToken].filter(Boolean);
+  return tokens.length ? tokens : null;
+};
+
 const apy = async () => {
   const data = await utils.getData(POOLS_URL);
   if (!Array.isArray(data)) throw new Error('gmtrade api response is not an array');
@@ -18,6 +26,8 @@ const apy = async () => {
       const poolAddress = String(p.pool ?? '').trim();
       if (!poolAddress) return null;
 
+      const underlyingTokens = parseUnderlyingTokens(p);
+
       return {
         pool: poolAddress,
         chain,
@@ -25,6 +35,7 @@ const apy = async () => {
         symbol: p.symbol,
         tvlUsd: parseNumberOrNaN(p.tvl_usd),
         apyBase: parseNumberOrNaN(p.apy_base),
+        ...(underlyingTokens ? { underlyingTokens } : {}),
         token: poolAddress,
       };
     })

--- a/src/adaptors/gmtrade/index.js
+++ b/src/adaptors/gmtrade/index.js
@@ -2,6 +2,12 @@ const utils = require('../utils');
 
 const POOLS_URL = 'https://market-info-mainnet-prod.gmtrade.xyz/defillama/pools';
 
+const parseNumberOrNaN = (v) => {
+  if (v === null || v === undefined || v === '') return NaN;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : NaN;
+};
+
 const apy = async () => {
   const data = await utils.getData(POOLS_URL);
   if (!Array.isArray(data)) throw new Error('gmtrade api response is not an array');
@@ -9,18 +15,16 @@ const apy = async () => {
   return data
     .map((p) => {
       const chain = utils.formatChain((p.chain ?? 'solana').toString());
-      const poolAddress = p.pool;
+      const poolAddress = String(p.pool ?? '').trim();
       if (!poolAddress) return null;
 
-      const pool = poolAddress.toLowerCase();
-
       return {
-        pool,
+        pool: poolAddress,
         chain,
         project: 'gmtrade',
         symbol: p.symbol,
-        tvlUsd: Number(p.tvl_usd),
-        apyBase: Number(p.apy_base),
+        tvlUsd: parseNumberOrNaN(p.tvl_usd),
+        apyBase: parseNumberOrNaN(p.apy_base),
         token: poolAddress,
       };
     })


### PR DESCRIPTION
### Protocol Info

- Product (adapter slug): gmtrade
- Protocol: GMTrade
- Website: https://gmtrade.xyz/
- Chain(s): Solana
- Type: GM (market) pools yielding fee-based base APY


### Yield Components
This adapter fetches and displays Base APY for each GMTrade market:

- Base APY (apyBase)
- Paid in: underlying pool value (fee-based yield; auto-reflected in GM price)
- Source: GMTrade market performance data
- Notes: APY values are taken directly from the GMTrade endpoint and are assumed to be already expressed as percent (%)
- The adapter currently does not separate reward APY; it reports base APY only.


### Data Sources
API: https://market-info-mainnet-prod.gmtrade.xyz/defillama/pools
Returns per-pool records including:

- pool (market token / pool identifier)
- symbol
- tvl_usd
- apy_base
- chain, project
- Adapter Logic / Field Mapping

For each pool returned by the API, the adapter maps into DefiLlama yield schema:

- pool: pool.toLowerCase() (aligned with existing GMX v2 adapter style: address-based identifier)
- chain: formatted via utils.formatChain
- project: fixed to gmtrade
- symbol: taken from API (e.g. XAU-USDC)
- tvlUsd: from tvl_usd
- apyBase: from apy_base
- token: original (non-lowercased) pool identifier from API
- url (module-level): https://gmtrade.xyz (used as default project link if per-pool urls are not provided)

### Pools Displayed
Displays one pool per GMTrade market on Solana.
Pools with TVL below DefiLlama UI thresholds may not appear on the frontend (expected behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GMTrade protocol integration to surface APY and TVL metrics for supported pools.
  * Pool responses are validated and normalized (chain, pool address, TVL, APY, underlying tokens) to improve accuracy and consistency.
  * Data is fetched from GMTrade (https://gmtrade.xyz) to provide up-to-date pool metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->