### PR TITLE
Add Covenant (Monad) Yield Coin pools

### DIFF
--- a/src/adaptors/covenant/covenant.json
+++ b/src/adaptors/covenant/covenant.json
@@ -1,0 +1,64 @@
+[
+  {
+    "type": "event",
+    "name": "CreateMarket",
+    "inputs": [
+      { "name": "marketId", "type": "bytes20", "indexed": true },
+      {
+        "name": "marketParams",
+        "type": "tuple",
+        "components": [
+          { "name": "baseToken", "type": "address" },
+          { "name": "quoteToken", "type": "address" },
+          { "name": "curator", "type": "address" },
+          { "name": "lex", "type": "address" }
+        ]
+      },
+      {
+        "name": "synthTokens",
+        "type": "tuple",
+        "components": [
+          { "name": "aToken", "type": "address" },
+          { "name": "zToken", "type": "address" }
+        ]
+      },
+      { "name": "initData", "type": "bytes" },
+      { "name": "lexData", "type": "bytes" }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "function",
+    "name": "getIdToMarketParams",
+    "stateMutability": "view",
+    "inputs": [{ "name": "marketId", "type": "bytes20" }],
+    "outputs": [
+      {
+        "type": "tuple",
+        "components": [
+          { "name": "baseToken", "type": "address" },
+          { "name": "quoteToken", "type": "address" },
+          { "name": "curator", "type": "address" },
+          { "name": "lex", "type": "address" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "getMarketState",
+    "stateMutability": "view",
+    "inputs": [{ "name": "marketId", "type": "bytes20" }],
+    "outputs": [
+      {
+        "type": "tuple",
+        "components": [
+          { "name": "baseSupply", "type": "uint256" },
+          { "name": "protocolFeeGrowth", "type": "uint128" },
+          { "name": "authorizedPauseAddress", "type": "address" },
+          { "name": "statusFlag", "type": "uint8" }
+        ]
+      }
+    ]
+  }
+]

--- a/src/adaptors/covenant/dataProvider.json
+++ b/src/adaptors/covenant/dataProvider.json
@@ -1,0 +1,770 @@
+[
+  {
+    "type": "function",
+    "name": "getMarketDetails",
+    "inputs": [
+      {
+        "name": "covenantLiquid",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "marketId",
+        "type": "bytes20",
+        "internalType": "MarketId"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "marketsDetails",
+        "type": "tuple",
+        "internalType": "struct MarketDetails",
+        "components": [
+          {
+            "name": "marketId",
+            "type": "bytes20",
+            "internalType": "MarketId"
+          },
+          {
+            "name": "baseToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "quoteToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "aToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "zToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "marketParams",
+            "type": "tuple",
+            "internalType": "struct MarketParams",
+            "components": [
+              {
+                "name": "baseToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quoteToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "curator",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "lex",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "marketState",
+            "type": "tuple",
+            "internalType": "struct MarketState",
+            "components": [
+              {
+                "name": "baseSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "protocolFeeGrowth",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "authorizedPauseAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "statusFlag",
+                "type": "uint8",
+                "internalType": "uint8"
+              }
+            ]
+          },
+          {
+            "name": "lexState",
+            "type": "tuple",
+            "internalType": "struct LexState",
+            "components": [
+              {
+                "name": "lastDebtNotionalPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastBaseTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastETWAPBaseSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "lastUpdateTimestamp",
+                "type": "uint96",
+                "internalType": "uint96"
+              },
+              {
+                "name": "lastLnRateBias",
+                "type": "int64",
+                "internalType": "int64"
+              }
+            ]
+          },
+          {
+            "name": "lexConfig",
+            "type": "tuple",
+            "internalType": "struct LexConfig",
+            "components": [
+              {
+                "name": "protocolFee",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "aToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "zToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "noCapLimit",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "scaleDecimals",
+                "type": "int8",
+                "internalType": "int8"
+              },
+              {
+                "name": "adaptive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "lexParams",
+            "type": "tuple",
+            "internalType": "struct LexParams",
+            "components": [
+              {
+                "name": "covenantCore",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "initLnRateBias",
+                "type": "int64",
+                "internalType": "int64"
+              },
+              {
+                "name": "edgeSqrtPriceX96_B",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "edgeSqrtPriceX96_A",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "limHighSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "limMaxSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "debtDuration",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "swapFee",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "targetXvsL",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentLTV",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "targetLTV",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "debtPriceDiscount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "tokenPrices",
+            "type": "tuple",
+            "internalType": "struct TokenPrices",
+            "components": [
+              {
+                "name": "baseTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "aTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "zTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getMarketsDetails",
+    "inputs": [
+      {
+        "name": "covenantLiquid",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "marketIds",
+        "type": "bytes20[]",
+        "internalType": "MarketId[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "marketsDetails",
+        "type": "tuple[]",
+        "internalType": "struct MarketDetails[]",
+        "components": [
+          {
+            "name": "marketId",
+            "type": "bytes20",
+            "internalType": "MarketId"
+          },
+          {
+            "name": "baseToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "quoteToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "aToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "zToken",
+            "type": "tuple",
+            "internalType": "struct ERC20Details",
+            "components": [
+              {
+                "name": "tokenAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "decimals",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "name",
+                "type": "string",
+                "internalType": "string"
+              },
+              {
+                "name": "symbol",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          },
+          {
+            "name": "marketParams",
+            "type": "tuple",
+            "internalType": "struct MarketParams",
+            "components": [
+              {
+                "name": "baseToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "quoteToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "curator",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "lex",
+                "type": "address",
+                "internalType": "address"
+              }
+            ]
+          },
+          {
+            "name": "marketState",
+            "type": "tuple",
+            "internalType": "struct MarketState",
+            "components": [
+              {
+                "name": "baseSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "protocolFeeGrowth",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "authorizedPauseAddress",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "statusFlag",
+                "type": "uint8",
+                "internalType": "uint8"
+              }
+            ]
+          },
+          {
+            "name": "lexState",
+            "type": "tuple",
+            "internalType": "struct LexState",
+            "components": [
+              {
+                "name": "lastDebtNotionalPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastBaseTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastETWAPBaseSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "lastSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "lastUpdateTimestamp",
+                "type": "uint96",
+                "internalType": "uint96"
+              },
+              {
+                "name": "lastLnRateBias",
+                "type": "int64",
+                "internalType": "int64"
+              }
+            ]
+          },
+          {
+            "name": "lexConfig",
+            "type": "tuple",
+            "internalType": "struct LexConfig",
+            "components": [
+              {
+                "name": "protocolFee",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "aToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "zToken",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "noCapLimit",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "scaleDecimals",
+                "type": "int8",
+                "internalType": "int8"
+              },
+              {
+                "name": "adaptive",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "lexParams",
+            "type": "tuple",
+            "internalType": "struct LexParams",
+            "components": [
+              {
+                "name": "covenantCore",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "initLnRateBias",
+                "type": "int64",
+                "internalType": "int64"
+              },
+              {
+                "name": "edgeSqrtPriceX96_B",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "edgeSqrtPriceX96_A",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "limHighSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "limMaxSqrtPriceX96",
+                "type": "uint160",
+                "internalType": "uint160"
+              },
+              {
+                "name": "debtDuration",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "swapFee",
+                "type": "uint8",
+                "internalType": "uint8"
+              },
+              {
+                "name": "targetXvsL",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentLTV",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "targetLTV",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "debtPriceDiscount",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "tokenPrices",
+            "type": "tuple",
+            "internalType": "struct TokenPrices",
+            "components": [
+              {
+                "name": "baseTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "aTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "zTokenPrice",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "error",
+    "name": "SafeCastOverflowedUintDowncast",
+    "inputs": [
+      {
+        "name": "bits",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  }
+]

--- a/src/adaptors/covenant/index.js
+++ b/src/adaptors/covenant/index.js
@@ -126,7 +126,7 @@ async function apy() {
       apyBase,
       underlyingTokens: [underlying.toLowerCase()],
       url: `${APP_URL}/market/${d.marketId.toLowerCase()}?action=swap&input=base&output=yield`,
-      poolMeta: `Fixed-rate ${quoteSym} yield, backed by ${d.baseToken.symbol}`,
+      poolMeta: `${quoteSym} Yield Coin (backed by ${d.baseToken.symbol})`,
     });
   }
   return pools;

--- a/src/adaptors/covenant/index.js
+++ b/src/adaptors/covenant/index.js
@@ -1,0 +1,117 @@
+const sdk = require('@defillama/sdk');
+const superagent = require('superagent');
+const utils = require('../utils');
+
+const covenantAbi = require('./covenant.json');
+const dataProviderAbi = require('./dataProvider.json');
+
+const CHAIN = 'monad';
+const COVENANT = '0x11a7ab0a9d7bd531dbcf0f0630bf7167f8f198f6';
+const DATA_PROVIDER = '0x3818a6d5018aa9eb69b6bce09e38a7c24bbe8c22';
+const DEPLOY_BLOCK = 35851140;
+const YEAR_SECONDS = 365 * 24 * 60 * 60;
+const PROJECT = 'covenant';
+const POOL_URL = 'https://covenant.finance';
+
+const createMarketAbi = covenantAbi.find((x) => x.name === 'CreateMarket');
+const getMarketsDetailsAbi = dataProviderAbi.find(
+  (x) => x.name === 'getMarketsDetails'
+);
+
+// Mirrors PRICE_DIVISOR in covenant-interface/data/adapters/EVMBlockchainAdapter.ts:45
+// (10^(2 * 18) — synth prices are pre-scaled so balance × price / 1e36 yields
+// the value in quote whole units regardless of token decimal mismatches).
+const PRICE_DIVISOR_WAD = 10n ** 18n;
+
+// Mirrors covenant-interface/data/adapters/EVMBlockchainAdapter.ts:483-504.
+// Computes the Yield Coin (zToken / debt token) APY.
+function computeYieldCoinApy(d) {
+  const discount = Number(d.debtPriceDiscount) / 1e18;
+  if (!isFinite(discount) || discount <= 0) return null;
+  const lnRateBias = Number(d.lexState.lastLnRateBias) / 1e18;
+  const debtDuration = Number(d.lexParams.debtDuration);
+  if (debtDuration === 0) return null;
+  const rate = lnRateBias - Math.log(discount);
+  const apy = (Math.exp(rate * (YEAR_SECONDS / debtDuration)) - 1) * 100;
+  return isFinite(apy) ? apy : null;
+}
+
+// zToken supply value in quote-token whole units. Spot-price (marginal) basis,
+// matching the convention DefiLlama uses for other tranching protocols.
+function zTokenSupplyValueInQuote(d) {
+  const supply = BigInt(d.zToken.totalSupply.toString());
+  const price = BigInt(d.tokenPrices.zTokenPrice.toString());
+  // (supply * price) / 1e36, kept as a float for downstream USD multiplication.
+  // Scale down one factor of 1e18 in bigint, then convert and divide by the other 1e18.
+  const wad = (supply * price) / PRICE_DIVISOR_WAD;
+  return Number(wad) / 1e18;
+}
+
+async function listMarketIds() {
+  const logs = await sdk.getEventLogs({
+    target: COVENANT,
+    eventAbi: createMarketAbi,
+    fromBlock: DEPLOY_BLOCK,
+    chain: CHAIN,
+  });
+  return logs.map((l) => l.args.marketId);
+}
+
+async function fetchMonUsdPrice() {
+  // Native MON, queried by chain identifier (no contract address for the gas token).
+  const res = await superagent.get(
+    `https://coins.llama.fi/prices/current/coingecko:monad`
+  );
+  return res.body?.coins?.['coingecko:monad']?.price ?? null;
+}
+
+async function apy() {
+  const marketIds = await listMarketIds();
+  if (!marketIds.length) return [];
+
+  const { output: details } = await sdk.api.abi.call({
+    target: DATA_PROVIDER,
+    abi: getMarketsDetailsAbi,
+    params: [COVENANT, marketIds],
+    chain: CHAIN,
+  });
+
+  const needsMon = details.some((d) => d.quoteToken.symbol === 'MON');
+  const monUsd = needsMon ? await fetchMonUsdPrice() : null;
+
+  const pools = [];
+  for (const d of details) {
+    if (Number(d.marketState.statusFlag) === 0) continue;
+
+    const apyBase = computeYieldCoinApy(d);
+    if (apyBase === null) continue;
+
+    const quoteSym = d.quoteToken.symbol;
+    let quoteUsd;
+    if (quoteSym === 'USD') quoteUsd = 1;
+    else if (quoteSym === 'MON') quoteUsd = monUsd;
+    else quoteUsd = null;
+    if (quoteUsd == null) continue;
+
+    const tvlUsd = zTokenSupplyValueInQuote(d) * quoteUsd;
+
+    pools.push({
+      pool: `${d.zToken.tokenAddress.toLowerCase()}-${CHAIN}`,
+      chain: utils.formatChain(CHAIN),
+      project: PROJECT,
+      symbol: utils.formatSymbol(d.zToken.symbol),
+      tvlUsd,
+      apyBase,
+      underlyingTokens: [d.marketParams.baseToken.toLowerCase()],
+      url: POOL_URL,
+      poolMeta: `${d.baseToken.symbol}/${quoteSym} Yield Coin`,
+    });
+  }
+  return pools;
+}
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: POOL_URL,
+};

--- a/src/adaptors/covenant/index.js
+++ b/src/adaptors/covenant/index.js
@@ -9,7 +9,7 @@ const COVENANT = '0x11a7ab0a9d7bd531dbcf0f0630bf7167f8f198f6';
 const DATA_PROVIDER = '0x3818a6d5018aa9eb69b6bce09e38a7c24bbe8c22';
 const YEAR_SECONDS = 365 * 24 * 60 * 60;
 const PROJECT = 'covenant';
-const POOL_URL = 'https://covenant.finance';
+const APP_URL = 'https://app.covenant.finance';
 
 // Yield Coin (zToken) is a synthetic claim denominated in the market's quote
 // unit (USD or MON), not in the baseToken collateral. Matches Synthetix-v3's
@@ -125,8 +125,8 @@ async function apy() {
       tvlUsd,
       apyBase,
       underlyingTokens: [underlying.toLowerCase()],
-      url: POOL_URL,
-      poolMeta: `${d.baseToken.symbol}/${quoteSym} Yield Coin (backed by ${d.baseToken.symbol})`,
+      url: `${APP_URL}/market/${d.marketId.toLowerCase()}?action=swap&input=base&output=yield`,
+      poolMeta: `Fixed-rate ${quoteSym} yield, backed by ${d.baseToken.symbol}`,
     });
   }
   return pools;
@@ -135,5 +135,5 @@ async function apy() {
 module.exports = {
   timetravel: false,
   apy,
-  url: POOL_URL,
+  url: APP_URL,
 };

--- a/src/adaptors/covenant/index.js
+++ b/src/adaptors/covenant/index.js
@@ -11,6 +11,13 @@ const YEAR_SECONDS = 365 * 24 * 60 * 60;
 const PROJECT = 'covenant';
 const POOL_URL = 'https://covenant.finance';
 
+// Yield Coin (zToken) is a synthetic claim denominated in the market's quote
+// unit (USD or MON), not in the baseToken collateral. Matches Synthetix-v3's
+// convention of marking USDC as the underlying for sUSD yield (and shmonad's
+// use of WMON for MON-denominated yield).
+const USDC_MONAD = '0xf817257fed379853cDe0fa4F97AB987181B1E5Ea';
+const WMON = '0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A';
+
 const getMarketsDetailsAbi = dataProviderAbi.find(
   (x) => x.name === 'getMarketsDetails'
 );
@@ -96,9 +103,16 @@ async function apy() {
 
     const quoteSym = d.quoteToken.symbol;
     let quoteUsd;
-    if (quoteSym === 'USD') quoteUsd = 1;
-    else if (quoteSym === 'MON') quoteUsd = monUsd;
-    else quoteUsd = null;
+    let underlying;
+    if (quoteSym === 'USD') {
+      quoteUsd = 1;
+      underlying = USDC_MONAD;
+    } else if (quoteSym === 'MON') {
+      quoteUsd = monUsd;
+      underlying = WMON;
+    } else {
+      continue;
+    }
     if (quoteUsd == null) continue;
 
     const tvlUsd = zTokenSupplyValueInQuote(d) * quoteUsd;
@@ -110,9 +124,9 @@ async function apy() {
       symbol: utils.formatSymbol(d.zToken.symbol),
       tvlUsd,
       apyBase,
-      underlyingTokens: [d.marketParams.baseToken.toLowerCase()],
+      underlyingTokens: [underlying.toLowerCase()],
       url: POOL_URL,
-      poolMeta: `${d.baseToken.symbol}/${quoteSym} Yield Coin`,
+      poolMeta: `${d.baseToken.symbol}/${quoteSym} Yield Coin (backed by ${d.baseToken.symbol})`,
     });
   }
   return pools;

--- a/src/adaptors/covenant/index.js
+++ b/src/adaptors/covenant/index.js
@@ -2,7 +2,6 @@ const sdk = require('@defillama/sdk');
 const superagent = require('superagent');
 const utils = require('../utils');
 
-const covenantAbi = require('./covenant.json');
 const dataProviderAbi = require('./dataProvider.json');
 
 const CHAIN = 'monad';
@@ -13,7 +12,9 @@ const YEAR_SECONDS = 365 * 24 * 60 * 60;
 const PROJECT = 'covenant';
 const POOL_URL = 'https://covenant.finance';
 
-const createMarketAbi = covenantAbi.find((x) => x.name === 'CreateMarket');
+const createMarketEvent =
+  'event CreateMarket(bytes20 indexed marketId, (address baseToken, address quoteToken, address curator, address lex) marketParams, (address aToken, address zToken) synthTokens, bytes initData, bytes lexData)';
+
 const getMarketsDetailsAbi = dataProviderAbi.find(
   (x) => x.name === 'getMarketsDetails'
 );
@@ -50,7 +51,7 @@ function zTokenSupplyValueInQuote(d) {
 async function listMarketIds() {
   const logs = await sdk.getEventLogs({
     target: COVENANT,
-    eventAbi: createMarketAbi,
+    eventAbi: createMarketEvent,
     fromBlock: DEPLOY_BLOCK,
     toTimestamp: Math.floor(Date.now() / 1000),
     chain: CHAIN,

--- a/src/adaptors/covenant/index.js
+++ b/src/adaptors/covenant/index.js
@@ -52,6 +52,7 @@ async function listMarketIds() {
     target: COVENANT,
     eventAbi: createMarketAbi,
     fromBlock: DEPLOY_BLOCK,
+    toTimestamp: Math.floor(Date.now() / 1000),
     chain: CHAIN,
   });
   return logs.map((l) => l.args.marketId);

--- a/src/adaptors/covenant/index.js
+++ b/src/adaptors/covenant/index.js
@@ -7,13 +7,9 @@ const dataProviderAbi = require('./dataProvider.json');
 const CHAIN = 'monad';
 const COVENANT = '0x11a7ab0a9d7bd531dbcf0f0630bf7167f8f198f6';
 const DATA_PROVIDER = '0x3818a6d5018aa9eb69b6bce09e38a7c24bbe8c22';
-const DEPLOY_BLOCK = 35851140;
 const YEAR_SECONDS = 365 * 24 * 60 * 60;
 const PROJECT = 'covenant';
 const POOL_URL = 'https://covenant.finance';
-
-const createMarketEvent =
-  'event CreateMarket(bytes20 indexed marketId, (address baseToken, address quoteToken, address curator, address lex) marketParams, (address aToken, address zToken) synthTokens, bytes initData, bytes lexData)';
 
 const getMarketsDetailsAbi = dataProviderAbi.find(
   (x) => x.name === 'getMarketsDetails'
@@ -48,16 +44,26 @@ function zTokenSupplyValueInQuote(d) {
   return Number(wad) / 1e18;
 }
 
-async function listMarketIds() {
-  const logs = await sdk.getEventLogs({
-    target: COVENANT,
-    eventAbi: createMarketEvent,
-    fromBlock: DEPLOY_BLOCK,
-    toTimestamp: Math.floor(Date.now() / 1000),
-    chain: CHAIN,
-  });
-  return logs.map((l) => l.args.marketId);
-}
+// Monad RPCs cap eth_getLogs at 100 blocks, so direct getLogs across the full
+// market history fails. Hardcode the current marketId list as a snapshot.
+// Refresh by running `node scripts/list-markets.js` in
+// https://github.com/covenant-labs/covenant-defillama when new markets launch.
+const KNOWN_MARKET_IDS = [
+  '0x1cf32aabab09cf73d5ebd22d08d472f9aaac0650', // WETH/USD
+  '0xc0e43be9048549aa7d4c78a20ce6c50aae603875', // aprMON/MON
+  '0x544e60c94e9aa394db6b0ed7868eb29b8745cd46', // gMON/MON
+  '0xb17ed620936f4f90c53d554f4ce4cf654855bcf0', // shMON/MON
+  '0xb2c399d52b748bcababf1ffab623135bbd2aa69a', // sMON/MON
+  '0xe36835496ea4c0e7c0cdd0d71d0a5335c1d234e7', // KURU-VAULT/USD
+  '0xc731f60dbdc480110e1fb135e985ee25d85c21bd', // shMON/USD
+  '0x84d4052c25391d26b16a685218b9ee8d9c78e4f8', // sbMU/USD
+  '0x3ed929b6c215655dfba05dcd524494c1644e4912', // bbqAUSD/USD
+  '0xf30d107691fde017fbf47af10eea67607dfa6f13', // earnAUSD/USD
+  '0xeb91150761cf353d9d9cd932d87b9e3a33649b5f', // aHYPER/USD
+  '0xc387a0dd7c67e96b0522b40c0425274eda8ec8b2', // naccUSDC/USD
+  '0xdae76886306e311307b0d406394555377c21a3e6', // hyperUSDCa/USD
+  '0x2bbb31f07be3bf497ada87eb9446e0eb5f937c89', // bbqUSDC/USD
+];
 
 async function fetchMonUsdPrice() {
   // Native MON, queried by chain identifier (no contract address for the gas token).
@@ -68,7 +74,7 @@ async function fetchMonUsdPrice() {
 }
 
 async function apy() {
-  const marketIds = await listMarketIds();
+  const marketIds = KNOWN_MARKET_IDS;
   if (!marketIds.length) return [];
 
   const { output: details } = await sdk.api.abi.call({

--- a/src/adaptors/covenant/index.js
+++ b/src/adaptors/covenant/index.js
@@ -51,26 +51,31 @@ function zTokenSupplyValueInQuote(d) {
   return Number(wad) / 1e18;
 }
 
-// Monad RPCs cap eth_getLogs at 100 blocks, so direct getLogs across the full
-// market history fails. Hardcode the current marketId list as a snapshot.
-// Refresh by running `node scripts/list-markets.js` in
-// https://github.com/covenant-labs/covenant-defillama when new markets launch.
-const KNOWN_MARKET_IDS = [
-  '0x1cf32aabab09cf73d5ebd22d08d472f9aaac0650', // WETH/USD
-  '0xc0e43be9048549aa7d4c78a20ce6c50aae603875', // aprMON/MON
-  '0x544e60c94e9aa394db6b0ed7868eb29b8745cd46', // gMON/MON
-  '0xb17ed620936f4f90c53d554f4ce4cf654855bcf0', // shMON/MON
-  '0xb2c399d52b748bcababf1ffab623135bbd2aa69a', // sMON/MON
-  '0xe36835496ea4c0e7c0cdd0d71d0a5335c1d234e7', // KURU-VAULT/USD
-  '0xc731f60dbdc480110e1fb135e985ee25d85c21bd', // shMON/USD
-  '0x84d4052c25391d26b16a685218b9ee8d9c78e4f8', // sbMU/USD
-  '0x3ed929b6c215655dfba05dcd524494c1644e4912', // bbqAUSD/USD
-  '0xf30d107691fde017fbf47af10eea67607dfa6f13', // earnAUSD/USD
-  '0xeb91150761cf353d9d9cd932d87b9e3a33649b5f', // aHYPER/USD
-  '0xc387a0dd7c67e96b0522b40c0425274eda8ec8b2', // naccUSDC/USD
-  '0xdae76886306e311307b0d406394555377c21a3e6', // hyperUSDCa/USD
-  '0x2bbb31f07be3bf497ada87eb9446e0eb5f937c89', // bbqUSDC/USD
-];
+// Markets are discovered at runtime from Covenant's hosted Envio indexer
+// (the same endpoint app.covenant.finance uses in production; unauthenticated
+// reads). Monad RPCs cap eth_getLogs at 100 blocks, so on-chain CreateMarket
+// enumeration is not possible from yield-server. Market *state* is still read
+// on-chain via DataProvider below; the indexer only supplies the id list.
+// Fails loudly on indexer errors rather than serving a stale market set.
+const INDEXER_URL = 'https://indexer.hyperindex.xyz/d06cd15/v1/graphql';
+const CHAIN_ID = 143; // Monad mainnet
+
+async function fetchMarketIds() {
+  const res = await superagent.post(INDEXER_URL).send({
+    query: `query CovenantMarkets($chainId: numeric!) {
+      Covenant_Market(where: { chainId: { _eq: $chainId } }) { marketId }
+    }`,
+    variables: { chainId: CHAIN_ID },
+  });
+  if (res.body?.errors?.length) {
+    throw new Error(
+      `covenant indexer error: ${res.body.errors.map((e) => e.message).join('; ')}`
+    );
+  }
+  const ids = (res.body?.data?.Covenant_Market ?? []).map((m) => m.marketId);
+  if (!ids.length) throw new Error('covenant indexer returned no markets');
+  return ids;
+}
 
 async function fetchMonUsdPrice() {
   // Native MON, queried by chain identifier (no contract address for the gas token).
@@ -81,8 +86,7 @@ async function fetchMonUsdPrice() {
 }
 
 async function apy() {
-  const marketIds = KNOWN_MARKET_IDS;
-  if (!marketIds.length) return [];
+  const marketIds = await fetchMarketIds();
 
   const { output: details } = await sdk.api.abi.call({
     target: DATA_PROVIDER,


### PR DESCRIPTION
Adds yield-server pools for Covenant on Monad. One pool per market for
the Yield Coin (zToken):

- APY uses the instantaneous formula from covenant-interface
  (EVMBlockchainAdapter.ts debtTokenAPYCalc), pulled from a single
  DataProvider.getMarketsDetails call on Monad mainnet
- Pool tvlUsd = zToken.totalSupply × tokenPrices.zTokenPrice / 1e36,
  converted to USD via the quote anchor (USDC = $1, MON via CoinGecko)
- 14 active markets, APYs ranging ~0.6%–52%
- No npm dependency additions; no lockfile changes

TVL adapter (already merged in DefiLlama-Adapters#19272):
https://defillama.com/protocol/covenant

Methodology rationale + source-of-truth ABIs:
https://github.com/covenant-labs/covenant-defillama

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Covenant markets on the Monad chain.
  * Covenant pools are now available for analysis in the app.
  * Added APY calculations and USD TVL metrics for supported Covenant pools.
  * Added market details, token information, and pool status data for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->