### PR TITLE
Add Gremlix yields adapter

### DIFF
--- a/src/adaptors/gremlix/index.js
+++ b/src/adaptors/gremlix/index.js
@@ -1,0 +1,38 @@
+const utils = require('../utils');
+const ethers = require('ethers');
+
+const VAULTS = [
+  {
+    symbol: 'USDC',
+    address: '0x973ae12ac9078e9f9b1708c477a9670bb3fb0886',
+    network: 'arbitrum',
+    underlyingToken: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+    underlyingTokenDecimals: 6,
+    poolMeta: 'USDC Dual Grid Vault',
+    url: 'https://app.gremlix.xyz/vaults/0x973Ae12aC9078E9f9B1708C477A9670bB3fB0886'
+  }
+];
+
+const getVaultData = async (timestamp, vault) => {
+  const vaultERC4626Info = await utils.getERC4626Info(vault.address, vault.network, timestamp);
+  const { tvl, ...rest } = vaultERC4626Info;
+  return {
+    ...rest,
+    project: 'gremlix',
+    symbol: vault.symbol,
+    underlyingTokens: [vault.underlyingToken],
+    tvlUsd: parseFloat(ethers.utils.formatUnits(tvl, vault.underlyingTokenDecimals)),
+    poolMeta: vault.poolMeta,
+    url: vault.url
+  };
+};
+
+const apy = async (timestamp) => {
+  return Promise.all(VAULTS.map(vault => getVaultData(timestamp, vault)));
+};
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: 'https://app.gremlix.xyz'
+};


### PR DESCRIPTION
Adds yields adapter for Gremlix ERC-4626 Vaults on Arbitrum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gremlix vault integration to the platform. Users can now access and monitor annual percentage yield (APY) and total value locked (TVL) data for Gremlix vaults with real-time updates. USDC vault support is currently available.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2673)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->