### PR TITLE
arche: add Metrom incentive APY

### DIFF
--- a/src/adaptors/arche/index.js
+++ b/src/adaptors/arche/index.js
@@ -7,6 +7,8 @@ const STRATEGY = '0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204'; // yvUSDC-1
 const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const CHAIN = 'ethereum';
 const DAY = 24 * 3600;
+const METROM_CAMPAIGNS_API = 'https://api.metrom.xyz/v2/campaigns/rewards';
+const METROM_PAGE_SIZE = 20;
 
 // Yearn v3 vaults book strategy yield only when process_report() runs (lazy
 // accounting). Reading vault.totalAssets() / convertToAssets() between reports
@@ -36,16 +38,68 @@ async function realPricePerShare(block) {
   return (Number(idle.output) + Number(stratValue)) / Number(supply.output);
 }
 
+function isActiveCampaign(campaign) {
+  const now = Date.now();
+  const from = campaign?.from ? Date.parse(campaign.from) : 0;
+  const to = campaign?.to ? Date.parse(campaign.to) : 0;
+  return from > 0 && from <= now && (to === 0 || to > now);
+}
+
+async function getMetromRewards() {
+  try {
+    let apyReward = 0;
+    const rewardTokens = new Set();
+
+    for (let page = 1; ; page++) {
+      const { data } = await axios.get(
+        `${METROM_CAMPAIGNS_API}?page=${page}&pageSize=${METROM_PAGE_SIZE}&chainIds=1&chainTypes=evm&statuses=active`
+      );
+      const campaigns = data?.campaigns || [];
+
+      for (const campaign of campaigns) {
+        const apr = Number(campaign?.apr);
+        const targetVault = campaign?.target?.vault?.address?.toLowerCase();
+        if (
+          targetVault !== VAULT.toLowerCase() ||
+          !isActiveCampaign(campaign) ||
+          !Number.isFinite(apr) ||
+          apr <= 0
+        ) {
+          continue;
+        }
+
+        apyReward += apr;
+        for (const reward of campaign?.rewards?.assets || []) {
+          if (reward.address) {
+            rewardTokens.add(utils.formatAddress(reward.address));
+          }
+        }
+      }
+
+      if (campaigns.length < METROM_PAGE_SIZE) break;
+    }
+
+    return {
+      apyReward: rewardTokens.size > 0 ? apyReward : 0,
+      rewardTokens: Array.from(rewardTokens),
+    };
+  } catch (e) {
+    console.warn(`arche metrom rewards unavailable: ${e.message}`);
+    return { apyReward: 0, rewardTokens: [] };
+  }
+}
+
 const getApy = async () => {
   const now = Math.floor(Date.now() / 1e3);
   const sevenDaysAgo = now - 7 * DAY;
+  const metromRewardsPromise = getMetromRewards();
 
   const [blockNow, block7d] = await Promise.all([
     axios.get(`https://coins.llama.fi/block/${CHAIN}/${now}`).then((r) => r.data.height),
     axios.get(`https://coins.llama.fi/block/${CHAIN}/${sevenDaysAgo}`).then((r) => r.data.height),
   ]);
 
-  const [ppsNow, pps7d, totalAssets] = await Promise.all([
+  const [ppsNow, pps7d, totalAssets, metromRewards] = await Promise.all([
     realPricePerShare(blockNow),
     realPricePerShare(block7d),
     sdk.api.abi.call({
@@ -54,6 +108,7 @@ const getApy = async () => {
       chain: CHAIN,
       block: blockNow,
     }),
+    metromRewardsPromise,
   ]);
 
   const apyBase = ((ppsNow / pps7d) ** (365 / 7) - 1) * 100;
@@ -72,6 +127,12 @@ const getApy = async () => {
       pricePerShare: ppsNow,
       underlyingTokens: [utils.formatAddress(USDC)],
       token: utils.formatAddress(VAULT),
+      ...(metromRewards.apyReward > 0
+        ? {
+            apyReward: metromRewards.apyReward,
+            rewardTokens: metromRewards.rewardTokens,
+          }
+        : {}),
       url: 'https://arche.money',
     },
   ];

--- a/src/adaptors/arche/index.js
+++ b/src/adaptors/arche/index.js
@@ -52,7 +52,8 @@ async function getMetromRewards() {
 
     for (let page = 1; ; page++) {
       const { data } = await axios.get(
-        `${METROM_CAMPAIGNS_API}?page=${page}&pageSize=${METROM_PAGE_SIZE}&chainIds=1&chainTypes=evm&statuses=active`
+        `${METROM_CAMPAIGNS_API}?page=${page}&pageSize=${METROM_PAGE_SIZE}&chainIds=1&chainTypes=evm&statuses=active`,
+        { timeout: 10_000 }
       );
       const campaigns = data?.campaigns || [];
 


### PR DESCRIPTION
Adds live Metrom incentives to the Arche arUSD yield adapter. The adapter now returns apyBase from the existing on-chain vault/share-price calculation and apyReward plus rewardTokens from active Metrom campaigns targeting the Arche vault, letting DefiLlama derive total APY as base + reward. Scope is limited to src/adaptors/arche/index.js. Tested with: env NODE_PATH=/home/kali/Desktop/defillama-yield-server/node_modules npm_config_adapter=arche /home/kali/Desktop/defillama-yield-server/node_modules/.bin/jest --runInBand (14 passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Metrom reward campaign data into APY calculations, providing enhanced visibility of available reward token information alongside existing yield metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2683)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->