### PR TITLE
refactor(scrubvault): publish under scrubvault slug for Basis Trading category

### DIFF
--- a/src/adaptors/scrubvault/index.js
+++ b/src/adaptors/scrubvault/index.js
@@ -37,7 +37,7 @@ const { ethers } = require('ethers');
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const PROJECT = 'scrub';
+const PROJECT = 'scrubvault';
 
 const VAULTS = {
   kava: {

--- a/src/adaptors/scrubvault/index.js
+++ b/src/adaptors/scrubvault/index.js
@@ -213,7 +213,7 @@ const apy = async () => {
       });
     } catch (err) {
       console.error(
-        `[scrub] ${vault.chain} vault ${vault.address} failed: ${err.message}`,
+        `[${PROJECT}] ${vault.chain} vault ${vault.address} failed: ${err.message}`,
       );
     }
   }


### PR DESCRIPTION
Follow-up to #2678 (merged).

#2678 added the ScrubVault delta-neutral pools under `project: 'scrub'`, which maps to the **"Scrub"** DefiLlama protocol (category **Algo-Stables**). These delta-neutral USDt/USDC vaults instead belong to the separately-registered **"ScrubVault"** protocol (slug `scrubvault`), which DefiLlama already classifies as **Basis Trading** (chains Kava + Arbitrum — exactly the two pools here).

## Change
- `git mv src/adaptors/scrub` → `src/adaptors/scrubvault` (99% rename, history preserved)
- `PROJECT` `'scrub'` → `'scrubvault'`

That's the entire diff — one rename + one line. No logic changes; all review fixes from #2678 (sdk.getEventLogs, raw apyBase/pricePerShare, getLatestBlock, overflow-safe math, per-vault error isolation) are carried over unchanged.

## Why a new PR
#2678 was already merged before this categorization issue was caught; a merged PR can't take new commits, so this is a clean follow-up branched off current `master`.

## Verification
Adapter run live against Kava + Arbitrum:

| chain | project | symbol | tvlUsd | apyBase | pricePerShare |
|---|---|---|---|---|---|
| Kava | scrubvault | USDt | 82913.75 | 14.9962 | 1.03809392 |
| Arbitrum | scrubvault | USDC | 32461.52 | 14.9958 | 1.02035828 |

`test.js` invariants satisfied: `project` === adapter folder name (`scrubvault`) and `scrubvault` is a known protocol slug (`api.llama.fi/protocols`, category "Basis Trading").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the project identifier in the adapter to correctly designate the proper project name for all returned pools, ensuring accurate project attribution and data consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->