### PR TITLE
feat: add Brix wiTRY yield adapter

### DIFF
--- a/src/adaptors/brix/index.js
+++ b/src/adaptors/brix/index.js
@@ -1,0 +1,149 @@
+const sdk = require('@defillama/sdk');
+const axios = require('axios');
+
+const ITRY = '0xb492B4aFD9658093694CF9452D5C272e8230F3B0';
+const WITRY = '0xE346C29b5B60Ef870b9724c57ccfbBc631e47DEE';
+
+const LOOKBACK_DAYS = 7;
+const SCAN_DAYS = 21;
+const SECONDS_PER_DAY = 86400;
+const DAYS_PER_YEAR = 365;
+const ONE_WITRY = '1000000000000000000';
+
+const abiConvertToAssets =
+  'function convertToAssets(uint256 shares) view returns (uint256)';
+const abiTotalAssets = 'uint256:totalAssets';
+const abiGetVestingPeriod = 'function getVestingPeriod() view returns (uint256)';
+const eventRewardsReceived = 'event RewardsReceived(uint256 amount)';
+
+async function getRateAtBlock(block) {
+  const { output } = await sdk.api.abi.call({
+    target: WITRY,
+    abi: abiConvertToAssets,
+    params: [ONE_WITRY],
+    chain: 'ethereum',
+    block,
+  });
+  return Number(output) / 1e18;
+}
+
+// Distribution-anchored APY.
+//
+// Both endpoints of the lookback are anchored to actual on-chain
+// RewardsReceived events. When no distribution arrives (Turkish holidays,
+// weekends, bayrams) both anchors freeze → APY stays flat. The catch-up
+// distribution at the end of a gap is absorbed symmetrically by both
+// anchors → no spike.
+//
+// Vesting-aware sampling: wiTRY follows the Ethena V2 pattern where
+// RewardsReceived adds to vestingAmount and unlocks linearly over
+// getVestingPeriod() seconds (currently 1h). totalAssets() subtracts the
+// unvested amount, so convertToAssets() at the event's own block reflects
+// the pre-distribution state. To capture the distribution's effect we
+// sample the rate at event.ts + vestingPeriod (clamped to latest block).
+const apy = async () => {
+  const latest = await sdk.api.util.getLatestBlock('ethereum');
+
+  // Query vestingPeriod from the contract — don't hardcode. Wired up
+  // because the VestingPeriodUpdated admin event implies this is mutable.
+  const { output: vestingPeriodRaw } = await sdk.api.abi.call({
+    target: WITRY,
+    abi: abiGetVestingPeriod,
+    chain: 'ethereum',
+  });
+  const vestingPeriod = Number(vestingPeriodRaw);
+
+  const fromTs = latest.timestamp - SCAN_DAYS * SECONDS_PER_DAY;
+  const { block: fromBlock } = await sdk.api.util.lookupBlock(fromTs, {
+    chain: 'ethereum',
+  });
+
+  // Pull every distribution event in the scan window.
+  const rawLogs = await sdk.getEventLogs({
+    target: WITRY,
+    eventAbi: eventRewardsReceived,
+    fromBlock,
+    toBlock: latest.number,
+    chain: 'ethereum',
+  });
+
+  // Each log needs a timestamp — fetch in parallel.
+  const events = await Promise.all(
+    rawLogs.map(async (l) => {
+      const ts = await sdk.api.util.getTimestamp(l.blockNumber, 'ethereum');
+      return { block: l.blockNumber, ts };
+    }),
+  );
+  events.sort((a, b) => a.ts - b.ts);
+
+  // Anchor selection. With <2 events we still try with whatever we have
+  // (early launch days); the fallback collapses both anchors to the same
+  // point, yielding apyBase = 0 rather than null — preserves a stable
+  // last value for downstream charts.
+  let apyBase = 0;
+  if (events.length >= 2) {
+    const endEvent = events[events.length - 1];
+    const startTarget = endEvent.ts - LOOKBACK_DAYS * SECONDS_PER_DAY;
+    let startEvent = events[0];
+    for (let i = events.length - 1; i >= 0; i--) {
+      if (events[i].ts <= startTarget) {
+        startEvent = events[i];
+        break;
+      }
+    }
+
+    // Sample rates at (event.ts + vestingPeriod) so the distribution
+    // emitted by each anchor event is fully reflected in convertToAssets.
+    // Clamp end to the latest block so we never query the future.
+    const endSampleTs = Math.min(latest.timestamp, endEvent.ts + vestingPeriod);
+    const startSampleTs = startEvent.ts + vestingPeriod;
+    const [{ block: endBlock }, { block: startBlock }] = await Promise.all([
+      sdk.api.util.lookupBlock(endSampleTs, { chain: 'ethereum' }),
+      sdk.api.util.lookupBlock(startSampleTs, { chain: 'ethereum' }),
+    ]);
+
+    const rateEnd = await getRateAtBlock(endBlock);
+    const rateStart = await getRateAtBlock(startBlock);
+    const elapsedDays = (endSampleTs - startSampleTs) / SECONDS_PER_DAY;
+
+    // convertToAssets growth is already net of the 10% performance fee —
+    // YieldForwarder deducts it before streaming iTRY into the vault.
+    if (elapsedDays > 0 && rateStart > 0) {
+      const ratioReturn = rateEnd / rateStart - 1;
+      apyBase =
+        (Math.pow(1 + ratioReturn, DAYS_PER_YEAR / elapsedDays) - 1) * 100;
+    }
+  }
+
+  const { output: totalAssetsRaw } = await sdk.api.abi.call({
+    target: WITRY,
+    abi: abiTotalAssets,
+    chain: 'ethereum',
+  });
+  const priceKey = `ethereum:${ITRY}`;
+  const priceResp = await axios.get(
+    `https://coins.llama.fi/prices/current/${priceKey}`,
+  );
+  const iTryPrice = priceResp.data.coins[priceKey]?.price ?? 0;
+  const tvlUsd = (Number(totalAssetsRaw) / 1e18) * iTryPrice;
+
+  return [
+    {
+      pool: `${WITRY.toLowerCase()}-ethereum`,
+      chain: 'Ethereum',
+      project: 'brix',
+      symbol: 'wiTRY',
+      tvlUsd,
+      apyBase,
+      underlyingTokens: [ITRY],
+      poolMeta: 'APY · distribution-anchored 7d',
+      url: 'https://app.brix.money',
+    },
+  ];
+};
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: 'https://app.brix.money',
+};

--- a/src/adaptors/brix/index.js
+++ b/src/adaptors/brix/index.js
@@ -142,6 +142,7 @@ const apy = async () => {
       apyBase,
       underlyingTokens: [ITRY],
       pricePerShare,
+      isIntrinsicSource: true,
       poolMeta: 'APY · distribution-anchored 7d',
       url: 'https://app.brix.money',
     },

--- a/src/adaptors/brix/index.js
+++ b/src/adaptors/brix/index.js
@@ -76,11 +76,11 @@ const apy = async () => {
   );
   events.sort((a, b) => a.ts - b.ts);
 
-  // Anchor selection. With <2 events we still try with whatever we have
-  // (early launch days); the fallback collapses both anchors to the same
-  // point, yielding apyBase = 0 rather than null — preserves a stable
-  // last value for downstream charts.
-  let apyBase = 0;
+  // Anchor selection. With <2 events we can't compute a meaningful
+  // 7-day rate (early launch days). Leave apyBase as null so the value
+  // is not ingested into the DefiLlama time-series — a 0 would be read
+  // as "APY was 0%" and skew downstream smoothing / averages.
+  let apyBase = null;
   if (events.length >= 2) {
     const endEvent = events[events.length - 1];
     const startTarget = endEvent.ts - LOOKBACK_DAYS * SECONDS_PER_DAY;
@@ -127,6 +127,11 @@ const apy = async () => {
   const iTryPrice = priceResp.data.coins[priceKey]?.price ?? 0;
   const tvlUsd = (Number(totalAssetsRaw) / 1e18) * iTryPrice;
 
+  // Current pricePerShare for the ERC-4626 vault: 1 wiTRY → N iTRY at the
+  // latest block. Sampled live (not from the APY anchors) so the UI always
+  // shows the current redemption rate.
+  const pricePerShare = await getRateAtBlock(latest.number);
+
   return [
     {
       pool: `${WITRY.toLowerCase()}-ethereum`,
@@ -136,6 +141,7 @@ const apy = async () => {
       tvlUsd,
       apyBase,
       underlyingTokens: [ITRY],
+      pricePerShare,
       poolMeta: 'APY · distribution-anchored 7d',
       url: 'https://app.brix.money',
     },


### PR DESCRIPTION
## Summary

Adds a yield adapter for wiTRY, the yield-bearing staking wrapper for Brix's iTRY (a TRY-pegged stablecoin backed by Turkish money market funds).

## APY methodology — distribution-anchored

Instead of sampling `convertToAssets(1e18)` at fixed "now" and "exactly 7 days ago" timestamps, both endpoints are anchored to actual on-chain `RewardsReceived` events emitted by the wiTRY vault every time yield is streamed in. This is robust to multi-day distribution gaps (Turkish public holidays, weekends, religious holidays) that would otherwise produce large false dips and spikes if a fixed `now − 7d` block were used.

```
1. Collect RewardsReceived(uint256) events from the wiTRY vault in the last 21 days.
2. end_event   = latest distribution
   start_event = latest event with ts ≤ end_event.ts − 7d (fallback: events[0])
3. vestingPeriod = getVestingPeriod() from the vault
   end_sample_ts   = min(now, end_event.ts + vestingPeriod)
   start_sample_ts = start_event.ts + vestingPeriod
4. rateEnd   = convertToAssets(1e18) at block(end_sample_ts)
   rateStart = convertToAssets(1e18) at block(start_sample_ts)
   elapsedDays = (end_sample_ts − start_sample_ts) / 86400   (dynamic, typically 7–9)
5. APY = (rateEnd / rateStart) ^ (365 / elapsedDays) − 1
```

**Why vesting-aware sampling.** wiTRY uses an Ethena V2-style vesting pattern where \`totalAssets()\` subtracts the unvested portion of the latest distribution. Reading \`convertToAssets\` at the distribution event's own block returns the pre-distribution rate — the new amount has been added to \`vestingAmount\` but is 0% unlocked. Sampling at \`event.ts + getVestingPeriod()\` (currently 3600s, read live from the contract — admin-mutable) ensures each anchor event's distribution is fully reflected.

**Why robust to holidays.** When no distribution arrives, both \`end_event\` and \`start_event\` stay frozen → APY stays flat. The catch-up distribution at the end of a gap shifts both anchors symmetrically (start_event also moves) → no spike. This was the key concern for a Turkish-yield protocol with frequent multi-day banking-holiday gaps.

**No fee multiplier needed.** The 10% performance fee is deducted by \`YieldForwarder\` before yield is streamed into the wiTRY vault, so \`convertToAssets\` growth already reflects net yield to wiTRY holders.

## Pool

- Chain: Ethereum
- Symbol: wiTRY
- Receipt token: \`0xE346C29b5B60Ef870b9724c57ccfbBc631e47DEE\`
- Underlying: iTRY (\`0xb492B4aFD9658093694CF9452D5C272e8230F3B0\`)
- TVL: \`totalAssets(wiTRY) × iTRY_USD_price\` via DefiLlama coins
- \`poolMeta\`: \`"APY · distribution-anchored 7d"\`

## Verified mainnet run

```json
{
  "pool": "0xe346c29b5b60ef870b9724c57ccfbbc631e47dee-ethereum",
  "chain": "Ethereum",
  "project": "brix",
  "symbol": "wiTRY",
  "tvlUsd": 0,
  "apyBase": 43.61888605833464,
  "underlyingTokens": ["0xb492B4aFD9658093694CF9452D5C272e8230F3B0"],
  "poolMeta": "APY · distribution-anchored 7d",
  "url": "https://app.brix.money"
}
```

\`tvlUsd: 0\` is expected and depends on the parallel price adapter PR landing in \`DefiLlama/defillama-server\`.

## Prerequisites

- TVL adapter must be merged (or in parallel) — yield-server requires the project slug \`brix\` to exist via the parallel TVL adapter PR in \`DefiLlama-Adapters\`.

## Project info

- App: https://app.brix.money
- Website: https://www.brix.money

Allow edits by maintainers: ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Brix protocol integration exposing a single wiTRY pool.
  * Provides a vesting-aware 7-day APY for wiTRY.
  * Shows total value locked (USD) for the pool.
  * Displays current price-per-share for wiTRY.
  * Includes a link to the Brix app for direct access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->