### PR TITLE
feat: add kerne yield adapter (skUSD staked synthetic dollar on Base)

### DIFF
--- a/src/adaptors/kerne-protocol/index.js
+++ b/src/adaptors/kerne-protocol/index.js
@@ -1,0 +1,120 @@
+// Kerne Protocol — DefiLlama Yield Adapter
+// ===========================================================
+// Pool listed: KerneVault (ERC-4626) on Base, share symbol kLP, asset WETH.
+//
+// Contract (verified on Basescan):
+//   https://basescan.org/address/0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC#code
+//
+// Data sources (all pulled at adapter run-time, no Kerne API dependency):
+//   - TVL   : KerneVault.totalAssets()          × WETH price (coins.llama.fi)
+//   - APY   : KerneVault.projectedAPY()         (returns basis points)
+//   - asset : KerneVault.asset()                (sanity-checked = WETH)
+//
+// Strategy: delta-neutral basis trade. Long leg accrues Lido stETH staking
+// yield via off-chain accounting reported on-chain by the strategist; short
+// leg captures perpetual funding on Hyperliquid. Yield is realized in kLP
+// share price appreciation.
+//
+// Reviewer notes:
+//   - vault.symbol() currently returns the string "2" (a placeholder set at
+//     deploy time). We hardcode "kLP" which is the documented share-token
+//     symbol (kerne.fi/docs).
+//   - vault.name()  similarly returns "1". Cosmetic only.
+//   - vault.projectedAPY() returns the governance-configured projected
+//     return for the active strategy in basis points (1200 = 12.00%).
+//
+// This adapter supersedes the earlier draft at
+//   https://github.com/DefiLlama/yield-server/pull/2254
+// which was closed pending a TVL adapter on the DefiLlama-Adapters side.
+
+const sdk = require('@defillama/sdk');
+const axios = require('axios');
+const utils = require('../utils');
+
+const CHAIN = 'base';
+const VAULT_ADDRESS = '0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC';
+const WETH_ADDRESS = '0x4200000000000000000000000000000000000006';
+
+const apy = async () => {
+  // 1. Parallel on-chain reads
+  const [totalAssetsCall, projectedApyCall, assetCall] = await Promise.all([
+    sdk.api.abi.call({
+      target: VAULT_ADDRESS,
+      abi: 'uint256:totalAssets',
+      chain: CHAIN,
+    }),
+    sdk.api.abi.call({
+      target: VAULT_ADDRESS,
+      abi: 'uint256:projectedAPY',
+      chain: CHAIN,
+    }),
+    sdk.api.abi.call({
+      target: VAULT_ADDRESS,
+      abi: 'address:asset',
+      chain: CHAIN,
+    }),
+  ]);
+
+  // 2. Defensive: ensure vault.asset() is still WETH (in case of redeploy).
+  const onchainAsset = String(assetCall.output).toLowerCase();
+  if (onchainAsset !== WETH_ADDRESS.toLowerCase()) {
+    throw new Error(
+      `KerneVault.asset() returned ${onchainAsset}, expected WETH ${WETH_ADDRESS}`
+    );
+  }
+
+  // 3. Price WETH via DefiLlama's coin price API (same source the rest of
+  //    the yield-server uses; reviewers can verify pricing trivially).
+  const priceKey = `${CHAIN}:${WETH_ADDRESS}`;
+  const priceResp = await axios.get(
+    `https://coins.llama.fi/prices/current/${priceKey}`,
+    { timeout: 15_000 }
+  );
+  const ethPrice = priceResp?.data?.coins?.[priceKey]?.price;
+  if (!Number.isFinite(ethPrice) || ethPrice <= 0) {
+    throw new Error(
+      `Invalid WETH price from coins.llama.fi for ${priceKey}: ${ethPrice}`
+    );
+  }
+
+  // 4. Compose TVL and APY values.
+  const totalAssetsEth = Number(totalAssetsCall.output) / 1e18;
+  const tvlUsd = totalAssetsEth * ethPrice;
+  const apyBase = Number(projectedApyCall.output) / 100;
+
+  // 5. Refuse to publish nonsense.
+  if (!Number.isFinite(tvlUsd) || tvlUsd < 0) {
+    throw new Error(
+      `Computed tvlUsd is not a valid non-negative number: ${tvlUsd}`
+    );
+  }
+  if (!Number.isFinite(apyBase) || apyBase < 0 || apyBase > 1000) {
+    throw new Error(
+      `Computed apyBase out of sane range [0, 1000]: ${apyBase}`
+    );
+  }
+
+  return [
+    {
+      pool: `${VAULT_ADDRESS}-${CHAIN}`.toLowerCase(),
+      chain: utils.formatChain(CHAIN),
+      project: 'kerne-protocol',
+      symbol: 'kLP',
+      tvlUsd,
+      apyBase,
+      apyReward: 0,
+      rewardTokens: [],
+      underlyingTokens: [WETH_ADDRESS],
+      poolMeta: 'ERC-4626: WETH → kLP (delta-neutral basis trade)',
+      url: 'https://app.kerne.fi',
+      token: VAULT_ADDRESS,
+      isIntrinsicSource: true,
+    },
+  ];
+};
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: 'https://kerne.fi',
+};

--- a/src/adaptors/kerne/index.js
+++ b/src/adaptors/kerne/index.js
@@ -1,27 +1,34 @@
 // Kerne Protocol — DefiLlama Yield Adapter
 // ===========================================================
-// Pool listed: KerneVault (ERC-4626) on Base, share symbol kLP, asset WETH.
+// Pool listed: skUSD (ERC-4626 staking vault) on Base.
+//   skUSD wraps kUSD, the protocol's synthetic dollar, which is minted
+//   1:1 against USDC through the on-chain Peg Stability Module. Yield
+//   accrues to skUSD holders through a rising share price.
 //
-// Contract (verified on Basescan):
-//   https://basescan.org/address/0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC#code
+// Contracts (verified, Sourcify perfect_match):
+//   skUSD : https://basescan.org/address/0xdEd74F7E06efc76455C07418b8b74Cc2bc009DB4
+//   kUSD  : https://basescan.org/address/0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3
 //
-// Data sources (all pulled at adapter run-time, no Kerne API dependency):
-//   - TVL   : KerneVault.totalAssets()          × WETH price (coins.llama.fi)
-//   - APY   : KerneVault.projectedAPY()         (returns basis points)
-//   - asset : KerneVault.asset()                (sanity-checked = WETH)
+// Data sources (pulled at adapter run-time):
+//   - TVL : skUSD.totalAssets()  (kUSD, 18 decimals)  x  USDC price
+//           (coins.llama.fi). kUSD is PSM-redeemable 1:1 for USDC, so
+//           the USDC price is the conservative, verifiable kUSD price.
+//   - APY : kerne.fi/api/apy field `expectedAPY` — the protocol's
+//           published, recomputable methodology (Lido staking SMA +
+//           Hyperliquid 180d trailing funding, costs and insurance
+//           netted out). Formula reference is public on the same
+//           endpoint and rendered on the kerne.fi homepage.
+//   - asset(): sanity-checked = kUSD (refuses to publish on mismatch).
 //
-// Strategy: delta-neutral basis trade. Long leg accrues Lido stETH staking
-// yield via off-chain accounting reported on-chain by the strategist; short
-// leg captures perpetual funding on Hyperliquid. Yield is realized in kLP
-// share price appreciation.
-//
-// Reviewer notes:
-//   - vault.symbol() currently returns the string "2" (a placeholder set at
-//     deploy time). We hardcode "kLP" which is the documented share-token
-//     symbol (kerne.fi/docs).
-//   - vault.name()  similarly returns "1". Cosmetic only.
-//   - vault.projectedAPY() returns the governance-configured projected
-//     return for the active strategy in basis points (1200 = 12.00%).
+// Reviewer notes (2026-06-11 revision):
+//   - This revision switches the tracked pool from the v1 WETH vault
+//     (kLP) to skUSD. The v1 vault is in a publicly disclosed degraded
+//     state pending a v2 redeploy and is intentionally excluded from
+//     protocol TVL by kerne.fi/api/stats; skUSD over the PSM-backed
+//     kUSD is the protocol's durable user-facing yield surface, so it
+//     is the correct pool for DefiLlama to track long-term.
+//   - Genesis-phase TVL is intentionally below the public yields
+//     display threshold, so the pool stays hidden until seeded.
 //
 // This adapter supersedes the earlier draft at
 //   https://github.com/DefiLlama/yield-server/pull/2254
@@ -29,92 +36,89 @@
 //
 // DefiLlama slug note: DefiLlama assigned this protocol the slug "kerne"
 // when the TVL adapter merged (DefiLlama-Adapters#19306, 2026-05-18), so
-// the project field below matches that slug. The TVL adapter directory in
-// DefiLlama-Adapters remains projects/kerne-protocol/ per the module field
-// on /api/protocols, but the yield-server adapter directory and project
-// field both follow the public slug "kerne".
+// the directory and project field both follow the public slug "kerne".
 
 const sdk = require('@defillama/sdk');
 const axios = require('axios');
 const utils = require('../utils');
 
 const CHAIN = 'base';
-const VAULT_ADDRESS = '0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC';
-const WETH_ADDRESS = '0x4200000000000000000000000000000000000006';
+const SKUSD_ADDRESS = '0xdEd74F7E06efc76455C07418b8b74Cc2bc009DB4';
+const KUSD_ADDRESS = '0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3';
+const USDC_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 
 const apy = async () => {
   // 1. Parallel on-chain reads
-  const [totalAssetsCall, projectedApyCall, assetCall] = await Promise.all([
+  const [totalAssetsCall, assetCall] = await Promise.all([
     sdk.api.abi.call({
-      target: VAULT_ADDRESS,
+      target: SKUSD_ADDRESS,
       abi: 'uint256:totalAssets',
       chain: CHAIN,
     }),
     sdk.api.abi.call({
-      target: VAULT_ADDRESS,
-      abi: 'uint256:projectedAPY',
-      chain: CHAIN,
-    }),
-    sdk.api.abi.call({
-      target: VAULT_ADDRESS,
+      target: SKUSD_ADDRESS,
       abi: 'address:asset',
       chain: CHAIN,
     }),
   ]);
 
-  // 2. Defensive: ensure vault.asset() is still WETH (in case of redeploy).
+  // 2. Defensive: ensure skUSD.asset() is still kUSD (in case of redeploy).
   const onchainAsset = String(assetCall.output).toLowerCase();
-  if (onchainAsset !== WETH_ADDRESS.toLowerCase()) {
+  if (onchainAsset !== KUSD_ADDRESS.toLowerCase()) {
     throw new Error(
-      `KerneVault.asset() returned ${onchainAsset}, expected WETH ${WETH_ADDRESS}`
+      `skUSD.asset() returned ${onchainAsset}, expected kUSD ${KUSD_ADDRESS}`
     );
   }
 
-  // 3. Price WETH via DefiLlama's coin price API (same source the rest of
-  //    the yield-server uses; reviewers can verify pricing trivially).
-  const priceKey = `${CHAIN}:${WETH_ADDRESS}`;
+  // 3. Price the kUSD backing at the USDC price (kUSD is PSM-redeemable
+  //    1:1 for USDC; using the coins.llama.fi USDC price keeps pricing
+  //    verifiable through the same source the rest of yield-server uses).
+  const priceKey = `${CHAIN}:${USDC_ADDRESS}`;
   const priceResp = await axios.get(
     `https://coins.llama.fi/prices/current/${priceKey}`,
     { timeout: 15_000 }
   );
-  const ethPrice = priceResp?.data?.coins?.[priceKey]?.price;
-  if (!Number.isFinite(ethPrice) || ethPrice <= 0) {
+  const usdcPrice = priceResp?.data?.coins?.[priceKey]?.price;
+  if (!Number.isFinite(usdcPrice) || usdcPrice <= 0) {
     throw new Error(
-      `Invalid WETH price from coins.llama.fi for ${priceKey}: ${ethPrice}`
+      `Invalid USDC price from coins.llama.fi for ${priceKey}: ${usdcPrice}`
     );
   }
 
-  // 4. Compose TVL and APY values.
-  const totalAssetsEth = Number(totalAssetsCall.output) / 1e18;
-  const tvlUsd = totalAssetsEth * ethPrice;
-  const apyBase = Number(projectedApyCall.output) / 100;
+  // 4. Published APY from the protocol's open methodology endpoint.
+  const apyResp = await axios.get('https://kerne.fi/api/apy', {
+    timeout: 15_000,
+  });
+  const expectedAPY = apyResp?.data?.expectedAPY;
 
-  // 5. Refuse to publish nonsense.
+  // 5. Compose TVL and APY values.
+  const tvlUsd = (Number(totalAssetsCall.output) / 1e18) * usdcPrice;
+  const apyBase = Number(expectedAPY) * 100;
+
+  // 6. Refuse to publish nonsense.
   if (!Number.isFinite(tvlUsd) || tvlUsd < 0) {
     throw new Error(
       `Computed tvlUsd is not a valid non-negative number: ${tvlUsd}`
     );
   }
-  if (!Number.isFinite(apyBase) || apyBase < 0 || apyBase > 1000) {
-    throw new Error(
-      `Computed apyBase out of sane range [0, 1000]: ${apyBase}`
-    );
+  if (!Number.isFinite(apyBase) || apyBase < 0 || apyBase > 100) {
+    throw new Error(`Computed apyBase out of sane range [0, 100]: ${apyBase}`);
   }
 
   return [
     {
-      pool: `${VAULT_ADDRESS}-${CHAIN}`.toLowerCase(),
+      pool: `${SKUSD_ADDRESS}-${CHAIN}`.toLowerCase(),
       chain: utils.formatChain(CHAIN),
       project: 'kerne',
-      symbol: 'kLP',
+      symbol: 'skUSD',
       tvlUsd,
       apyBase,
       apyReward: 0,
       rewardTokens: [],
-      underlyingTokens: [WETH_ADDRESS],
-      poolMeta: 'ERC-4626: WETH → kLP (delta-neutral basis trade)',
-      url: 'https://app.kerne.fi',
-      token: VAULT_ADDRESS,
+      underlyingTokens: [KUSD_ADDRESS],
+      poolMeta: 'ERC-4626: kUSD -> skUSD (staked delta-neutral synthetic dollar)',
+      url: 'https://app.kerne.fi/stake',
+      token: SKUSD_ADDRESS,
       isIntrinsicSource: true,
     },
   ];

--- a/src/adaptors/kerne/index.js
+++ b/src/adaptors/kerne/index.js
@@ -9,34 +9,35 @@
 //   skUSD : https://basescan.org/address/0xdEd74F7E06efc76455C07418b8b74Cc2bc009DB4
 //   kUSD  : https://basescan.org/address/0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3
 //
-// Data sources (pulled at adapter run-time):
-//   - TVL : skUSD.totalAssets()  (kUSD, 18 decimals)  x  USDC price
-//           (coins.llama.fi). kUSD is PSM-redeemable 1:1 for USDC, so
-//           the USDC price is the conservative, verifiable kUSD price.
-//   - APY : kerne.fi/api/apy field `expectedAPY` — the protocol's
-//           published, recomputable methodology (Lido staking SMA +
-//           Hyperliquid 180d trailing funding, costs and insurance
-//           netted out). Formula reference is public on the same
-//           endpoint and rendered on the kerne.fi homepage.
-//   - asset(): sanity-checked = kUSD (refuses to publish on mismatch).
+// Everything is read on-chain at adapter run-time (no Kerne API dependency):
+//   - TVL          : skUSD.totalAssets() (kUSD, asset decimals) x USDC price
+//                    (coins.llama.fi). kUSD is PSM-redeemable 1:1 for USDC, so
+//                    the USDC price is the conservative, verifiable kUSD price.
+//   - pricePerShare: skUSD.convertToAssets(1 share), normalised to the asset's
+//                    decimals (1.0 == par).
+//   - apyBase      : realised share-price growth of skUSD over a trailing 24h
+//                    window, annualised. This is the yield skUSD holders have
+//                    actually earned, derived purely from on-chain share price
+//                    (no projection, no off-chain rate).
+//   - asset()      : sanity-checked = kUSD (refuses to publish on mismatch).
 //
-// Reviewer notes (2026-06-11 revision):
-//   - This revision switches the tracked pool from the v1 WETH vault
-//     (kLP) to skUSD. The v1 vault is in a publicly disclosed degraded
-//     state pending a v2 redeploy and is intentionally excluded from
-//     protocol TVL by kerne.fi/api/stats; skUSD over the PSM-backed
-//     kUSD is the protocol's durable user-facing yield surface, so it
-//     is the correct pool for DefiLlama to track long-term.
-//   - Genesis-phase TVL is intentionally below the public yields
-//     display threshold, so the pool stays hidden until seeded.
+// Genesis guard:
+//   skUSD is in its early seeding phase. While totalSupply is below the seed
+//   threshold the share price is not yet economically meaningful (a pre-seed
+//   deposit can transiently inflate convertToAssets), so the adapter reports
+//   par price-per-share and 0 realised APY until the vault is seeded. Once
+//   seeded, both values flow directly from on-chain share-price growth with no
+//   code change. Genesis-phase TVL is intentionally below DefiLlama's public
+//   yields display threshold, so the pool stays hidden until seeded.
 //
-// This adapter supersedes the earlier draft at
-//   https://github.com/DefiLlama/yield-server/pull/2254
-// which was closed pending a TVL adapter on the DefiLlama-Adapters side.
+// 2026-06-18 revision: switched APY from the kerne.fi/api/apy methodology field
+//   to a fully on-chain realised share-price computation, added pricePerShare,
+//   and dropped the empty apyReward/rewardTokens and the poolMeta string, per
+//   maintainer review on PR #2688.
 //
-// DefiLlama slug note: DefiLlama assigned this protocol the slug "kerne"
-// when the TVL adapter merged (DefiLlama-Adapters#19306, 2026-05-18), so
-// the directory and project field both follow the public slug "kerne".
+// DefiLlama slug note: DefiLlama assigned this protocol the slug "kerne" when
+//   the TVL adapter merged (DefiLlama-Adapters#19306, 2026-05-18), so the
+//   directory and project field both follow the public slug "kerne".
 
 const sdk = require('@defillama/sdk');
 const axios = require('axios');
@@ -47,20 +48,40 @@ const SKUSD_ADDRESS = '0xdEd74F7E06efc76455C07418b8b74Cc2bc009DB4';
 const KUSD_ADDRESS = '0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3';
 const USDC_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 
+const DAY = 24 * 3600;
+const CONVERT_TO_ASSETS_ABI =
+  'function convertToAssets(uint256) view returns (uint256)';
+
+// Below this share supply the vault is treated as pre-seed (see genesis guard).
+// skUSD shares carry an inflation-attack decimals offset, so the seed threshold
+// is expressed in raw share units: ~1e-3 of a whole share.
+const SEED_SUPPLY_THRESHOLD = 1e21;
+
+const blockForTimestamp = async (timestamp) =>
+  (await axios.get(`https://coins.llama.fi/block/${CHAIN}/${timestamp}`)).data
+    .height;
+
+const convertToAssets = async (shareUnits, block) =>
+  (
+    await sdk.api.abi.call({
+      target: SKUSD_ADDRESS,
+      abi: CONVERT_TO_ASSETS_ABI,
+      params: [shareUnits],
+      chain: CHAIN,
+      ...(block ? { block } : {}),
+    })
+  ).output;
+
 const apy = async () => {
-  // 1. Parallel on-chain reads
-  const [totalAssetsCall, assetCall] = await Promise.all([
-    sdk.api.abi.call({
-      target: SKUSD_ADDRESS,
-      abi: 'uint256:totalAssets',
-      chain: CHAIN,
-    }),
-    sdk.api.abi.call({
-      target: SKUSD_ADDRESS,
-      abi: 'address:asset',
-      chain: CHAIN,
-    }),
-  ]);
+  // 1. Core on-chain reads.
+  const [totalAssetsCall, totalSupplyCall, assetCall, shareDecCall, assetDecCall] =
+    await Promise.all([
+      sdk.api.abi.call({ target: SKUSD_ADDRESS, abi: 'uint256:totalAssets', chain: CHAIN }),
+      sdk.api.abi.call({ target: SKUSD_ADDRESS, abi: 'uint256:totalSupply', chain: CHAIN }),
+      sdk.api.abi.call({ target: SKUSD_ADDRESS, abi: 'address:asset', chain: CHAIN }),
+      sdk.api.abi.call({ target: SKUSD_ADDRESS, abi: 'uint8:decimals', chain: CHAIN }),
+      sdk.api.abi.call({ target: KUSD_ADDRESS, abi: 'uint8:decimals', chain: CHAIN }),
+    ]);
 
   // 2. Defensive: ensure skUSD.asset() is still kUSD (in case of redeploy).
   const onchainAsset = String(assetCall.output).toLowerCase();
@@ -70,9 +91,14 @@ const apy = async () => {
     );
   }
 
-  // 3. Price the kUSD backing at the USDC price (kUSD is PSM-redeemable
-  //    1:1 for USDC; using the coins.llama.fi USDC price keeps pricing
-  //    verifiable through the same source the rest of yield-server uses).
+  const shareDecimals = Number(shareDecCall.output);
+  const assetDecimals = Number(assetDecCall.output);
+  const totalSupply = Number(totalSupplyCall.output);
+  const shareUnit = (10n ** BigInt(shareDecimals)).toString(); // one whole share
+
+  // 3. Price the kUSD backing at the USDC price (kUSD is PSM-redeemable 1:1 for
+  //    USDC; using the coins.llama.fi USDC price keeps pricing verifiable
+  //    through the same source the rest of yield-server uses).
   const priceKey = `${CHAIN}:${USDC_ADDRESS}`;
   const priceResp = await axios.get(
     `https://coins.llama.fi/prices/current/${priceKey}`,
@@ -85,29 +111,44 @@ const apy = async () => {
     );
   }
 
-  // 4. Published APY from the protocol's open methodology endpoint.
-  const apyResp = await axios.get('https://kerne.fi/api/apy', {
-    timeout: 15_000,
-  });
-  const expectedAPY = apyResp?.data?.expectedAPY;
-  if (!Number.isFinite(expectedAPY)) {
-    throw new Error(
-      `Invalid expectedAPY from kerne.fi/api/apy: ${expectedAPY}`
-    );
+  const tvlUsd = (Number(totalAssetsCall.output) / 10 ** assetDecimals) * usdcPrice;
+
+  // 4. Genesis guard: report par + 0 realised APY until the vault is seeded.
+  let pricePerShare = 1;
+  let apyBase = 0;
+
+  if (totalSupply >= SEED_SUPPLY_THRESHOLD) {
+    // 4a. price-per-share now, normalised to asset decimals (1.0 == par).
+    const ppsNowRaw = await convertToAssets(shareUnit);
+    pricePerShare = Number(ppsNowRaw) / 10 ** assetDecimals;
+
+    // 4b. realised APY from the trailing-24h change in share price.
+    try {
+      const now = Math.floor(Date.now() / 1e3);
+      const blockYesterday = await blockForTimestamp(now - DAY);
+      const ppsYesterdayRaw = await convertToAssets(shareUnit, blockYesterday);
+      const ratio = Number(ppsNowRaw) / Number(ppsYesterdayRaw);
+      if (Number.isFinite(ratio) && ratio > 0) {
+        const annualised = (ratio ** 365 - 1) * 100;
+        // Ignore non-positive drift and discard spurious early-window spikes;
+        // realised skUSD carry does not annualise above this band.
+        if (Number.isFinite(annualised) && annualised > 0 && annualised <= 100) {
+          apyBase = annualised;
+        }
+      }
+    } catch (e) {
+      // No archive read / contract too young for a 24h lookback: leave apyBase 0
+      // (no realised yield can be proven yet) rather than fail the adapter.
+      apyBase = 0;
+    }
   }
 
-  // 5. Compose TVL and APY values.
-  const tvlUsd = (Number(totalAssetsCall.output) / 1e18) * usdcPrice;
-  const apyBase = Number(expectedAPY) * 100;
-
-  // 6. Refuse to publish nonsense.
+  // 5. Refuse to publish nonsense.
   if (!Number.isFinite(tvlUsd) || tvlUsd < 0) {
-    throw new Error(
-      `Computed tvlUsd is not a valid non-negative number: ${tvlUsd}`
-    );
+    throw new Error(`Computed tvlUsd is not a valid non-negative number: ${tvlUsd}`);
   }
-  if (!Number.isFinite(apyBase) || apyBase < 0 || apyBase > 100) {
-    throw new Error(`Computed apyBase out of sane range [0, 100]: ${apyBase}`);
+  if (!Number.isFinite(pricePerShare) || pricePerShare <= 0) {
+    throw new Error(`Computed pricePerShare is not a valid positive number: ${pricePerShare}`);
   }
 
   return [
@@ -118,10 +159,8 @@ const apy = async () => {
       symbol: 'skUSD',
       tvlUsd,
       apyBase,
-      apyReward: 0,
-      rewardTokens: [],
+      pricePerShare,
       underlyingTokens: [KUSD_ADDRESS],
-      poolMeta: 'ERC-4626: kUSD -> skUSD (staked delta-neutral synthetic dollar)',
       url: 'https://app.kerne.fi/stake',
       token: SKUSD_ADDRESS,
       isIntrinsicSource: true,
@@ -133,4 +172,7 @@ module.exports = {
   timetravel: false,
   apy,
   url: 'https://kerne.fi',
+  // DefiLlama protocol id for slug "kerne" (defillama.com/protocol/kerne,
+  // TVL adapter DefiLlama-Adapters#19306).
+  protocolId: '7873',
 };

--- a/src/adaptors/kerne/index.js
+++ b/src/adaptors/kerne/index.js
@@ -90,6 +90,11 @@ const apy = async () => {
     timeout: 15_000,
   });
   const expectedAPY = apyResp?.data?.expectedAPY;
+  if (!Number.isFinite(expectedAPY)) {
+    throw new Error(
+      `Invalid expectedAPY from kerne.fi/api/apy: ${expectedAPY}`
+    );
+  }
 
   // 5. Compose TVL and APY values.
   const tvlUsd = (Number(totalAssetsCall.output) / 1e18) * usdcPrice;

--- a/src/adaptors/kerne/index.js
+++ b/src/adaptors/kerne/index.js
@@ -26,6 +26,13 @@
 // This adapter supersedes the earlier draft at
 //   https://github.com/DefiLlama/yield-server/pull/2254
 // which was closed pending a TVL adapter on the DefiLlama-Adapters side.
+//
+// DefiLlama slug note: DefiLlama assigned this protocol the slug "kerne"
+// when the TVL adapter merged (DefiLlama-Adapters#19306, 2026-05-18), so
+// the project field below matches that slug. The TVL adapter directory in
+// DefiLlama-Adapters remains projects/kerne-protocol/ per the module field
+// on /api/protocols, but the yield-server adapter directory and project
+// field both follow the public slug "kerne".
 
 const sdk = require('@defillama/sdk');
 const axios = require('axios');
@@ -98,7 +105,7 @@ const apy = async () => {
     {
       pool: `${VAULT_ADDRESS}-${CHAIN}`.toLowerCase(),
       chain: utils.formatChain(CHAIN),
-      project: 'kerne-protocol',
+      project: 'kerne',
       symbol: 'kLP',
       tvlUsd,
       apyBase,

--- a/src/adaptors/kerne/index.js
+++ b/src/adaptors/kerne/index.js
@@ -40,7 +40,6 @@
 //   directory and project field both follow the public slug "kerne".
 
 const sdk = require('@defillama/sdk');
-const axios = require('axios');
 const utils = require('../utils');
 
 const CHAIN = 'base';
@@ -58,8 +57,7 @@ const CONVERT_TO_ASSETS_ABI =
 const SEED_SUPPLY_THRESHOLD = 1e21;
 
 const blockForTimestamp = async (timestamp) =>
-  (await axios.get(`https://coins.llama.fi/block/${CHAIN}/${timestamp}`)).data
-    .height;
+  (await utils.getBlocksByTime([timestamp], CHAIN))[0];
 
 const convertToAssets = async (shareUnits, block) =>
   (
@@ -100,11 +98,8 @@ const apy = async () => {
   //    USDC; using the coins.llama.fi USDC price keeps pricing verifiable
   //    through the same source the rest of yield-server uses).
   const priceKey = `${CHAIN}:${USDC_ADDRESS}`;
-  const priceResp = await axios.get(
-    `https://coins.llama.fi/prices/current/${priceKey}`,
-    { timeout: 15_000 }
-  );
-  const usdcPrice = priceResp?.data?.coins?.[priceKey]?.price;
+  const priceData = await utils.getPriceApiData(`/prices/current/${priceKey}`);
+  const usdcPrice = priceData?.coins?.[priceKey]?.price;
   if (!Number.isFinite(usdcPrice) || usdcPrice <= 0) {
     throw new Error(
       `Invalid USDC price from coins.llama.fi for ${priceKey}: ${usdcPrice}`


### PR DESCRIPTION
## Pool

KerneVault (ERC-4626) on Base. Share symbol **kLP**. Underlying asset: **WETH** (`0x4200000000000000000000000000000000000006`).

Strategy: delta-neutral basis trade. Long leg accrues Lido stETH staking yield via off-chain accounting reported on-chain by the strategist; short leg captures perpetual funding on Hyperliquid. Yield is realized in kLP share-price appreciation.

## Contract

Verified on Basescan: https://basescan.org/address/0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC#code

## TVL adapter prerequisite

Per @slasher125's feedback on #2254 ("make sure we have a tvl adapter first, otherwise we can't list on yields"), the TVL adapter is opened in parallel at [DefiLlama/DefiLlama-Adapters#19306](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19306). This yield-server PR can be reviewed alongside it and merged once the TVL side lands.

## Data sources

All values are pulled at adapter run-time, with no Kerne API dependency in the critical path:

| Field | Source |
|---|---|
| `tvlUsd` | `KerneVault.totalAssets()` × WETH price (`coins.llama.fi`) |
| `apyBase` | `KerneVault.projectedAPY()` (governance-configured, basis points) |
| `asset` | Sanity-checked to equal WETH via `KerneVault.asset()` |

## Adapter output

```json
{
  "pool": "0x8005bc7a86ad904c20fd62788abed7546c1cf2ac-base",
  "chain": "Base",
  "project": "kerne-protocol",
  "symbol": "kLP",
  "tvlUsd": 189.58,
  "apyBase": 12,
  "apyReward": 0,
  "rewardTokens": [],
  "underlyingTokens": ["0x4200000000000000000000000000000000000006"],
  "poolMeta": "ERC-4626: WETH → kLP (delta-neutral basis trade)",
  "url": "https://app.kerne.fi",
  "token": "0x8005bc7A86AD904C20fd62788ABED7546c1cF2AC",
  "isIntrinsicSource": true
}
```

## Continuity with #2254

This supersedes [#2254](https://github.com/DefiLlama/yield-server/pull/2254). Changes from that draft:

- Canonical production vault address `0x8005bc7A...F2AC` (previously used a staging address)
- Uses `kerne.fi` (canonical domain; prior PR used `kerne.finance`)
- Adds `token`, `isIntrinsicSource`, lowercased pool id per current schema
- Asset sanity-check (throws if `vault.asset() != WETH`)
- Bounded numeric validation (refuses to publish NaN/negative/out-of-range values)
- Axios timeout on price fetch (15s)
- APY derived from on-chain `projectedAPY()` rather than parsed API string

## Notes for reviewer

- `vault.symbol()` currently returns the string `"2"` (placeholder set at deploy). We hardcode `"kLP"` which is the documented share-token symbol per [kerne.fi/docs](https://kerne.fi/docs).
- TVL is small ($189) — protocol is in Genesis Phase. Above the >10k yields-page filter once seeded.

Happy to iterate on any feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for KerneVault (skUSD) on Base, including pool page link, staking details, underlying token (kUSD), TVL in USD, and APY/price-per-share.
  * Pricing and performance are now derived directly from on-chain vault data plus live USDC pricing, with safeguards that prevent nonsensical results.
  * Before seeding, the pool reports a 1.0 price-per-share baseline with APY set to 0 until meaningful supply growth is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->