### PR TITLE
feat(yo-protocol): include yoSOL rewards in adapter

### DIFF
--- a/src/adaptors/yo-protocol/index.js
+++ b/src/adaptors/yo-protocol/index.js
@@ -143,6 +143,7 @@ const getSolanaPools = async () => {
       url: `https://app.yo.xyz/vault/Solana/${vault.id.toLowerCase()}`,
       ...(rewardYield && rewardYield > 0 && {
         apyReward: rewardYield,
+        rewardTokens: ['0x1925450f5e5fb974b0aae1f3408cf5286fbd1a72'],
       }),
     };
 


### PR DESCRIPTION
## Summary
- Attach `rewardTokens` on the Solana branch of the yo-protocol adapter when `rewardYield > 0`, mirroring the existing EVM pattern.
- Without `rewardTokens`, the adapter test invariant (`apyReward` requires `rewardTokens`) strips yoSOL's reward APY.

## Test plan
- [x] `npm test --adapter=yo-protocol` passes locally
- [x] yoSOL pool now reports `apyReward: 3` with `rewardTokens: ['0x1925450f5e5fb974b0aae1f3408cf5286fbd1a72']`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Solana pool reward token configuration to align with other chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->