### PR TITLE
Add Liquidium USDC pool to yields adapter

### DIFF
--- a/src/adaptors/liquidium/index.js
+++ b/src/adaptors/liquidium/index.js
@@ -3,10 +3,12 @@ const { queryCanister, decodeCandid, hashCandidLabel } = require('./icp')
 
 const LENDING_CANISTER_ID = 'hyk4r-jqaaa-aaaar-qb4ca-cai'
 const BTC_POOL_CANISTER_ID = 'hkmli-faaaa-aaaar-qb4ba-cai'
-const ERC_POOL_CANISTER_ID = 'hnnn4-iyaaa-aaaar-qb4bq-cai'
+const USDT_POOL_CANISTER_ID = 'hnnn4-iyaaa-aaaar-qb4bq-cai'
+const USDC_POOL_CANISTER_ID = '6sna2-oiaaa-aaaar-qb66q-cai'
 const ALLOWED_POOL_CANISTERS = new Set([
   BTC_POOL_CANISTER_ID,
-  ERC_POOL_CANISTER_ID,
+  USDT_POOL_CANISTER_ID,
+  USDC_POOL_CANISTER_ID,
 ])
 const RAY = 10n ** 27n
 const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)


### PR DESCRIPTION
Adds the Liquidium USDC lending pool canister to the Liquidium yields adapter allowlist.

The existing adapter logic already handles USDC pricing, decimals, APY, and ckAsset underlying token reporting. This also renames the existing USDT pool constant for clarity.

Validation:
- `npm run test --adapter=liquidium`