### PR TITLE
 Update APY calculation to include landing sales revenue

### DIFF
--- a/src/adaptors/tr-energy/index.js
+++ b/src/adaptors/tr-energy/index.js
@@ -22,12 +22,18 @@ async function apy() {
   const stats = await getStats();
   const trxPrice = await getTrxPrice();
 
+  const {
+    profit_percent = 0,
+    static_percent = 0,
+    landing_percent = 0
+  } = cfg ?? {};
+
   // TVL
   const tvlTrx = Number((stats.total_energy / cfg.trx_staking_energy_rate).toFixed(2));
   const tvlUsd = Number((tvlTrx * trxPrice['coingecko:tron'].price).toFixed(2));
 
   // APY
-  const baseApy = Number(((cfg.profit_percent + cfg.static_percent + cfg.landing_percent) * 100).toFixed(2));
+  const baseApy = Number(((profit_percent + static_percent + landing_percent) * 100).toFixed(2));
   
   return [
     {

--- a/src/adaptors/tr-energy/index.js
+++ b/src/adaptors/tr-energy/index.js
@@ -26,8 +26,8 @@ async function apy() {
   const tvlTrx = Number((stats.total_energy / cfg.trx_staking_energy_rate).toFixed(2));
   const tvlUsd = Number((tvlTrx * trxPrice['coingecko:tron'].price).toFixed(2));
 
-  // APY  (profit_percent + static_percent) * percent_cef
-  const baseApy = Number(((cfg.profit_percent + cfg.static_percent) * 100).toFixed(2));
+  // APY
+  const baseApy = Number(((cfg.profit_percent + cfg.static_percent + cfg.landing_percent) * 100).toFixed(2));
   
   return [
     {


### PR DESCRIPTION
Updated the APY calculation for TR-Energy. We have added landing_percent to the baseApy.

This parameter represents the additional yield generated from retail energy sales via our landing page. This revenue is distributed to users, so including it provides a more accurate representation of the total real-time APY for stakers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected APY calculation for the TRX pool to include the previously omitted landing component. APY values now incorporate profit, static, and landing portions with sensible defaults, so displayed yields are more accurate and may change for affected pools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->