### PR TITLE
credit.cash: align tvlUsd with documented lending schema

### DIFF
--- a/src/adaptors/credit/index.js
+++ b/src/adaptors/credit/index.js
@@ -53,6 +53,7 @@ const apy = async () => {
 
   const totalAssets = totalAssetsRaw / 10 ** USDC_DECIMALS;
   const totalOutstanding = totalOutstandingRaw / 10 ** USDC_DECIMALS;
+  const availableLiquidity = Math.max(totalAssets - totalOutstanding, 0);
 
   const params = {
     optimalUtilization: optimalUtilizationRaw / precision,
@@ -61,7 +62,10 @@ const apy = async () => {
   };
 
   const utilRate = totalAssets > 0 ? totalOutstanding / totalAssets : 0;
-  const tvlUsd = totalAssets * usdcPrice;
+
+  const totalSupplyUsd = totalAssets * usdcPrice;
+  const totalBorrowUsd = totalOutstanding * usdcPrice;
+  const tvlUsd = availableLiquidity * usdcPrice;
 
   return [
     {
@@ -74,6 +78,8 @@ const apy = async () => {
       underlyingTokens: [USDC],
       url: 'https://credit.cash',
       poolMeta: '$3M supply cap',
+      totalSupplyUsd,
+      totalBorrowUsd,
     },
   ];
 };


### PR DESCRIPTION
This PR aligns the Credit adapter with the schema documented in the yield-server README for lending protocols:

> `tvlUsd: number; // for lending protocols: tvlUsd = totalSupplyUsd - totalBorrowUsd`

The current adapter sets `tvlUsd` to the full `totalAssets()` value of the vault, which represents the supply side rather than the available liquidity. Since the adapter already reads `totalOutstandingPrincipal()` for its utilization calculation, we can populate the dedicated `totalSupplyUsd` and `totalBorrowUsd` fields and let `tvlUsd` reflect the available liquidity, so the breakdown matches what is shown for other lending pools (Aave, Compound, Morpho, etc.).

  ## Changes

  - `tvlUsd` is now `(totalAssets − totalOutstandingPrincipal) * price` (available liquidity).
  - New `totalSupplyUsd = totalAssets * price`.
  - New `totalBorrowUsd = totalOutstandingPrincipal * price`.
  - A `Math.max(..., 0)` guard is added on the available-liquidity computation to absorb any transient case where 'totalOutstanding` briefly exceeds `totalAssets` due to accrued-but-unrealized interest.
  - APY calculation, utilization rate, and ABIs are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved available liquidity calculation methodology for more accurate reporting.
  * Corrected TVL calculation to align with actual available liquidity.

* **New Features**
  * Added USD-denominated total supply and total borrow metrics to pool data output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->