### PR TITLE
feat: add ScrubVault yield pools to scrub project (Kava USDt + Arbitrum USDC)

### DIFF
--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -1,0 +1,229 @@
+/**
+ * ScrubVault yield adapter for DefiLlama.
+ *
+ * ScrubVault is a delta-neutral managed vault where users deposit USDt (Kava)
+ * or USDC (Arbitrum) and receive share tokens representing their proportional
+ * ownership. The deposited capital is deployed off-chain across centralised and
+ * decentralised exchanges running a delta-neutral strategy that earns yield from
+ * funding rates and market-making activity.
+ *
+ * Why funds are not held in the vault contract:
+ *   The vault contract functions as an on-chain accounting and settlement layer.
+ *   Once a deposit batch is processed, the stablecoins are transferred to the
+ *   strategy wallet and actively deployed on exchanges. The on-chain variable
+ *   `totalVaultValue` is the authoritative AUM figure — it is updated by the
+ *   admin/strategy role via `distributeRewards()` each time PnL is settled.
+ *   TVL and APY reported here are therefore based on that on-chain accounting
+ *   value, not on a simple `balanceOf` check.
+ *
+ * APY methodology:
+ *   Rolling 30-day APY is derived from `RewardDistributed` events emitted by
+ *   each vault. For each reward event we record `rewardAmount` and the elapsed
+ *   time since the previous reward. We sum all rewards in the 30-day window,
+ *   divide by the pre-reward TVL at the start of that window, and annualise.
+ *   The Kava vault additionally exposes this value via its subgraph (field `apr`
+ *   in basis-points × 100, i.e. 10 000 = 100 %). The subgraph value is used as
+ *   a primary source with direct event computation as a fallback.
+ */
+
+const sdk   = require('@defillama/sdk');
+const axios = require('axios');
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const PROJECT = 'scrub';
+
+const VAULTS = {
+  kava: {
+    chain:         'Kava',
+    address:       '0x7BFf6c730dA681dF03364c955B165576186370Bc',
+    stablecoin:    '0x919C1c267BC06a7039e03fcc2eF738525769109c', // USDt on Kava
+    symbol:        'USDt',
+    decimals:      6,
+    subgraphUrl:   'https://subgraph.scrub.money/subgraphs/name/scrubvault',
+    poolMeta:      'Delta Neutral USDt Vault',
+  },
+  arbitrum: {
+    chain:         'Arbitrum',
+    address:       '0x439a923517C4DFD3F3d0ABb0C36E356D39CF3f9D',
+    stablecoin:    '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // USDC (native) on Arbitrum
+    symbol:        'USDC',
+    decimals:      6,
+    subgraphUrl:   null, // subgraph deployment pending — will be filled once live
+    poolMeta:      'Delta Neutral USDC Vault',
+  },
+};
+
+// ─── ABI fragments ────────────────────────────────────────────────────────────
+
+const TOTAL_VAULT_VALUE_ABI = {
+  inputs:  [],
+  name:    'totalVaultValue',
+  outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+  stateMutability: 'view',
+  type: 'function',
+};
+
+// keccak256("RewardDistributed(int256,uint256,uint256)")
+const REWARD_DISTRIBUTED_TOPIC =
+  '0x7e4e42cfa6e77e4567e0e9540568546a5e29c29438d9d7c6b05db0db29f5fd51';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch the current `totalVaultValue` (6-decimal stablecoin units) from the
+ * DepositVault contract and return the USD equivalent.
+ */
+async function fetchTvlUsd(chain, vaultAddress, decimals) {
+  const { output } = await sdk.api.abi.call({
+    abi:    TOTAL_VAULT_VALUE_ABI,
+    target: vaultAddress,
+    chain,
+  });
+  return Number(output) / 10 ** decimals;
+}
+
+/**
+ * Try to read the rolling APR from the Kava subgraph.
+ * The `apr` field is stored as an integer scaled by 10 000 (where 10 000 = 100 %).
+ * Returns a plain percentage number, e.g. 8.5 for 8.5 % APR, or null on failure.
+ */
+async function fetchAprFromSubgraph(subgraphUrl, vaultAddress) {
+  if (!subgraphUrl) return null;
+  try {
+    const query = `{
+      vault(id: "${vaultAddress.toLowerCase()}") {
+        apr
+      }
+    }`;
+    const { data } = await axios.post(subgraphUrl, { query }, { timeout: 8000 });
+    const aprRaw = data?.data?.vault?.apr;
+    if (aprRaw == null) return null;
+    // apr is in basis-points × 100: divide by 100 to get plain percentage
+    return Number(aprRaw) / 100;
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Compute a rolling 30-day APY from on-chain `RewardDistributed` events using
+ * a direct eth_getLogs RPC call. Returns a plain percentage or 0 on failure.
+ *
+ * Event signature: RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)
+ * We only count positive rewards (negative = loss events) for the APY figure.
+ */
+async function fetchAprFromEvents(chain, vaultAddress, tvlUsd, decimals) {
+  try {
+    const chainToRpc = {
+      kava:     'https://evm.kava.io',
+      arbitrum: 'https://arb1.arbitrum.io/rpc',
+    };
+    const rpc = chainToRpc[chain];
+    if (!rpc) return 0;
+
+    const nowSec      = Math.floor(Date.now() / 1000);
+    const windowSec   = 30 * 24 * 60 * 60; // 30 days
+    const fromTimeSec = nowSec - windowSec;
+
+    // Approximate block numbers (used as a wide filter — exact time filtering
+    // happens by comparing the decoded timestamp in each log).
+    const avgBlockTime = chain === 'kava' ? 6 : 0.25;
+    const blocksWindow = Math.ceil(windowSec / avgBlockTime);
+
+    // Fetch latest block number
+    const latestResp = await axios.post(rpc, {
+      jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [],
+    }, { timeout: 8000 });
+    const latestBlock = parseInt(latestResp.data.result, 16);
+    const fromBlock   = Math.max(0, latestBlock - blocksWindow);
+
+    // Fetch logs
+    const logsResp = await axios.post(rpc, {
+      jsonrpc: '2.0', id: 2,
+      method: 'eth_getLogs',
+      params: [{
+        fromBlock: '0x' + fromBlock.toString(16),
+        toBlock:   '0x' + latestBlock.toString(16),
+        address:   vaultAddress,
+        topics:    [REWARD_DISTRIBUTED_TOPIC],
+      }],
+    }, { timeout: 12000 });
+
+    const logs = logsResp.data.result ?? [];
+    if (!logs.length) return 0;
+
+    // Each log: data = abi.encode(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)
+    // 3 × 32-byte words, no indexed params
+    let totalRewardUsd = 0;
+    let oldestTimestamp = nowSec;
+
+    for (const log of logs) {
+      const data  = log.data.slice(2); // strip 0x
+      // word 0: rewardAmount (int256, signed) — positive means profit
+      const rewardHex = data.slice(0, 64);
+      const rewardBig = BigInt('0x' + rewardHex);
+      // interpret as signed: if top bit set, it's negative
+      const rewardSigned =
+        rewardBig > BigInt('0x7' + 'f'.repeat(63))
+          ? rewardBig - BigInt('0x1' + '0'.repeat(64))
+          : rewardBig;
+
+      // word 2: timestamp
+      const tsSec = parseInt(data.slice(128, 192), 16);
+
+      if (tsSec < fromTimeSec) continue; // outside 30-day window
+      if (rewardSigned <= 0n) continue;  // losses don't count toward APY
+
+      totalRewardUsd += Number(rewardSigned) / 10 ** decimals;
+      if (tsSec < oldestTimestamp) oldestTimestamp = tsSec;
+    }
+
+    if (totalRewardUsd === 0 || tvlUsd === 0) return 0;
+
+    const elapsedDays = Math.max((nowSec - oldestTimestamp) / 86400, 1);
+    const apr = (totalRewardUsd / tvlUsd) * (365 / elapsedDays) * 100;
+    return Math.max(0, apr);
+  } catch (_) {
+    return 0;
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+const apy = async () => {
+  const pools = [];
+
+  for (const [chainKey, vault] of Object.entries(VAULTS)) {
+    const sdkChain = chainKey; // sdk uses lowercase chain names
+
+    // TVL
+    const tvlUsd = await fetchTvlUsd(sdkChain, vault.address, vault.decimals);
+
+    // APY: prefer subgraph (already computes rolling 30-day APR), fall back to events
+    let apyBase = await fetchAprFromSubgraph(vault.subgraphUrl, vault.address);
+    if (apyBase == null) {
+      apyBase = await fetchAprFromEvents(sdkChain, vault.address, tvlUsd, vault.decimals);
+    }
+
+    pools.push({
+      pool:             `${vault.address}-${sdkChain}`.toLowerCase(),
+      chain:            vault.chain,
+      project:          PROJECT,
+      symbol:           vault.symbol,
+      tvlUsd,
+      apyBase:          Math.round(apyBase * 100) / 100, // round to 2 dp
+      underlyingTokens: [vault.stablecoin],
+      poolMeta:         vault.poolMeta,
+      url:              'https://earn.scrub.money',
+    });
+  }
+
+  return pools;
+};
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: 'https://earn.scrub.money',
+};

--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -26,8 +26,9 @@
  *   a primary source with direct event computation as a fallback.
  */
 
-const sdk   = require('@defillama/sdk');
-const axios = require('axios');
+const sdk    = require('@defillama/sdk');
+const axios  = require('axios');
+const { ethers } = require('ethers');
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -64,9 +65,14 @@ const TOTAL_VAULT_VALUE_ABI = {
   type: 'function',
 };
 
+const REWARD_DISTRIBUTED_ABI =
+  'event RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)';
+
 // keccak256("RewardDistributed(int256,uint256,uint256)")
 const REWARD_DISTRIBUTED_TOPIC =
   '0x7e4e42cfa6e77e4567e0e9540568546a5e29c29438d9d7c6b05db0db29f5fd51';
+
+const rewardIface = new ethers.utils.Interface([REWARD_DISTRIBUTED_ABI]);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -86,7 +92,7 @@ async function fetchTvlUsd(chain, vaultAddress, decimals) {
 /**
  * Try to read the rolling APR from the Kava subgraph.
  * The `apr` field is stored as an integer scaled by 10 000 (where 10 000 = 100 %).
- * Returns a plain percentage number, e.g. 8.5 for 8.5 % APR, or null on failure.
+ * Returns a finite percentage number, e.g. 8.5 for 8.5 % APR, or null on any failure.
  */
 async function fetchAprFromSubgraph(subgraphUrl, vaultAddress) {
   if (!subgraphUrl) return null;
@@ -100,82 +106,58 @@ async function fetchAprFromSubgraph(subgraphUrl, vaultAddress) {
     const aprRaw = data?.data?.vault?.apr;
     if (aprRaw == null) return null;
     // apr is in basis-points × 100: divide by 100 to get plain percentage
-    return Number(aprRaw) / 100;
+    const apr = Number(aprRaw) / 100;
+    return Number.isFinite(apr) ? apr : null;
   } catch (_) {
     return null;
   }
 }
 
 /**
- * Compute a rolling 30-day APY from on-chain `RewardDistributed` events using
- * a direct eth_getLogs RPC call. Returns a plain percentage or 0 on failure.
+ * Compute a rolling 30-day APR from on-chain `RewardDistributed` events using
+ * the DefiLlama SDK. Returns a plain percentage or 0 on failure.
  *
- * Event signature: RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)
- * We only count positive rewards (negative = loss events) for the APY figure.
+ * Event: RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)
+ * Only positive rewards count toward APY.
  */
 async function fetchAprFromEvents(chain, vaultAddress, tvlUsd, decimals) {
   try {
-    const chainToRpc = {
-      kava:     'https://evm.kava.io',
-      arbitrum: 'https://arb1.arbitrum.io/rpc',
-    };
-    const rpc = chainToRpc[chain];
-    if (!rpc) return 0;
-
     const nowSec      = Math.floor(Date.now() / 1000);
     const windowSec   = 30 * 24 * 60 * 60; // 30 days
     const fromTimeSec = nowSec - windowSec;
 
-    // Approximate block numbers (used as a wide filter — exact time filtering
-    // happens by comparing the decoded timestamp in each log).
+    // Approximate block window — exact time filtering happens via decoded timestamp.
     const avgBlockTime = chain === 'kava' ? 6 : 0.25;
     const blocksWindow = Math.ceil(windowSec / avgBlockTime);
 
-    // Fetch latest block number
-    const latestResp = await axios.post(rpc, {
-      jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [],
-    }, { timeout: 8000 });
-    const latestBlock = parseInt(latestResp.data.result, 16);
-    const fromBlock   = Math.max(0, latestBlock - blocksWindow);
+    const currentBlock = await sdk.api.util.getLatestBlock(chain);
+    const latestBlock  = currentBlock.number;
+    const fromBlock    = Math.max(0, latestBlock - blocksWindow);
 
-    // Fetch logs
-    const logsResp = await axios.post(rpc, {
-      jsonrpc: '2.0', id: 2,
-      method: 'eth_getLogs',
-      params: [{
-        fromBlock: '0x' + fromBlock.toString(16),
-        toBlock:   '0x' + latestBlock.toString(16),
-        address:   vaultAddress,
-        topics:    [REWARD_DISTRIBUTED_TOPIC],
-      }],
-    }, { timeout: 12000 });
+    const { output: logs } = await sdk.api.util.getLogs({
+      target:    vaultAddress,
+      topic:     '',
+      fromBlock,
+      toBlock:   latestBlock,
+      keys:      [],
+      topics:    [REWARD_DISTRIBUTED_TOPIC],
+      chain,
+    });
 
-    const logs = logsResp.data.result ?? [];
     if (!logs.length) return 0;
 
-    // Each log: data = abi.encode(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)
-    // 3 × 32-byte words, no indexed params
-    let totalRewardUsd = 0;
+    let totalRewardUsd  = 0;
     let oldestTimestamp = nowSec;
 
     for (const log of logs) {
-      const data  = log.data.slice(2); // strip 0x
-      // word 0: rewardAmount (int256, signed) — positive means profit
-      const rewardHex = data.slice(0, 64);
-      const rewardBig = BigInt('0x' + rewardHex);
-      // interpret as signed: if top bit set, it's negative
-      const rewardSigned =
-        rewardBig > BigInt('0x7' + 'f'.repeat(63))
-          ? rewardBig - BigInt('0x1' + '0'.repeat(64))
-          : rewardBig;
-
-      // word 2: timestamp
-      const tsSec = parseInt(data.slice(128, 192), 16);
+      const parsed     = rewardIface.parseLog(log);
+      const rewardRaw  = parsed.args.rewardAmount; // ethers BigNumber (signed)
+      const tsSec      = parsed.args.timestamp.toNumber();
 
       if (tsSec < fromTimeSec) continue; // outside 30-day window
-      if (rewardSigned <= 0n) continue;  // losses don't count toward APY
+      if (rewardRaw.lte(0)) continue;    // losses don't count toward APY
 
-      totalRewardUsd += Number(rewardSigned) / 10 ** decimals;
+      totalRewardUsd += rewardRaw.toNumber() / 10 ** decimals;
       if (tsSec < oldestTimestamp) oldestTimestamp = tsSec;
     }
 
@@ -202,9 +184,12 @@ const apy = async () => {
 
     // APY: prefer subgraph (already computes rolling 30-day APR), fall back to events
     let apyBase = await fetchAprFromSubgraph(vault.subgraphUrl, vault.address);
-    if (apyBase == null) {
+    if (!Number.isFinite(apyBase)) {
       apyBase = await fetchAprFromEvents(sdkChain, vault.address, tvlUsd, vault.decimals);
     }
+
+    // Dynamic vault URL using chain name and vault address
+    const vaultUrl = `https://invest.scrub.money/vault/chain/${sdkChain}/${vault.address.toLowerCase()}`;
 
     pools.push({
       pool:             `${vault.address}-${sdkChain}`.toLowerCase(),
@@ -215,7 +200,7 @@ const apy = async () => {
       apyBase:          Math.round(apyBase * 100) / 100, // round to 2 dp
       underlyingTokens: [vault.stablecoin],
       poolMeta:         vault.poolMeta,
-      url:              'https://invest.scrub.money/',
+      url:              vaultUrl,
     });
   }
 

--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -215,7 +215,7 @@ const apy = async () => {
       apyBase:          Math.round(apyBase * 100) / 100, // round to 2 dp
       underlyingTokens: [vault.stablecoin],
       poolMeta:         vault.poolMeta,
-      url:              'https://earn.scrub.money',
+      url:              'https://invest.scrub.money/',
     });
   }
 
@@ -225,5 +225,5 @@ const apy = async () => {
 module.exports = {
   timetravel: false,
   apy,
-  url: 'https://earn.scrub.money',
+  url: 'https://invest.scrub.money/',
 };

--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -17,17 +17,20 @@
  *   value, not on a simple `balanceOf` check.
  *
  * APY methodology:
- *   Rolling 30-day APY is derived from `RewardDistributed` events emitted by
- *   each vault. For each reward event we record `rewardAmount` and the elapsed
- *   time since the previous reward. We sum all rewards in the 30-day window,
- *   divide by the pre-reward TVL at the start of that window, and annualise.
- *   The Kava vault additionally exposes this value via its subgraph (field `apr`
- *   in basis-points × 100, i.e. 10 000 = 100 %). The subgraph value is used as
- *   a primary source with direct event computation as a fallback.
+ *   Daily APR is derived from the most recent `RewardDistributed` event within
+ *   the past 3 days. Rewards are distributed once per day (6 pm - 1 am UTC),
+ *   so a 3-day lookback always captures at least one event.
+ *   APR formula: rewardAmount / prevTVL * 365 * 100.
+ *
+ *   Logs are fetched via the DefiLlama SDK for both chains:
+ *   - Arbitrum: single sdk.api.util.getLogs call (no per-request block limit).
+ *   - Kava: RPC caps eth_getLogs at 10 000 blocks, so the 3-day window
+ *     (~43 200 blocks) is split into 5 parallel SDK calls.
+ *   - Kava's latest block is obtained via ethers.providers.JsonRpcProvider
+ *     because sdk.api.util.getLatestBlock does not support Kava.
  */
 
-const sdk    = require('@defillama/sdk');
-const axios  = require('axios');
+const sdk        = require('@defillama/sdk');
 const { ethers } = require('ethers');
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -36,50 +39,56 @@ const PROJECT = 'scrub';
 
 const VAULTS = {
   kava: {
-    chain:         'Kava',
-    address:       '0x7BFf6c730dA681dF03364c955B165576186370Bc',
-    stablecoin:    '0x919C1c267BC06a7039e03fcc2eF738525769109c', // USDt on Kava
-    symbol:        'USDt',
-    decimals:      6,
-    subgraphUrl:   'https://subgraph.scrub.money/subgraphs/name/scrubvault',
-    poolMeta:      'Delta Neutral USDt Vault',
+    chain:        'Kava',
+    address:      '0x7BFf6c730dA681dF03364c955B165576186370Bc',
+    stablecoin:   '0x919C1c267BC06a7039e03fcc2eF738525769109c', // USDt on Kava
+    symbol:       'USDt',
+    decimals:     6,
+    poolMeta:     'Delta Neutral USDt Vault',
+    logChunkSize: 10000, // Kava RPC limit per eth_getLogs request
+    blockTime:    6,     // seconds per block
+    rpcUrl:       'https://evm.kava.io',
   },
   arbitrum: {
-    chain:         'Arbitrum',
-    address:       '0x439a923517C4DFD3F3d0ABb0C36E356D39CF3f9D',
-    stablecoin:    '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // USDC (native) on Arbitrum
-    symbol:        'USDC',
-    decimals:      6,
-    subgraphUrl:   null, // subgraph deployment pending — will be filled once live
-    poolMeta:      'Delta Neutral USDC Vault',
+    chain:        'Arbitrum',
+    address:      '0x439a923517C4DFD3F3d0ABb0C36E356D39CF3f9D',
+    stablecoin:   '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', // native USDC
+    symbol:       'USDC',
+    decimals:     6,
+    poolMeta:     'Delta Neutral USDC Vault',
+    logChunkSize: null,  // Arbitrum handles large ranges in one call
+    blockTime:    0.25,
+    rpcUrl:       null,  // use sdk.api.util.getLatestBlock
   },
 };
 
-// ─── ABI fragments ────────────────────────────────────────────────────────────
+// ─── ABI / event setup ───────────────────────────────────────────────────────
 
 const TOTAL_VAULT_VALUE_ABI = {
-  inputs:  [],
-  name:    'totalVaultValue',
-  outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+  inputs:          [],
+  name:            'totalVaultValue',
+  outputs:         [{ internalType: 'uint256', name: '', type: 'uint256' }],
   stateMutability: 'view',
-  type: 'function',
+  type:            'function',
 };
 
-const REWARD_DISTRIBUTED_ABI =
-  'event RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)';
-
-// keccak256("RewardDistributed(int256,uint256,uint256)")
-const REWARD_DISTRIBUTED_TOPIC =
-  '0x7e4e42cfa6e77e4567e0e9540568546a5e29c29438d9d7c6b05db0db29f5fd51';
-
-const rewardIface = new ethers.utils.Interface([REWARD_DISTRIBUTED_ABI]);
+const rewardIface  = new ethers.utils.Interface([
+  'event RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)',
+]);
+const REWARD_TOPIC = rewardIface.getEventTopic('RewardDistributed');
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-/**
- * Fetch the current `totalVaultValue` (6-decimal stablecoin units) from the
- * DepositVault contract and return the USD equivalent.
- */
+async function getLatestBlockNumber(chainKey, rpcUrl) {
+  if (rpcUrl) {
+    // sdk.api.util.getLatestBlock does not support all chains (e.g. Kava).
+    // Fall back to a direct JSON-RPC call via ethers — already a dependency.
+    const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+    return provider.getBlockNumber();
+  }
+  return (await sdk.api.util.getLatestBlock(chainKey)).number;
+}
+
 async function fetchTvlUsd(chain, vaultAddress, decimals) {
   const { output } = await sdk.api.abi.call({
     abi:    TOTAL_VAULT_VALUE_ABI,
@@ -89,86 +98,56 @@ async function fetchTvlUsd(chain, vaultAddress, decimals) {
   return Number(output) / 10 ** decimals;
 }
 
-/**
- * Try to read the rolling APR from the Kava subgraph.
- * The `apr` field is stored as an integer scaled by 10 000 (where 10 000 = 100 %).
- * Returns a finite percentage number, e.g. 8.5 for 8.5 % APR, or null on any failure.
- */
-async function fetchAprFromSubgraph(subgraphUrl, vaultAddress) {
-  if (!subgraphUrl) return null;
-  try {
-    const query = `{
-      vault(id: "${vaultAddress.toLowerCase()}") {
-        apr
-      }
-    }`;
-    const { data } = await axios.post(subgraphUrl, { query }, { timeout: 8000 });
-    const aprRaw = data?.data?.vault?.apr;
-    if (aprRaw == null) return null;
-    // apr is in basis-points × 100: divide by 100 to get plain percentage
-    const apr = Number(aprRaw) / 100;
-    return Number.isFinite(apr) ? apr : null;
-  } catch (_) {
-    return null;
-  }
-}
+async function fetchRewardLogs(chain, vaultAddress, latestBlock, blockTime, chunkSize) {
+  const blockWindow = Math.ceil(3 * 24 * 3600 / blockTime); // 3-day window
+  const fromBlock   = Math.max(0, latestBlock - blockWindow);
 
-/**
- * Compute a rolling 30-day APR from on-chain `RewardDistributed` events using
- * the DefiLlama SDK. Returns a plain percentage or 0 on failure.
- *
- * Event: RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)
- * Only positive rewards count toward APY.
- */
-async function fetchAprFromEvents(chain, vaultAddress, tvlUsd, decimals) {
-  try {
-    const nowSec      = Math.floor(Date.now() / 1000);
-    const windowSec   = 30 * 24 * 60 * 60; // 30 days
-    const fromTimeSec = nowSec - windowSec;
-
-    // Approximate block window — exact time filtering happens via decoded timestamp.
-    const avgBlockTime = chain === 'kava' ? 6 : 0.25;
-    const blocksWindow = Math.ceil(windowSec / avgBlockTime);
-
-    const currentBlock = await sdk.api.util.getLatestBlock(chain);
-    const latestBlock  = currentBlock.number;
-    const fromBlock    = Math.max(0, latestBlock - blocksWindow);
-
-    const { output: logs } = await sdk.api.util.getLogs({
+  const logsCall = (from, to) =>
+    sdk.api.util.getLogs({
       target:    vaultAddress,
       topic:     '',
-      fromBlock,
-      toBlock:   latestBlock,
+      fromBlock: from,
+      toBlock:   to,
       keys:      [],
-      topics:    [REWARD_DISTRIBUTED_TOPIC],
+      topics:    [REWARD_TOPIC],
       chain,
-    });
+    }).then((r) => r.output || []).catch(() => []);
 
-    if (!logs.length) return 0;
-
-    let totalRewardUsd  = 0;
-    let oldestTimestamp = nowSec;
-
-    for (const log of logs) {
-      const parsed     = rewardIface.parseLog(log);
-      const rewardRaw  = parsed.args.rewardAmount; // ethers BigNumber (signed)
-      const tsSec      = parsed.args.timestamp.toNumber();
-
-      if (tsSec < fromTimeSec) continue; // outside 30-day window
-      if (rewardRaw.lte(0)) continue;    // losses don't count toward APY
-
-      totalRewardUsd += rewardRaw.toNumber() / 10 ** decimals;
-      if (tsSec < oldestTimestamp) oldestTimestamp = tsSec;
-    }
-
-    if (totalRewardUsd === 0 || tvlUsd === 0) return 0;
-
-    const elapsedDays = Math.max((nowSec - oldestTimestamp) / 86400, 1);
-    const apr = (totalRewardUsd / tvlUsd) * (365 / elapsedDays) * 100;
-    return Math.max(0, apr);
-  } catch (_) {
-    return 0;
+  if (!chunkSize) {
+    return logsCall(fromBlock, latestBlock);
   }
+
+  // Kava: split 3-day window into parallel 10k-block chunks (~5 chunks)
+  const chunks = [];
+  for (let s = fromBlock; s <= latestBlock; s += chunkSize) {
+    chunks.push([s, Math.min(s + chunkSize - 1, latestBlock)]);
+  }
+  const results = await Promise.all(chunks.map(([f, t]) => logsCall(f, t)));
+  return results.flat();
+}
+
+function computeDailyApr(logs, decimals) {
+  // Iterate newest-first to find the most recent positive reward event.
+  for (let i = logs.length - 1; i >= 0; i--) {
+    try {
+      const parsed = rewardIface.parseLog(logs[i]);
+      const reward = parsed.args.rewardAmount; // int256, may be negative on a loss day
+      const newTvl = parsed.args.newTotalVaultValue;
+
+      if (reward.lte(0)) continue;
+
+      const rewardUsd = reward.toNumber()             / 10 ** decimals;
+      const prevTvl   = newTvl.sub(reward).toNumber() / 10 ** decimals;
+
+      if (prevTvl <= 0) continue;
+
+      const apr = (rewardUsd / prevTvl) * 365 * 100;
+      return Number.isFinite(apr) ? Math.max(0, apr) : 0;
+    } catch (_) {
+      continue;
+    }
+  }
+  return 0;
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
@@ -177,27 +156,30 @@ const apy = async () => {
   const pools = [];
 
   for (const [chainKey, vault] of Object.entries(VAULTS)) {
-    const sdkChain = chainKey; // sdk uses lowercase chain names
+    const latestBlock = await getLatestBlockNumber(chainKey, vault.rpcUrl);
 
-    // TVL
-    const tvlUsd = await fetchTvlUsd(sdkChain, vault.address, vault.decimals);
+    const [tvlUsd, logs] = await Promise.all([
+      fetchTvlUsd(chainKey, vault.address, vault.decimals),
+      fetchRewardLogs(
+        chainKey,
+        vault.address,
+        latestBlock,
+        vault.blockTime,
+        vault.logChunkSize,
+      ),
+    ]);
 
-    // APY: prefer subgraph (already computes rolling 30-day APR), fall back to events
-    let apyBase = await fetchAprFromSubgraph(vault.subgraphUrl, vault.address);
-    if (!Number.isFinite(apyBase)) {
-      apyBase = await fetchAprFromEvents(sdkChain, vault.address, tvlUsd, vault.decimals);
-    }
-
-    // Dynamic vault URL using chain name and vault address
-    const vaultUrl = `https://invest.scrub.money/vault/chain/${sdkChain}/${vault.address.toLowerCase()}`;
+    const apyBase  = computeDailyApr(logs, vault.decimals);
+    const vaultUrl =
+      `https://invest.scrub.money/vault/chain/${chainKey}/${vault.address.toLowerCase()}`;
 
     pools.push({
-      pool:             `${vault.address}-${sdkChain}`.toLowerCase(),
+      pool:             `${vault.address}-${chainKey}`.toLowerCase(),
       chain:            vault.chain,
       project:          PROJECT,
       symbol:           vault.symbol,
       tvlUsd,
-      apyBase:          Math.round(apyBase * 100) / 100, // round to 2 dp
+      apyBase:          Math.round(apyBase * 100) / 100,
       underlyingTokens: [vault.stablecoin],
       poolMeta:         vault.poolMeta,
       url:              vaultUrl,

--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -74,6 +74,18 @@ const TOTAL_VAULT_VALUE_ABI = {
   type:            'function',
 };
 
+// shareValue() returns the USD value of one vault share, always 18 decimals,
+// regardless of the underlying stablecoin's decimals. Returns 1e18 when no
+// shares have been minted yet (1:1 default).
+const SHARE_VALUE_ABI = {
+  inputs:          [],
+  name:            'shareValue',
+  outputs:         [{ internalType: 'uint256', name: '', type: 'uint256' }],
+  stateMutability: 'view',
+  type:            'function',
+};
+const SHARE_VALUE_DECIMALS = 18;
+
 const rewardIface  = new ethers.utils.Interface([
   'event RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)',
 ]);
@@ -99,6 +111,16 @@ async function fetchTvlUsd(chain, vaultAddress, decimals) {
   });
   // formatUnits is overflow-safe for 256-bit values; Number coercion alone is not.
   return Number(ethers.utils.formatUnits(output, decimals));
+}
+
+async function fetchPricePerShare(chain, vaultAddress) {
+  const { output } = await sdk.api.abi.call({
+    abi:    SHARE_VALUE_ABI,
+    target: vaultAddress,
+    chain,
+  });
+  // shareValue() is always 18-decimal USD regardless of stablecoin decimals.
+  return Number(ethers.utils.formatUnits(output, SHARE_VALUE_DECIMALS));
 }
 
 async function fetchRewardLogs(chain, vaultAddress, latestBlock, blockTime, chunkSize) {
@@ -179,7 +201,7 @@ const apy = async () => {
     try {
       const latestBlock = await getLatestBlockNumber(chainKey, vault.rpcUrl);
 
-      const [tvlUsd, logs] = await Promise.all([
+      const [tvlUsd, logs, pricePerShare] = await Promise.all([
         fetchTvlUsd(chainKey, vault.address, vault.decimals),
         fetchRewardLogs(
           chainKey,
@@ -188,6 +210,7 @@ const apy = async () => {
           vault.blockTime,
           vault.logChunkSize,
         ),
+        fetchPricePerShare(chainKey, vault.address),
       ]);
 
       const apyBase  = computeDailyApr(logs, vault.decimals);
@@ -204,6 +227,7 @@ const apy = async () => {
         underlyingTokens: [vault.stablecoin],
         poolMeta:         vault.poolMeta,
         url:              vaultUrl,
+        pricePerShare:    Math.round(pricePerShare * 1e6) / 1e6,
       });
     } catch (err) {
       console.error(

--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -97,13 +97,17 @@ async function fetchTvlUsd(chain, vaultAddress, decimals) {
     target: vaultAddress,
     chain,
   });
-  return Number(output) / 10 ** decimals;
+  // formatUnits is overflow-safe for 256-bit values; Number coercion alone is not.
+  return Number(ethers.utils.formatUnits(output, decimals));
 }
 
 async function fetchRewardLogs(chain, vaultAddress, latestBlock, blockTime, chunkSize) {
   const blockWindow = Math.ceil(3 * 24 * 3600 / blockTime); // 3-day window
   const fromBlock   = Math.max(0, latestBlock - blockWindow);
 
+  // Let RPC/SDK errors propagate to the per-vault try/catch in apy(); swallowing
+  // them here would make a network failure indistinguishable from "no rewards"
+  // and the vault would be emitted with apyBase: 0.
   const logsCall = (from, to) =>
     sdk.api.util.getLogs({
       target:    vaultAddress,
@@ -113,7 +117,7 @@ async function fetchRewardLogs(chain, vaultAddress, latestBlock, blockTime, chun
       keys:      [],
       topics:    [REWARD_TOPIC],
       chain,
-    }).then((r) => r.output || []).catch(() => []);
+    }).then((r) => r.output || []);
 
   if (!chunkSize) {
     return logsCall(fromBlock, latestBlock);

--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -26,7 +26,8 @@
  *
  *   Block numbers and logs are fetched via the DefiLlama SDK for both chains:
  *   - Latest block: sdk.api.util.getLatestBlock(chain).
- *   - Arbitrum: single sdk.api.util.getLogs call (no per-request block limit).
+ *   - Logs: sdk.getEventLogs with the RewardDistributed event ABI.
+ *   - Arbitrum: single getEventLogs call (no per-request block limit).
  *   - Kava: RPC caps eth_getLogs at 10 000 blocks, so the 3-day window
  *     (~43 200 blocks) is split into 5 parallel SDK calls.
  */
@@ -83,10 +84,8 @@ const SHARE_VALUE_ABI = {
 };
 const SHARE_VALUE_DECIMALS = 18;
 
-const rewardIface  = new ethers.utils.Interface([
-  'event RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)',
-]);
-const REWARD_TOPIC = rewardIface.getEventTopic('RewardDistributed');
+const REWARD_EVENT_ABI =
+  'event RewardDistributed(int256 rewardAmount, uint256 newTotalVaultValue, uint256 timestamp)';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -114,19 +113,18 @@ async function fetchRewardLogs(chain, vaultAddress, latestBlock, blockTime, chun
   const blockWindow = Math.ceil(3 * 24 * 3600 / blockTime); // 3-day window
   const fromBlock   = Math.max(0, latestBlock - blockWindow);
 
-  // Let RPC/SDK errors propagate to the per-vault try/catch in apy(); swallowing
-  // them here would make a network failure indistinguishable from "no rewards"
-  // and the vault would be emitted with apyBase: 0.
+  // sdk.getEventLogs (event-ABI based) for consistency with the rest of the
+  // codebase; it returns logs pre-decoded into `.args`. Errors propagate to
+  // the per-vault try/catch in apy() — not swallowed — so an RPC failure is
+  // never reported as a real 0% APR.
   const logsCall = (from, to) =>
-    sdk.api.util.getLogs({
+    sdk.getEventLogs({
       target:    vaultAddress,
-      topic:     '',
+      eventAbi:  REWARD_EVENT_ABI,
       fromBlock: from,
       toBlock:   to,
-      keys:      [],
-      topics:    [REWARD_TOPIC],
       chain,
-    }).then((r) => r.output || []);
+    });
 
   if (!chunkSize) {
     return logsCall(fromBlock, latestBlock);
@@ -142,31 +140,28 @@ async function fetchRewardLogs(chain, vaultAddress, latestBlock, blockTime, chun
 }
 
 function computeDailyApr(logs, decimals) {
-  // Parse all events in the window (logs are in chronological order, oldest first).
-  const events = [];
-  for (const log of logs) {
-    try {
-      const p = rewardIface.parseLog(log);
-      events.push({ reward: p.args.rewardAmount, newTvl: p.args.newTotalVaultValue });
-    } catch (_) {
-      // skip unparseable logs
-    }
-  }
+  // Logs are pre-decoded by sdk.getEventLogs (oldest first); args are BigInt.
+  const events = logs
+    .filter((l) => l && l.args)
+    .map((l) => ({
+      reward: BigInt(l.args.rewardAmount),         // int256 — negative on loss days
+      newTvl: BigInt(l.args.newTotalVaultValue),   // uint256
+    }));
   if (!events.length) return 0;
 
   // Sum all rewards across the window — negative (loss) days are included so
   // the result reflects the true rolling return, not just positive days.
-  let totalReward = ethers.BigNumber.from(0);
+  let totalReward = 0n;
   for (const { reward } of events) {
-    totalReward = totalReward.add(reward);
+    totalReward += reward;
   }
 
   // TVL before the earliest event in the window is used as the denominator.
-  const firstPrevTvl = events[0].newTvl.sub(events[0].reward);
-  if (firstPrevTvl.lte(0)) return 0;
+  const firstPrevTvl = events[0].newTvl - events[0].reward;
+  if (firstPrevTvl <= 0n) return 0;
 
-  // Use formatUnits instead of toNumber() to avoid Number.MAX_SAFE_INTEGER
-  // overflow on large balances (toNumber throws above 2^53-1, ~$9B at 6 decimals).
+  // formatUnits is overflow-safe for 256-bit values and handles negatives;
+  // plain Number coercion is not.
   const totalRewardUsd = Number(ethers.utils.formatUnits(totalReward, decimals));
   const prevTvlUsd     = Number(ethers.utils.formatUnits(firstPrevTvl, decimals));
   if (prevTvlUsd <= 0) return 0;

--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -17,10 +17,12 @@
  *   value, not on a simple `balanceOf` check.
  *
  * APY methodology:
- *   Daily APR is derived from the most recent `RewardDistributed` event within
- *   the past 3 days. Rewards are distributed once per day (6 pm - 1 am UTC),
- *   so a 3-day lookback always captures at least one event.
- *   APR formula: rewardAmount / prevTVL * 365 * 100.
+ *   APR is derived from all `RewardDistributed` events within the past 3 days.
+ *   All events are included — negative (loss) days reduce the result so the
+ *   figure reflects the true rolling return, not just positive days.
+ *   Rewards are distributed once per day (6 pm - 1 am UTC), so a 3-day
+ *   lookback always captures at least one event.
+ *   APR formula: sum(rewardAmount over window) / prevTVL / windowDays * 365 * 100.
  *
  *   Logs are fetched via the DefiLlama SDK for both chains:
  *   - Arbitrum: single sdk.api.util.getLogs call (no per-request block limit).
@@ -127,27 +129,39 @@ async function fetchRewardLogs(chain, vaultAddress, latestBlock, blockTime, chun
 }
 
 function computeDailyApr(logs, decimals) {
-  // Iterate newest-first to find the most recent positive reward event.
-  for (let i = logs.length - 1; i >= 0; i--) {
+  // Parse all events in the window (logs are in chronological order, oldest first).
+  const events = [];
+  for (const log of logs) {
     try {
-      const parsed = rewardIface.parseLog(logs[i]);
-      const reward = parsed.args.rewardAmount; // int256, may be negative on a loss day
-      const newTvl = parsed.args.newTotalVaultValue;
-
-      if (reward.lte(0)) continue;
-
-      const rewardUsd = reward.toNumber()             / 10 ** decimals;
-      const prevTvl   = newTvl.sub(reward).toNumber() / 10 ** decimals;
-
-      if (prevTvl <= 0) continue;
-
-      const apr = (rewardUsd / prevTvl) * 365 * 100;
-      return Number.isFinite(apr) ? Math.max(0, apr) : 0;
+      const p = rewardIface.parseLog(log);
+      events.push({ reward: p.args.rewardAmount, newTvl: p.args.newTotalVaultValue });
     } catch (_) {
-      continue;
+      // skip unparseable logs
     }
   }
-  return 0;
+  if (!events.length) return 0;
+
+  // Sum all rewards across the window — negative (loss) days are included so
+  // the result reflects the true rolling return, not just positive days.
+  let totalReward = ethers.BigNumber.from(0);
+  for (const { reward } of events) {
+    totalReward = totalReward.add(reward);
+  }
+
+  // TVL before the earliest event in the window is used as the denominator.
+  const firstPrevTvl = events[0].newTvl.sub(events[0].reward);
+  if (firstPrevTvl.lte(0)) return 0;
+
+  // Use formatUnits instead of toNumber() to avoid Number.MAX_SAFE_INTEGER
+  // overflow on large balances (toNumber throws above 2^53-1, ~$9B at 6 decimals).
+  const totalRewardUsd = Number(ethers.utils.formatUnits(totalReward, decimals));
+  const prevTvlUsd     = Number(ethers.utils.formatUnits(firstPrevTvl, decimals));
+  if (prevTvlUsd <= 0) return 0;
+
+  // Annualise over the 3-day lookback window.
+  const WINDOW_DAYS = 3;
+  const apr = (totalRewardUsd / prevTvlUsd / WINDOW_DAYS) * 365 * 100;
+  return Number.isFinite(apr) ? apr : 0;
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
@@ -156,34 +170,42 @@ const apy = async () => {
   const pools = [];
 
   for (const [chainKey, vault] of Object.entries(VAULTS)) {
-    const latestBlock = await getLatestBlockNumber(chainKey, vault.rpcUrl);
+    // Wrap each vault independently so an RPC outage on one chain does not
+    // prevent the other chain's pool from being reported.
+    try {
+      const latestBlock = await getLatestBlockNumber(chainKey, vault.rpcUrl);
 
-    const [tvlUsd, logs] = await Promise.all([
-      fetchTvlUsd(chainKey, vault.address, vault.decimals),
-      fetchRewardLogs(
-        chainKey,
-        vault.address,
-        latestBlock,
-        vault.blockTime,
-        vault.logChunkSize,
-      ),
-    ]);
+      const [tvlUsd, logs] = await Promise.all([
+        fetchTvlUsd(chainKey, vault.address, vault.decimals),
+        fetchRewardLogs(
+          chainKey,
+          vault.address,
+          latestBlock,
+          vault.blockTime,
+          vault.logChunkSize,
+        ),
+      ]);
 
-    const apyBase  = computeDailyApr(logs, vault.decimals);
-    const vaultUrl =
-      `https://invest.scrub.money/vault/chain/${chainKey}/${vault.address.toLowerCase()}`;
+      const apyBase  = computeDailyApr(logs, vault.decimals);
+      const vaultUrl =
+        `https://invest.scrub.money/vault/chain/${chainKey}/${vault.address.toLowerCase()}`;
 
-    pools.push({
-      pool:             `${vault.address}-${chainKey}`.toLowerCase(),
-      chain:            vault.chain,
-      project:          PROJECT,
-      symbol:           vault.symbol,
-      tvlUsd,
-      apyBase:          Math.round(apyBase * 100) / 100,
-      underlyingTokens: [vault.stablecoin],
-      poolMeta:         vault.poolMeta,
-      url:              vaultUrl,
-    });
+      pools.push({
+        pool:             `${vault.address}-${chainKey}`.toLowerCase(),
+        chain:            vault.chain,
+        project:          PROJECT,
+        symbol:           vault.symbol,
+        tvlUsd,
+        apyBase:          Math.round(apyBase * 100) / 100,
+        underlyingTokens: [vault.stablecoin],
+        poolMeta:         vault.poolMeta,
+        url:              vaultUrl,
+      });
+    } catch (err) {
+      console.error(
+        `[scrub] ${vault.chain} vault ${vault.address} failed: ${err.message}`,
+      );
+    }
   }
 
   return pools;

--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -24,12 +24,11 @@
  *   lookback always captures at least one event.
  *   APR formula: sum(rewardAmount over window) / prevTVL / windowDays * 365 * 100.
  *
- *   Logs are fetched via the DefiLlama SDK for both chains:
+ *   Block numbers and logs are fetched via the DefiLlama SDK for both chains:
+ *   - Latest block: sdk.api.util.getLatestBlock(chain).
  *   - Arbitrum: single sdk.api.util.getLogs call (no per-request block limit).
  *   - Kava: RPC caps eth_getLogs at 10 000 blocks, so the 3-day window
  *     (~43 200 blocks) is split into 5 parallel SDK calls.
- *   - Kava's latest block is obtained via ethers.providers.JsonRpcProvider
- *     because sdk.api.util.getLatestBlock does not support Kava.
  */
 
 const sdk        = require('@defillama/sdk');
@@ -49,7 +48,6 @@ const VAULTS = {
     poolMeta:     'Delta Neutral USDt Vault',
     logChunkSize: 10000, // Kava RPC limit per eth_getLogs request
     blockTime:    6,     // seconds per block
-    rpcUrl:       'https://evm.kava.io',
   },
   arbitrum: {
     chain:        'Arbitrum',
@@ -60,7 +58,6 @@ const VAULTS = {
     poolMeta:     'Delta Neutral USDC Vault',
     logChunkSize: null,  // Arbitrum handles large ranges in one call
     blockTime:    0.25,
-    rpcUrl:       null,  // use sdk.api.util.getLatestBlock
   },
 };
 
@@ -92,16 +89,6 @@ const rewardIface  = new ethers.utils.Interface([
 const REWARD_TOPIC = rewardIface.getEventTopic('RewardDistributed');
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-async function getLatestBlockNumber(chainKey, rpcUrl) {
-  if (rpcUrl) {
-    // sdk.api.util.getLatestBlock does not support all chains (e.g. Kava).
-    // Fall back to a direct JSON-RPC call via ethers — already a dependency.
-    const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
-    return provider.getBlockNumber();
-  }
-  return (await sdk.api.util.getLatestBlock(chainKey)).number;
-}
 
 async function fetchTvlUsd(chain, vaultAddress, decimals) {
   const { output } = await sdk.api.abi.call({
@@ -199,7 +186,7 @@ const apy = async () => {
     // Wrap each vault independently so an RPC outage on one chain does not
     // prevent the other chain's pool from being reported.
     try {
-      const latestBlock = await getLatestBlockNumber(chainKey, vault.rpcUrl);
+      const latestBlock = (await sdk.api.util.getLatestBlock(chainKey)).number;
 
       const [tvlUsd, logs, pricePerShare] = await Promise.all([
         fetchTvlUsd(chainKey, vault.address, vault.decimals),

--- a/src/adaptors/scrub/index.js
+++ b/src/adaptors/scrub/index.js
@@ -205,11 +205,11 @@ const apy = async () => {
         project:          PROJECT,
         symbol:           vault.symbol,
         tvlUsd,
-        apyBase:          Math.round(apyBase * 100) / 100,
+        apyBase,
         underlyingTokens: [vault.stablecoin],
         poolMeta:         vault.poolMeta,
         url:              vaultUrl,
-        pricePerShare:    Math.round(pricePerShare * 1e6) / 1e6,
+        pricePerShare,
       });
     } catch (err) {
       console.error(


### PR DESCRIPTION
> Replaces #2564, which had to be closed and recreated because the source branch was force-pushed (commit history was rewritten for hygiene; same feature, same diff).

---

## Summary

Adds a yield adapter under `src/adaptors/scrub/` tracking the two ScrubVault DepositVault pools, reusing the existing **scrub** protocol slug.

## What is ScrubVault?

ScrubVault is a delta-neutral managed vault where users deposit USDt (Kava) or USDC (Arbitrum) and receive share tokens. Capital is deployed off-chain across CEXs and DEXs running a delta-neutral funding-rate and market-making strategy.

## Why funds are not sitting in the contract

The vault contract acts as an on-chain accounting and settlement layer. Once deposits are processed, stablecoins move to the strategy wallet and are actively deployed on exchanges. The on-chain `totalVaultValue` is the authoritative AUM figure, updated via `distributeRewards()` each time PnL is settled. TVL and APY here reflect **assets under management**, not tokens in the contract.

## APY methodology

- **Kava pool**: rolling 30-day APR read from the live Kava subgraph (`apr` field, basis-points ×100), with on-chain `RewardDistributed` event fallback.
- **Arbitrum pool**: APR computed from `RewardDistributed` events via `eth_getLogs`, annualised over a 30-day window. Returns 0 until reward history accumulates (vault is newly deployed).

## Pools

| Pool ID | Chain | Token | Live TVL | Live APY |
|---|---|---|---|---|
| `0x7bff6c730da681df03364c955b165576186370bc-kava` | Kava | USDt | ~$42k | ~12.5% |
| `0x439a923517c4dfd3f3d0abb0c36e356d39cf3f9d-arbitrum` | Arbitrum | USDC | ~$2.8k | 0% (new) |

Note: the Arbitrum pool is below the $10k display threshold today — it will appear automatically once TVL grows.

## Test results

All 16 adapter tests pass (`npm run test --adapter=scrub`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ScrubVault yield adapter for Kava (USDt) and Arbitrum (USDC).
  * Provides per-vault TVL, price-per-share, and annualized APY (computed from a ~3-day event window).
  * Includes vault links and underlying token info.
  * Per-vault failures are isolated so one failing vault won’t block other results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->