### PR TITLE
Add BTCD sBTCD yield adapter

### DIFF
--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -185,14 +185,15 @@ const apy = async () => {
       `SBTCDOracle.latestRoundData().answer must be positive, got ${priceUsd_e8}`
     );
   }
-  // tvlUsd = totalSupply × price / 10^(18+8) = USD raw with 8 decimals.
+  // tvlUsd = totalSupply × price / 10^(18+8) = USD raw with 8 decimals
+  // (the oracle's `decimals()` is fixed at 8 per IPriceOracle).
   // Split the BigInt into whole+fractional dollars so we don't lose cents
   // of precision once total TVL grows past Number.MAX_SAFE_INTEGER (~$90M
   // when expressed at 8-decimal scale).
   const tvlUsdScaled = (totalSupply * priceUsd_e8) / 10n ** 18n; // 8-decimal USD
-  const HUNDRED_M = 10n ** 8n;
-  const wholeUsd = tvlUsdScaled / HUNDRED_M;
-  const fracUsd = tvlUsdScaled % HUNDRED_M;
+  const ONE_USD_E8 = 10n ** 8n; // = 1.00 USD expressed in 8-dec oracle units
+  const wholeUsd = tvlUsdScaled / ONE_USD_E8;
+  const fracUsd = tvlUsdScaled % ONE_USD_E8;
   const tvlUsd = Number(wholeUsd) + Number(fracUsd) / 1e8;
 
   return [

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -1,98 +1,39 @@
-/**
- * @file BTCD yield-server adapter — exposes the sBTCD staking vault as a
- *       single Ethereum pool with TVL and 30-day APR.
- *
- * @description
- * BTCD is a synthetic basket-backed token (~50% BTC / ~50% USD) RFQ-minted
- * via BTCDMinting against whitelisted collateral. sBTCD is the protocol's
- * ERC-4626 staking vault: deposit BTCD, receive sBTCD shares, share price
- * grows as the YieldDistributor pushes freshly-minted BTCD into the vault
- * over 8h linear vesting cycles. A 7-day Silo cooldown gates withdrawals.
- */
+// BTCD yield-server adapter — single Ethereum pool (sBTCD ERC-4626 staking
+// vault) with TVL and 30-day simple APR. APR mirrors
+// services/vault/sbtcdror/sbtcdrorcalculator.go: previewRedeem(1e18) growth
+// over a 30-day window, simple-rate annualised on a 365.25-day year, clamped
+// to the yield-activation block.
 
 const sdk = require('@defillama/sdk');
 const axios = require('axios');
 
-/** @type {string} DefiLlama chain slug. */
 const CHAIN = 'ethereum';
-/** @type {string} BTCD token (the underlying ERC-20). */
-const BTCD = '0xC6694e05B750015f54Ac646544a4a9D33cbe4086';
-/** @type {string} sBTCD ERC-4626 staking vault (the receipt token). */
+const BTCD  = '0xC6694e05B750015f54Ac646544a4a9D33cbe4086';
 const SBTCD = '0x3BC801419479865B24b4d32faB0Bf64638Abbd5f';
-/**
- * @type {string} SBTCDOracle — Chainlink-compatible IPriceOracle returning
- *                sBTCD/USD with 8 decimals via `latestRoundData()`.
- */
-const SBTCD_ORACLE = '0x332ebF042a7B7D87A8a2628186f8A5B12d8a6d94';
 
-/**
- * APR methodology mirrors the protocol's canonical sBTCD rate-of-return
- * calculator at `services/vault/sbtcdror/sbtcdrorcalculator.go`:
- *   - 30-day lookback window
- *   - `previewRedeem(1e18)` for share-price reads (matches the canonical Go)
- *   - Simple APR (not compound APY) with a 365.25-day year
- *   - Clamp the start block to `SBTCDYieldTurnedOnBlock` so share prices
- *     from before yield activation are never sampled
- */
+// Chainlink BTC/USD aggregator (public infra; not the BTCD-specific oracle).
+const BTC_USD_FEED = '0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c';
+// Initial BTC/USD reference; peg = sqrt(BTC_USD / P0) algorithmically.
+// Must match SBTCDOracle.P0_WAD at deploy. Re-verify if the oracle is redeployed.
+const P0_USD = 94000;
 
-/** @type {string} 1e18 in raw token units; the standard ERC-4626 share unit. */
 const WAD = '1000000000000000000';
-/** @type {bigint} BigInt mirror of WAD, used for ratio scaling. */
 const SCALE = 10n ** 18n;
-/** @type {number} */
 const SECONDS_PER_DAY = 86400;
-/** @type {number} APR lookback window. Matches the canonical Go calculator. */
 const LOOKBACK_DAYS = 30;
-/** @type {number} 365.25 × 86400 — leap-year-aware seconds per year. */
 const SECONDS_PER_YEAR = 365.25 * SECONDS_PER_DAY;
-/**
- * @type {number} Block at which the YieldDistributor first delivered yield
- *                to sBTCD. Sourced from
- *                `services/vault/monitor/setpointprovider` (see the
- *                `keySBTCDYieldTurnedOnBlock` default).
- */
+// First block at which the YieldDistributor delivered yield to sBTCD; share
+// prices before this would corrupt the APR ratio.
 const SBTCD_YIELD_TURNED_ON_BLOCK = 24450207;
 
-/** @type {string} Human-readable ABI for `IERC4626.previewRedeem`. */
-const previewRedeemAbi =
-  'function previewRedeem(uint256 shares) view returns (uint256)';
-/** @type {string} Human-readable ABI for `IPriceOracle.latestRoundData`. */
+const previewRedeemAbi = 'function previewRedeem(uint256 shares) view returns (uint256)';
+const totalAssetsAbi = 'function totalAssets() view returns (uint256)';
 const latestRoundDataAbi =
-  'function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)';
+  'function latestRoundData() view returns (uint80, int256, uint256, uint256, uint80)';
 
-/**
- * Resolves a chain block height for a given Unix timestamp using DefiLlama's
- * timestamp→block index. Returns the block whose timestamp is closest to the
- * requested second.
- *
- * @param {string} chain DefiLlama chain slug (e.g. `'ethereum'`).
- * @param {number} timestamp Unix seconds.
- * @returns {Promise<number>} The block height at (or nearest to) `timestamp`.
- * @throws {Error} If the HTTP request fails or the response is malformed.
- */
 const getBlockAtTimestamp = async (chain, timestamp) =>
-  (await axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)).data
-    .height;
+  (await axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)).data.height;
 
-/**
- * Computes the 30-day simple APR of the sBTCD vault from share-price growth.
- *
- * Reads `previewRedeem(1e18)` at the latest block and at a block 30 days ago,
- * computes the percentage increase, and annualises with a 365.25-day year:
- *
- *     APR = (priceNow / priceStart − 1) × secondsPerYear / secondsElapsed
- *
- * Mirrors `SBTCDRORCalculator.annualizeRate` in
- * `services/vault/sbtcdror/sbtcdrorcalculator.go`. Returns 0 (instead of
- * throwing) when the historical block is unavailable, predates yield
- * activation, or the share price did not grow — so a young vault still
- * publishes 0% APR alongside a valid TVL rather than failing the whole
- * adapter run.
- *
- * @returns {Promise<number>} APR as a percentage (e.g. `17.22` for 17.22%).
- *                            Always non-negative; returns 0 on any error or
- *                            non-positive growth.
- */
 async function computeApyBase() {
   const nowTs = Math.floor(Date.now() / 1000);
   const oldTs = nowTs - LOOKBACK_DAYS * SECONDS_PER_DAY;
@@ -102,27 +43,12 @@ async function computeApyBase() {
   } catch (e) {
     return 0;
   }
-  // If the lookback window starts before yield was turned on, the resulting
-  // rate would be meaningless. The canonical calculator clamps to the
-  // activation block; we just bail since the vault is < 30 days post-activation
-  // only briefly and a 0% read is a clearer signal than a partial-window APR.
   if (oldBlock < SBTCD_YIELD_TURNED_ON_BLOCK) return 0;
   let nowVal, oldVal;
   try {
     const [nowRes, oldRes] = await Promise.all([
-      sdk.api.abi.call({
-        chain: CHAIN,
-        target: SBTCD,
-        abi: previewRedeemAbi,
-        params: [WAD],
-      }),
-      sdk.api.abi.call({
-        chain: CHAIN,
-        target: SBTCD,
-        abi: previewRedeemAbi,
-        params: [WAD],
-        block: oldBlock,
-      }),
+      sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: previewRedeemAbi, params: [WAD] }),
+      sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: previewRedeemAbi, params: [WAD], block: oldBlock }),
     ]);
     nowVal = BigInt(nowRes.output);
     oldVal = BigInt(oldRes.output);
@@ -130,71 +56,38 @@ async function computeApyBase() {
     return 0;
   }
   if (oldVal <= 0n || nowVal <= oldVal) return 0;
-  // Simple APR:
-  //   rate = (priceNow / priceStart - 1) × secondsPerYear / secondsElapsed
-  const rateScaled = ((nowVal - oldVal) * SCALE) / oldVal; // (ratio − 1) × 1e18
+  const rateScaled = ((nowVal - oldVal) * SCALE) / oldVal;
   const rate = Number(rateScaled) / 1e18;
   if (!isFinite(rate) || rate <= 0) return 0;
-  const secondsElapsed = nowTs - oldTs; // = LOOKBACK_DAYS × SECONDS_PER_DAY
+  const secondsElapsed = nowTs - oldTs;
   return ((rate * SECONDS_PER_YEAR) / secondsElapsed) * 100;
 }
 
-/**
- * Adapter entry point — produces DefiLlama yield-server pool entries for sBTCD.
- *
- * Reads `sBTCD.totalSupply()`, `SBTCDOracle.latestRoundData()`, and
- * computes APR in parallel. TVL is `totalSupply × oracleAnswer / 10^26`,
- * where the oracle answer is sBTCD/USD with 8 decimals (sBTCD has 18).
- *
- * @returns {Promise<Array<{
- *   pool: string,
- *   chain: string,
- *   project: string,
- *   symbol: string,
- *   tvlUsd: number,
- *   apyBase: number,
- *   underlyingTokens: string[],
- *   poolMeta: string,
- *   url: string,
- *   token: string,
- * }>>} Single-element array containing the sBTCD pool entry.
- * @throws {Error} If `SBTCDOracle.latestRoundData().answer` is non-positive.
- *                 (Morpho's IOracle spec returns 0 on bad feed data instead
- *                 of reverting; the int256 return type also technically
- *                 permits a negative answer. We surface either as a hard
- *                 error rather than silently publishing zero or negative TVL.)
- */
-const apy = async () => {
-  const [totalSupplyRes, oracleRes, apyBase] = await Promise.all([
-    sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: 'erc20:totalSupply' }),
-    sdk.api.abi.call({
+// Algorithmic peg: peg = sqrt(BTC_USD / P0). Mirrors SBTCDOracle's formula
+// (services/contracts/price-oracle/src/PriceOracle.sol) but reads Chainlink
+// BTC/USD directly so the adapter doesn't depend on the protocol's own oracle.
+async function btcdPriceUsd() {
+  try {
+    const r = await sdk.api.abi.call({
       chain: CHAIN,
-      target: SBTCD_ORACLE,
+      target: BTC_USD_FEED,
       abi: latestRoundDataAbi,
-    }),
+    });
+    const btcUsd = Number(r.output[1]) / 1e8; // Chainlink BTC/USD has 8 decimals
+    if (!isFinite(btcUsd) || btcUsd <= 0) return 1.0;
+    return Math.sqrt(btcUsd / P0_USD);
+  } catch (e) {
+    return 1.0;
+  }
+}
+
+const apy = async () => {
+  const [totalAssetsRes, price, apyBase] = await Promise.all([
+    sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: totalAssetsAbi }),
+    btcdPriceUsd(),
     computeApyBase(),
   ]);
-
-  const totalSupply = BigInt(totalSupplyRes.output); // 18 decimals
-  const priceUsd_e8 = BigInt(oracleRes.output.answer); // 8 decimals (int256)
-  // SBTCDOracle returns 0 on bad feed data per Morpho non-revert spec, and
-  // the int256 return type technically permits a negative answer. Surface
-  // either as a hard error rather than silently publishing 0 or negative TVL.
-  if (priceUsd_e8 <= 0n) {
-    throw new Error(
-      `SBTCDOracle.latestRoundData().answer must be positive, got ${priceUsd_e8}`
-    );
-  }
-  // tvlUsd = totalSupply × price / 10^(18+8) = USD raw with 8 decimals
-  // (the oracle's `decimals()` is fixed at 8 per IPriceOracle).
-  // Split the BigInt into whole+fractional dollars so we don't lose cents
-  // of precision once total TVL grows past Number.MAX_SAFE_INTEGER (~$90M
-  // when expressed at 8-decimal scale).
-  const tvlUsdScaled = (totalSupply * priceUsd_e8) / 10n ** 18n; // 8-decimal USD
-  const ONE_USD_E8 = 10n ** 8n; // = 1.00 USD expressed in 8-dec oracle units
-  const wholeUsd = tvlUsdScaled / ONE_USD_E8;
-  const fracUsd = tvlUsdScaled % ONE_USD_E8;
-  const tvlUsd = Number(wholeUsd) + Number(fracUsd) / 1e8;
+  const tvlUsd = (Number(BigInt(totalAssetsRes.output)) / 1e18) * price;
 
   return [
     {
@@ -212,13 +105,6 @@ const apy = async () => {
   ];
 };
 
-/**
- * @type {{ apy: () => Promise<object[]>, url: string }}
- *
- * - `apy` — see {@link apy}.
- * - `url` — protocol landing page (used by yield-server when a pool entry
- *   does not specify its own `url`).
- */
 module.exports = {
   apy,
   url: 'https://btcd.fi',

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -8,7 +8,7 @@ const sdk = require('@defillama/sdk');
 const axios = require('axios');
 
 const CHAIN = 'ethereum';
-const BTCD  = '0xC6694e05B750015f54Ac646544a4a9D33cbe4086';
+const BTCD = '0xC6694e05B750015f54Ac646544a4a9D33cbe4086';
 const SBTCD = '0x3BC801419479865B24b4d32faB0Bf64638Abbd5f';
 
 // Chainlink BTC/USD aggregator (public infra; not the BTCD-specific oracle).
@@ -17,7 +17,6 @@ const BTC_USD_FEED = '0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c';
 // Must match SBTCDOracle.P0_WAD at deploy. Re-verify if the oracle is redeployed.
 const P0_USD = 94000;
 
-const WAD = '1000000000000000000';
 const SCALE = 10n ** 18n;
 const SECONDS_PER_DAY = 86400;
 const LOOKBACK_DAYS = 30;
@@ -26,13 +25,15 @@ const SECONDS_PER_YEAR = 365.25 * SECONDS_PER_DAY;
 // prices before this would corrupt the APR ratio.
 const SBTCD_YIELD_TURNED_ON_BLOCK = 24450207;
 
-const previewRedeemAbi = 'function previewRedeem(uint256 shares) view returns (uint256)';
+const previewRedeemAbi =
+  'function previewRedeem(uint256 shares) view returns (uint256)';
 const totalAssetsAbi = 'function totalAssets() view returns (uint256)';
 const latestRoundDataAbi =
   'function latestRoundData() view returns (uint80, int256, uint256, uint256, uint80)';
 
 const getBlockAtTimestamp = async (chain, timestamp) =>
-  (await axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)).data.height;
+  (await axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)).data
+    .height;
 
 async function computeApyBase() {
   const nowTs = Math.floor(Date.now() / 1000);
@@ -47,8 +48,19 @@ async function computeApyBase() {
   let nowVal, oldVal;
   try {
     const [nowRes, oldRes] = await Promise.all([
-      sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: previewRedeemAbi, params: [WAD] }),
-      sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: previewRedeemAbi, params: [WAD], block: oldBlock }),
+      sdk.api.abi.call({
+        chain: CHAIN,
+        target: SBTCD,
+        abi: previewRedeemAbi,
+        params: [SCALE.toString()],
+      }),
+      sdk.api.abi.call({
+        chain: CHAIN,
+        target: SBTCD,
+        abi: previewRedeemAbi,
+        params: [SCALE.toString()],
+        block: oldBlock,
+      }),
     ]);
     nowVal = BigInt(nowRes.output);
     oldVal = BigInt(oldRes.output);
@@ -82,12 +94,12 @@ async function btcdPriceUsd() {
 }
 
 const apy = async () => {
-  const [totalAssetsRes, price, apyBase] = await Promise.all([
+  const [sBtcdAssetsRes, price, sBtcdApyBase] = await Promise.all([
     sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: totalAssetsAbi }),
     btcdPriceUsd(),
     computeApyBase(),
   ]);
-  const tvlUsd = (Number(BigInt(totalAssetsRes.output)) / 1e18) * price;
+  const sBtcdTvlUsd = (Number(BigInt(sBtcdAssetsRes.output)) / 1e18) * price;
 
   return [
     {
@@ -95,11 +107,11 @@ const apy = async () => {
       chain: 'Ethereum',
       project: 'btcd',
       symbol: 'sBTCD',
-      tvlUsd,
-      apyBase,
+      tvlUsd: sBtcdTvlUsd,
+      apyBase: sBtcdApyBase,
       underlyingTokens: [BTCD],
       poolMeta: 'BTCD staking vault (8h vesting, 7d cooldown)',
-      url: 'https://btcd.fi',
+      url: 'https://btcd.fi/app/stake/btcd',
       token: SBTCD,
     },
   ];

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -1,84 +1,117 @@
 const sdk = require('@defillama/sdk');
+const axios = require('axios');
 
 // BTCD: synthetic basket-backed token (~50% BTC / ~50% USD), RFQ-minted via BTCDMinting.
 // sBTCD: ERC-4626 staking vault over BTCD with 8h linear vesting and 7-day Silo cooldown.
 // SBTCDOracle: on-chain Chainlink-compatible oracle returning sBTCD/USD in 8 decimals.
 
+const CHAIN = 'ethereum';
 const BTCD = '0xC6694e05B750015f54Ac646544a4a9D33cbe4086';
 const SBTCD = '0x3BC801419479865B24b4d32faB0Bf64638Abbd5f';
 const SBTCD_ORACLE = '0x332ebF042a7B7D87A8a2628186f8A5B12d8a6d94';
 
+// APR methodology mirrors the protocol's canonical sBTCD rate-of-return
+// calculator at services/vault/sbtcdror/sbtcdrorcalculator.go:
+//   - 30-day window
+//   - PreviewRedeem(1e18) for share-price reads
+//   - Simple APR (not compound APY) with a 365.25-day year
+//   - Clamp the start block to SBTCDYieldTurnedOnBlock so we never sample
+//     share prices from before yield was activated
 const WAD = '1000000000000000000'; // 1e18
 const SCALE = 10n ** 18n;
 const SECONDS_PER_DAY = 86400;
-const SECONDS_PER_BLOCK = 12;
-const LOOKBACK_DAYS = 7;
-const BLOCKS_PER_LOOKBACK = Math.floor((SECONDS_PER_DAY * LOOKBACK_DAYS) / SECONDS_PER_BLOCK);
+const LOOKBACK_DAYS = 30;
+const SECONDS_PER_YEAR = 365.25 * SECONDS_PER_DAY;
+const SBTCD_YIELD_TURNED_ON_BLOCK = 24450207;
 
-const convertToAssetsAbi = {
-  inputs: [{ type: 'uint256', name: 'shares' }],
-  name: 'convertToAssets',
-  outputs: [{ type: 'uint256', name: 'assets' }],
-  stateMutability: 'view',
-  type: 'function',
-};
+const previewRedeemAbi =
+  'function previewRedeem(uint256 shares) view returns (uint256)';
+const latestRoundDataAbi =
+  'function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)';
 
-const latestRoundDataAbi = {
-  inputs: [],
-  name: 'latestRoundData',
-  outputs: [
-    { type: 'uint80', name: 'roundId' },
-    { type: 'int256', name: 'answer' },
-    { type: 'uint256', name: 'startedAt' },
-    { type: 'uint256', name: 'updatedAt' },
-    { type: 'uint80', name: 'answeredInRound' },
-  ],
-  stateMutability: 'view',
-  type: 'function',
-};
+const getBlockAtTimestamp = async (chain, timestamp) =>
+  (await axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)).data
+    .height;
 
-// 7-day annualised share-price growth, compounded to APY.
-async function computeApyBase(currentBlock) {
-  const olderBlock = currentBlock - BLOCKS_PER_LOOKBACK;
-  const calls = [
-    sdk.api.abi.call({
-      chain: 'ethereum',
-      target: SBTCD,
-      abi: convertToAssetsAbi,
-      params: [WAD],
-    }),
-    sdk.api.abi.call({
-      chain: 'ethereum',
-      target: SBTCD,
-      abi: convertToAssetsAbi,
-      params: [WAD],
-      block: olderBlock,
-    }),
-  ];
-  const [nowRes, oldRes] = await Promise.all(calls);
-  const nowVal = BigInt(nowRes.output);
-  const oldVal = BigInt(oldRes.output);
-  if (oldVal <= 0n || nowVal <= 0n) return 0;
-  const ratioScaled = (nowVal * SCALE) / oldVal; // (now/old) × 1e18
-  const ratio = Number(ratioScaled) / 1e18;
-  if (!isFinite(ratio) || ratio <= 0) return 0;
-  return (Math.pow(ratio, 365 / LOOKBACK_DAYS) - 1) * 100;
+// Returns 0 (instead of throwing) if the historical block is unavailable or
+// pre-dates yield activation, so a young vault still publishes a 0% APR
+// alongside a valid TVL rather than failing the whole adapter run.
+async function computeApyBase() {
+  const nowTs = Math.floor(Date.now() / 1000);
+  const oldTs = nowTs - LOOKBACK_DAYS * SECONDS_PER_DAY;
+  let oldBlock;
+  try {
+    oldBlock = await getBlockAtTimestamp(CHAIN, oldTs);
+  } catch (e) {
+    return 0;
+  }
+  // If the lookback window starts before yield was turned on, the resulting
+  // rate would be meaningless. The canonical calculator clamps to the
+  // activation block; we just bail since the vault is < 30 days post-activation
+  // only briefly and a 0% read is a clearer signal than a partial-window APR.
+  if (oldBlock < SBTCD_YIELD_TURNED_ON_BLOCK) return 0;
+  let nowVal, oldVal;
+  try {
+    const [nowRes, oldRes] = await Promise.all([
+      sdk.api.abi.call({
+        chain: CHAIN,
+        target: SBTCD,
+        abi: previewRedeemAbi,
+        params: [WAD],
+      }),
+      sdk.api.abi.call({
+        chain: CHAIN,
+        target: SBTCD,
+        abi: previewRedeemAbi,
+        params: [WAD],
+        block: oldBlock,
+      }),
+    ]);
+    nowVal = BigInt(nowRes.output);
+    oldVal = BigInt(oldRes.output);
+  } catch (e) {
+    return 0;
+  }
+  if (oldVal <= 0n || nowVal <= oldVal) return 0;
+  // Simple APR:
+  //   rate = (priceNow / priceStart - 1) × secondsPerYear / secondsElapsed
+  const rateScaled = ((nowVal - oldVal) * SCALE) / oldVal; // (ratio − 1) × 1e18
+  const rate = Number(rateScaled) / 1e18;
+  if (!isFinite(rate) || rate <= 0) return 0;
+  const secondsElapsed = nowTs - oldTs; // = LOOKBACK_DAYS × SECONDS_PER_DAY
+  return ((rate * SECONDS_PER_YEAR) / secondsElapsed) * 100;
 }
 
 const apy = async () => {
-  const [totalSupplyRes, oracleRes, latestBlock] = await Promise.all([
-    sdk.api.abi.call({ chain: 'ethereum', target: SBTCD, abi: 'erc20:totalSupply' }),
-    sdk.api.abi.call({ chain: 'ethereum', target: SBTCD_ORACLE, abi: latestRoundDataAbi }),
-    sdk.api.util.getLatestBlock('ethereum'),
+  const [totalSupplyRes, oracleRes, apyBase] = await Promise.all([
+    sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: 'erc20:totalSupply' }),
+    sdk.api.abi.call({
+      chain: CHAIN,
+      target: SBTCD_ORACLE,
+      abi: latestRoundDataAbi,
+    }),
+    computeApyBase(),
   ]);
 
-  const totalSupply = BigInt(totalSupplyRes.output);    // 18 decimals
-  const priceUsd_e8 = BigInt(oracleRes.output.answer);  // 8 decimals
-  // tvlUsd = totalSupply × price / 10^(18+8). Use BigInt to avoid float overflow on large supply.
+  const totalSupply = BigInt(totalSupplyRes.output); // 18 decimals
+  const priceUsd_e8 = BigInt(oracleRes.output.answer); // 8 decimals (int256)
+  // SBTCDOracle returns 0 on bad feed data per Morpho non-revert spec, and
+  // the int256 return type technically permits a negative answer. Surface
+  // either as a hard error rather than silently publishing 0 or negative TVL.
+  if (priceUsd_e8 <= 0n) {
+    throw new Error(
+      `SBTCDOracle.latestRoundData().answer must be positive, got ${priceUsd_e8}`
+    );
+  }
+  // tvlUsd = totalSupply × price / 10^(18+8) = USD raw with 8 decimals.
+  // Split the BigInt into whole+fractional dollars so we don't lose cents
+  // of precision once total TVL grows past Number.MAX_SAFE_INTEGER (~$90M
+  // when expressed at 8-decimal scale).
   const tvlUsdScaled = (totalSupply * priceUsd_e8) / 10n ** 18n; // 8-decimal USD
-  const tvlUsd = Number(tvlUsdScaled) / 1e8;
-
-  const apyBase = await computeApyBase(latestBlock.number);
+  const HUNDRED_M = 10n ** 8n;
+  const wholeUsd = tvlUsdScaled / HUNDRED_M;
+  const fracUsd = tvlUsdScaled % HUNDRED_M;
+  const tvlUsd = Number(wholeUsd) + Number(fracUsd) / 1e8;
 
   return [
     {
@@ -90,7 +123,7 @@ const apy = async () => {
       apyBase,
       underlyingTokens: [BTCD],
       poolMeta: 'BTCD staking vault (8h vesting, 7d cooldown)',
-      url: 'https://app.btcd.com',
+      url: 'https://btcd.fi',
       token: SBTCD,
     },
   ];
@@ -99,5 +132,5 @@ const apy = async () => {
 module.exports = {
   timetravel: false,
   apy,
-  url: 'https://app.btcd.com',
+  url: 'https://btcd.fi',
 };

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -1,50 +1,53 @@
-// BTCD yield-server adapter — single Ethereum pool (sBTCD ERC-4626 staking
-// vault) with TVL and 30-day simple APR. APR mirrors
-// services/vault/sbtcdror/sbtcdrorcalculator.go: previewRedeem(1e18) growth
-// over a 30-day window, simple-rate annualised on a 365.25-day year, clamped
-// to the yield-activation block.
+// sBTCD ERC-4626 staking vault: TVL + 30-day simple APR from previewRedeem
+// growth, annualised on 365 days to match btcd.fi's public APY.
 
 const sdk = require('@defillama/sdk');
-const axios = require('axios');
 
 const CHAIN = 'ethereum';
 const BTCD = '0xC6694e05B750015f54Ac646544a4a9D33cbe4086';
 const SBTCD = '0x3BC801419479865B24b4d32faB0Bf64638Abbd5f';
 
-// Chainlink BTC/USD aggregator (public infra; not the BTCD-specific oracle).
+// Chainlink BTC/USD — public infra, not the BTCD-specific oracle.
 const BTC_USD_FEED = '0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c';
-// Initial BTC/USD reference; peg = sqrt(BTC_USD / P0) algorithmically.
-// Must match SBTCDOracle.P0_WAD at deploy. Re-verify if the oracle is redeployed.
+// Must match SBTCDOracle.P0_WAD; re-verify if that oracle is redeployed.
 const P0_USD = 94000;
 
 const SCALE = 10n ** 18n;
 const SECONDS_PER_DAY = 86400;
 const LOOKBACK_DAYS = 30;
-const SECONDS_PER_YEAR = 365.25 * SECONDS_PER_DAY;
-// First block at which the YieldDistributor delivered yield to sBTCD; share
-// prices before this would corrupt the APR ratio.
+const SECONDS_PER_YEAR = 365 * SECONDS_PER_DAY;
+// APR before this block would include pre-yield share prices and be wrong.
 const SBTCD_YIELD_TURNED_ON_BLOCK = 24450207;
 
 const previewRedeemAbi =
   'function previewRedeem(uint256 shares) view returns (uint256)';
 const totalAssetsAbi = 'function totalAssets() view returns (uint256)';
+const vestingPeriodAbi = 'function vestingPeriod() view returns (uint24)';
+const cooldownDurationAbi =
+  'function cooldownDuration() view returns (uint24)';
 const latestRoundDataAbi =
   'function latestRoundData() view returns (uint80, int256, uint256, uint256, uint80)';
 
-const getBlockAtTimestamp = async (chain, timestamp) =>
-  (await axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)).data
-    .height;
+function formatDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  if (seconds % 86400 === 0) return `${seconds / 86400}d`;
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
 
+// Mirrors services/vault/sbtcdror/sbtcdrorcalculator.go: pins both share-price
+// reads to real blocks and uses actual block timestamps as the divisor.
 async function computeApyBase() {
-  const nowTs = Math.floor(Date.now() / 1000);
-  const oldTs = nowTs - LOOKBACK_DAYS * SECONDS_PER_DAY;
-  let oldBlock;
+  let latest, old;
   try {
-    oldBlock = await getBlockAtTimestamp(CHAIN, oldTs);
+    latest = await sdk.api.util.getLatestBlock(CHAIN);
+    const oldTarget = latest.timestamp - LOOKBACK_DAYS * SECONDS_PER_DAY;
+    old = await sdk.api.util.lookupBlock(oldTarget, { chain: CHAIN });
   } catch (e) {
     return 0;
   }
-  if (oldBlock < SBTCD_YIELD_TURNED_ON_BLOCK) return 0;
+  if (old.block < SBTCD_YIELD_TURNED_ON_BLOCK) return 0;
   let nowVal, oldVal;
   try {
     const [nowRes, oldRes] = await Promise.all([
@@ -53,13 +56,14 @@ async function computeApyBase() {
         target: SBTCD,
         abi: previewRedeemAbi,
         params: [SCALE.toString()],
+        block: latest.number,
       }),
       sdk.api.abi.call({
         chain: CHAIN,
         target: SBTCD,
         abi: previewRedeemAbi,
         params: [SCALE.toString()],
-        block: oldBlock,
+        block: old.block,
       }),
     ]);
     nowVal = BigInt(nowRes.output);
@@ -71,13 +75,14 @@ async function computeApyBase() {
   const rateScaled = ((nowVal - oldVal) * SCALE) / oldVal;
   const rate = Number(rateScaled) / 1e18;
   if (!isFinite(rate) || rate <= 0) return 0;
-  const secondsElapsed = nowTs - oldTs;
+  const secondsElapsed = latest.timestamp - old.timestamp;
+  if (secondsElapsed <= 0) return 0;
   return ((rate * SECONDS_PER_YEAR) / secondsElapsed) * 100;
 }
 
-// Algorithmic peg: peg = sqrt(BTC_USD / P0). Mirrors SBTCDOracle's formula
-// (services/contracts/price-oracle/src/PriceOracle.sol) but reads Chainlink
-// BTC/USD directly so the adapter doesn't depend on the protocol's own oracle.
+// peg = sqrt(BTC_USD / P0) — mirrors SBTCDOracle (services/contracts/
+// price-oracle/src/PriceOracle.sol) but reads Chainlink directly. Returns
+// null on failure so apy() skips the pool instead of publishing a stale peg.
 async function btcdPriceUsd() {
   try {
     const r = await sdk.api.abi.call({
@@ -85,21 +90,53 @@ async function btcdPriceUsd() {
       target: BTC_USD_FEED,
       abi: latestRoundDataAbi,
     });
-    const btcUsd = Number(r.output[1]) / 1e8; // Chainlink BTC/USD has 8 decimals
-    if (!isFinite(btcUsd) || btcUsd <= 0) return 1.0;
+    const btcUsd = Number(r.output[1]) / 1e8;
+    if (!isFinite(btcUsd) || btcUsd <= 0) return null;
     return Math.sqrt(btcUsd / P0_USD);
   } catch (e) {
-    return 1.0;
+    return null;
   }
 }
 
 const apy = async () => {
-  const [sBtcdAssetsRes, price, sBtcdApyBase] = await Promise.all([
-    sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: totalAssetsAbi }),
-    btcdPriceUsd(),
-    computeApyBase(),
-  ]);
-  const sBtcdTvlUsd = (Number(BigInt(sBtcdAssetsRes.output)) / 1e18) * price;
+  const [sBtcdAssetsRes, price, sBtcdApyBase, vestingRes, cooldownRes] =
+    await Promise.all([
+      sdk.api.abi
+        .call({ chain: CHAIN, target: SBTCD, abi: totalAssetsAbi })
+        .catch(() => null),
+      btcdPriceUsd(),
+      computeApyBase(),
+      sdk.api.abi
+        .call({ chain: CHAIN, target: SBTCD, abi: vestingPeriodAbi })
+        .catch(() => null),
+      sdk.api.abi
+        .call({ chain: CHAIN, target: SBTCD, abi: cooldownDurationAbi })
+        .catch(() => null),
+    ]);
+  if (!sBtcdAssetsRes?.output || price == null) return [];
+  let sBtcdAssets;
+  try {
+    sBtcdAssets = BigInt(sBtcdAssetsRes.output);
+  } catch (e) {
+    return [];
+  }
+  const sBtcdTvlUsd = (Number(sBtcdAssets) / 1e18) * price;
+
+  const metaParts = [];
+  const vestingLabel =
+    vestingRes?.output != null
+      ? formatDuration(Number(vestingRes.output))
+      : null;
+  if (vestingLabel) metaParts.push(`${vestingLabel} vesting`);
+  const cooldownLabel =
+    cooldownRes?.output != null
+      ? formatDuration(Number(cooldownRes.output))
+      : null;
+  if (cooldownLabel) metaParts.push(`${cooldownLabel} cooldown`);
+  const poolMeta =
+    metaParts.length > 0
+      ? `BTCD staking vault (${metaParts.join(', ')})`
+      : 'BTCD staking vault';
 
   return [
     {
@@ -110,7 +147,7 @@ const apy = async () => {
       tvlUsd: sBtcdTvlUsd,
       apyBase: sBtcdApyBase,
       underlyingTokens: [BTCD],
-      poolMeta: 'BTCD staking vault (8h vesting)',
+      poolMeta,
       url: 'https://btcd.fi/app/stake/btcd',
       token: SBTCD,
     },

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -110,7 +110,7 @@ const apy = async () => {
       tvlUsd: sBtcdTvlUsd,
       apyBase: sBtcdApyBase,
       underlyingTokens: [BTCD],
-      poolMeta: 'BTCD staking vault (8h vesting, 7d cooldown)',
+      poolMeta: 'BTCD staking vault (8h vesting)',
       url: 'https://btcd.fi/app/stake/btcd',
       token: SBTCD,
     },

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -1,41 +1,98 @@
+/**
+ * @file BTCD yield-server adapter — exposes the sBTCD staking vault as a
+ *       single Ethereum pool with TVL and 30-day APR.
+ *
+ * @description
+ * BTCD is a synthetic basket-backed token (~50% BTC / ~50% USD) RFQ-minted
+ * via BTCDMinting against whitelisted collateral. sBTCD is the protocol's
+ * ERC-4626 staking vault: deposit BTCD, receive sBTCD shares, share price
+ * grows as the YieldDistributor pushes freshly-minted BTCD into the vault
+ * over 8h linear vesting cycles. A 7-day Silo cooldown gates withdrawals.
+ */
+
 const sdk = require('@defillama/sdk');
 const axios = require('axios');
 
-// BTCD: synthetic basket-backed token (~50% BTC / ~50% USD), RFQ-minted via BTCDMinting.
-// sBTCD: ERC-4626 staking vault over BTCD with 8h linear vesting and 7-day Silo cooldown.
-// SBTCDOracle: on-chain Chainlink-compatible oracle returning sBTCD/USD in 8 decimals.
-
+/** @type {string} DefiLlama chain slug. */
 const CHAIN = 'ethereum';
+/** @type {string} BTCD token (the underlying ERC-20). */
 const BTCD = '0xC6694e05B750015f54Ac646544a4a9D33cbe4086';
+/** @type {string} sBTCD ERC-4626 staking vault (the receipt token). */
 const SBTCD = '0x3BC801419479865B24b4d32faB0Bf64638Abbd5f';
+/**
+ * @type {string} SBTCDOracle — Chainlink-compatible IPriceOracle returning
+ *                sBTCD/USD with 8 decimals via `latestRoundData()`.
+ */
 const SBTCD_ORACLE = '0x332ebF042a7B7D87A8a2628186f8A5B12d8a6d94';
 
-// APR methodology mirrors the protocol's canonical sBTCD rate-of-return
-// calculator at services/vault/sbtcdror/sbtcdrorcalculator.go:
-//   - 30-day window
-//   - PreviewRedeem(1e18) for share-price reads
-//   - Simple APR (not compound APY) with a 365.25-day year
-//   - Clamp the start block to SBTCDYieldTurnedOnBlock so we never sample
-//     share prices from before yield was activated
-const WAD = '1000000000000000000'; // 1e18
+/**
+ * APR methodology mirrors the protocol's canonical sBTCD rate-of-return
+ * calculator at `services/vault/sbtcdror/sbtcdrorcalculator.go`:
+ *   - 30-day lookback window
+ *   - `previewRedeem(1e18)` for share-price reads (matches the canonical Go)
+ *   - Simple APR (not compound APY) with a 365.25-day year
+ *   - Clamp the start block to `SBTCDYieldTurnedOnBlock` so share prices
+ *     from before yield activation are never sampled
+ */
+
+/** @type {string} 1e18 in raw token units; the standard ERC-4626 share unit. */
+const WAD = '1000000000000000000';
+/** @type {bigint} BigInt mirror of WAD, used for ratio scaling. */
 const SCALE = 10n ** 18n;
+/** @type {number} */
 const SECONDS_PER_DAY = 86400;
+/** @type {number} APR lookback window. Matches the canonical Go calculator. */
 const LOOKBACK_DAYS = 30;
+/** @type {number} 365.25 × 86400 — leap-year-aware seconds per year. */
 const SECONDS_PER_YEAR = 365.25 * SECONDS_PER_DAY;
+/**
+ * @type {number} Block at which the YieldDistributor first delivered yield
+ *                to sBTCD. Sourced from
+ *                `services/vault/monitor/setpointprovider` (see the
+ *                `keySBTCDYieldTurnedOnBlock` default).
+ */
 const SBTCD_YIELD_TURNED_ON_BLOCK = 24450207;
 
+/** @type {string} Human-readable ABI for `IERC4626.previewRedeem`. */
 const previewRedeemAbi =
   'function previewRedeem(uint256 shares) view returns (uint256)';
+/** @type {string} Human-readable ABI for `IPriceOracle.latestRoundData`. */
 const latestRoundDataAbi =
   'function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)';
 
+/**
+ * Resolves a chain block height for a given Unix timestamp using DefiLlama's
+ * timestamp→block index. Returns the block whose timestamp is closest to the
+ * requested second.
+ *
+ * @param {string} chain DefiLlama chain slug (e.g. `'ethereum'`).
+ * @param {number} timestamp Unix seconds.
+ * @returns {Promise<number>} The block height at (or nearest to) `timestamp`.
+ * @throws {Error} If the HTTP request fails or the response is malformed.
+ */
 const getBlockAtTimestamp = async (chain, timestamp) =>
   (await axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)).data
     .height;
 
-// Returns 0 (instead of throwing) if the historical block is unavailable or
-// pre-dates yield activation, so a young vault still publishes a 0% APR
-// alongside a valid TVL rather than failing the whole adapter run.
+/**
+ * Computes the 30-day simple APR of the sBTCD vault from share-price growth.
+ *
+ * Reads `previewRedeem(1e18)` at the latest block and at a block 30 days ago,
+ * computes the percentage increase, and annualises with a 365.25-day year:
+ *
+ *     APR = (priceNow / priceStart − 1) × secondsPerYear / secondsElapsed
+ *
+ * Mirrors `SBTCDRORCalculator.annualizeRate` in
+ * `services/vault/sbtcdror/sbtcdrorcalculator.go`. Returns 0 (instead of
+ * throwing) when the historical block is unavailable, predates yield
+ * activation, or the share price did not grow — so a young vault still
+ * publishes 0% APR alongside a valid TVL rather than failing the whole
+ * adapter run.
+ *
+ * @returns {Promise<number>} APR as a percentage (e.g. `17.22` for 17.22%).
+ *                            Always non-negative; returns 0 on any error or
+ *                            non-positive growth.
+ */
 async function computeApyBase() {
   const nowTs = Math.floor(Date.now() / 1000);
   const oldTs = nowTs - LOOKBACK_DAYS * SECONDS_PER_DAY;
@@ -82,6 +139,31 @@ async function computeApyBase() {
   return ((rate * SECONDS_PER_YEAR) / secondsElapsed) * 100;
 }
 
+/**
+ * Adapter entry point — produces DefiLlama yield-server pool entries for sBTCD.
+ *
+ * Reads `sBTCD.totalSupply()`, `SBTCDOracle.latestRoundData()`, and
+ * computes APR in parallel. TVL is `totalSupply × oracleAnswer / 10^26`,
+ * where the oracle answer is sBTCD/USD with 8 decimals (sBTCD has 18).
+ *
+ * @returns {Promise<Array<{
+ *   pool: string,
+ *   chain: string,
+ *   project: string,
+ *   symbol: string,
+ *   tvlUsd: number,
+ *   apyBase: number,
+ *   underlyingTokens: string[],
+ *   poolMeta: string,
+ *   url: string,
+ *   token: string,
+ * }>>} Single-element array containing the sBTCD pool entry.
+ * @throws {Error} If `SBTCDOracle.latestRoundData().answer` is non-positive.
+ *                 (Morpho's IOracle spec returns 0 on bad feed data instead
+ *                 of reverting; the int256 return type also technically
+ *                 permits a negative answer. We surface either as a hard
+ *                 error rather than silently publishing zero or negative TVL.)
+ */
 const apy = async () => {
   const [totalSupplyRes, oracleRes, apyBase] = await Promise.all([
     sdk.api.abi.call({ chain: CHAIN, target: SBTCD, abi: 'erc20:totalSupply' }),
@@ -129,8 +211,14 @@ const apy = async () => {
   ];
 };
 
+/**
+ * @type {{ apy: () => Promise<object[]>, url: string }}
+ *
+ * - `apy` — see {@link apy}.
+ * - `url` — protocol landing page (used by yield-server when a pool entry
+ *   does not specify its own `url`).
+ */
 module.exports = {
-  timetravel: false,
   apy,
   url: 'https://btcd.fi',
 };

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -51,9 +51,12 @@ function formatDuration(seconds) {
  * reads to real blocks and uses actual block timestamps as the divisor, the
  * same shape as services/vault/sbtcdror/sbtcdrorcalculator.go.
  *
- * Returns 0 on any RPC failure, a pre-yield lookback, or non-positive growth
- * so the pool publishes without an APY rather than poisoning the cycle.
- * @returns {Promise<number>} APR as a percentage (e.g. 11.88 for 11.88%).
+ * Returns null on any RPC failure, a pre-yield lookback, or non-positive
+ * growth so the pool publishes with no APY rather than ingesting a misleading
+ * 0% that would skew the trailing 30-day average — a failed read is "no data",
+ * not a real zero return.
+ * @returns {Promise<number | null>} APR as a percentage (e.g. 11.88 for
+ *   11.88%), or null when it cannot be computed.
  */
 async function computeApyBase() {
   let latest, old;
@@ -62,23 +65,23 @@ async function computeApyBase() {
     const oldTarget = latest.timestamp - LOOKBACK_DAYS * SECONDS_PER_DAY;
     old = await sdk.api.util.lookupBlock(oldTarget, { chain: CHAIN });
   } catch (e) {
-    return 0;
+    return null;
   }
   if (
     !latest ||
     typeof latest.number !== 'number' ||
     typeof latest.timestamp !== 'number'
   ) {
-    return 0;
+    return null;
   }
   if (
     !old ||
     typeof old.block !== 'number' ||
     typeof old.timestamp !== 'number'
   ) {
-    return 0;
+    return null;
   }
-  if (old.block < SBTCD_YIELD_TURNED_ON_BLOCK) return 0;
+  if (old.block < SBTCD_YIELD_TURNED_ON_BLOCK) return null;
   let nowVal, oldVal;
   try {
     const [nowRes, oldRes] = await Promise.all([
@@ -100,14 +103,14 @@ async function computeApyBase() {
     nowVal = BigInt(nowRes.output);
     oldVal = BigInt(oldRes.output);
   } catch (e) {
-    return 0;
+    return null;
   }
-  if (oldVal <= 0n || nowVal <= oldVal) return 0;
+  if (oldVal <= 0n || nowVal <= oldVal) return null;
   const rateScaled = ((nowVal - oldVal) * SCALE) / oldVal;
   const rate = Number(rateScaled) / 1e18;
-  if (!isFinite(rate) || rate <= 0) return 0;
+  if (!isFinite(rate) || rate <= 0) return null;
   const secondsElapsed = latest.timestamp - old.timestamp;
-  if (secondsElapsed <= 0) return 0;
+  if (secondsElapsed <= 0) return null;
   return ((rate * SECONDS_PER_YEAR) / secondsElapsed) * 100;
 }
 
@@ -150,7 +153,8 @@ async function btcdPriceUsd() {
  *   project: string,
  *   symbol: string,
  *   tvlUsd: number,
- *   apyBase: number,
+ *   apyBase: number | null,
+ *   pricePerShare: number | null,
  *   underlyingTokens: string[],
  *   poolMeta: string,
  *   url: string,
@@ -158,20 +162,34 @@ async function btcdPriceUsd() {
  * }>>}
  */
 const apy = async () => {
-  const [sBtcdAssetsRes, price, sBtcdApyBase, vestingRes, cooldownRes] =
-    await Promise.all([
-      sdk.api.abi
-        .call({ chain: CHAIN, target: SBTCD, abi: totalAssetsAbi })
-        .catch(() => null),
-      btcdPriceUsd(),
-      computeApyBase(),
-      sdk.api.abi
-        .call({ chain: CHAIN, target: SBTCD, abi: vestingPeriodAbi })
-        .catch(() => null),
-      sdk.api.abi
-        .call({ chain: CHAIN, target: SBTCD, abi: cooldownDurationAbi })
-        .catch(() => null),
-    ]);
+  const [
+    sBtcdAssetsRes,
+    price,
+    sBtcdApyBase,
+    vestingRes,
+    cooldownRes,
+    previewRedeemRes,
+  ] = await Promise.all([
+    sdk.api.abi
+      .call({ chain: CHAIN, target: SBTCD, abi: totalAssetsAbi })
+      .catch(() => null),
+    btcdPriceUsd(),
+    computeApyBase(),
+    sdk.api.abi
+      .call({ chain: CHAIN, target: SBTCD, abi: vestingPeriodAbi })
+      .catch(() => null),
+    sdk.api.abi
+      .call({ chain: CHAIN, target: SBTCD, abi: cooldownDurationAbi })
+      .catch(() => null),
+    sdk.api.abi
+      .call({
+        chain: CHAIN,
+        target: SBTCD,
+        abi: previewRedeemAbi,
+        params: [SCALE.toString()],
+      })
+      .catch(() => null),
+  ]);
   if (!sBtcdAssetsRes?.output || price == null) return [];
   let sBtcdAssets;
   try {
@@ -180,6 +198,19 @@ const apy = async () => {
     return [];
   }
   const sBtcdTvlUsd = (Number(sBtcdAssets) / 1e18) * price;
+
+  // ERC-4626 share price: BTCD assets redeemable per 1 sBTCD share. null when
+  // the read fails or the result is non-finite/<=0 so we never publish a bogus
+  // price-per-share alongside an otherwise valid pool.
+  let pricePerShare = null;
+  if (previewRedeemRes?.output != null) {
+    try {
+      const pps = Number(BigInt(previewRedeemRes.output)) / 1e18;
+      if (isFinite(pps) && pps > 0) pricePerShare = pps;
+    } catch (e) {
+      pricePerShare = null;
+    }
+  }
 
   const metaParts = [];
   const vestingLabel =
@@ -205,6 +236,7 @@ const apy = async () => {
       symbol: 'sBTCD',
       tvlUsd: sBtcdTvlUsd,
       apyBase: sBtcdApyBase,
+      pricePerShare,
       underlyingTokens: [BTCD],
       poolMeta,
       url: 'https://btcd.fi/app/stake/btcd',

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -1,0 +1,103 @@
+const sdk = require('@defillama/sdk');
+
+// BTCD: synthetic basket-backed token (~50% BTC / ~50% USD), RFQ-minted via BTCDMinting.
+// sBTCD: ERC-4626 staking vault over BTCD with 8h linear vesting and 7-day Silo cooldown.
+// SBTCDOracle: on-chain Chainlink-compatible oracle returning sBTCD/USD in 8 decimals.
+
+const BTCD = '0xC6694e05B750015f54Ac646544a4a9D33cbe4086';
+const SBTCD = '0x3BC801419479865B24b4d32faB0Bf64638Abbd5f';
+const SBTCD_ORACLE = '0x332ebF042a7B7D87A8a2628186f8A5B12d8a6d94';
+
+const WAD = '1000000000000000000'; // 1e18
+const SCALE = 10n ** 18n;
+const SECONDS_PER_DAY = 86400;
+const SECONDS_PER_BLOCK = 12;
+const LOOKBACK_DAYS = 7;
+const BLOCKS_PER_LOOKBACK = Math.floor((SECONDS_PER_DAY * LOOKBACK_DAYS) / SECONDS_PER_BLOCK);
+
+const convertToAssetsAbi = {
+  inputs: [{ type: 'uint256', name: 'shares' }],
+  name: 'convertToAssets',
+  outputs: [{ type: 'uint256', name: 'assets' }],
+  stateMutability: 'view',
+  type: 'function',
+};
+
+const latestRoundDataAbi = {
+  inputs: [],
+  name: 'latestRoundData',
+  outputs: [
+    { type: 'uint80', name: 'roundId' },
+    { type: 'int256', name: 'answer' },
+    { type: 'uint256', name: 'startedAt' },
+    { type: 'uint256', name: 'updatedAt' },
+    { type: 'uint80', name: 'answeredInRound' },
+  ],
+  stateMutability: 'view',
+  type: 'function',
+};
+
+// 7-day annualised share-price growth, compounded to APY.
+async function computeApyBase(currentBlock) {
+  const olderBlock = currentBlock - BLOCKS_PER_LOOKBACK;
+  const calls = [
+    sdk.api.abi.call({
+      chain: 'ethereum',
+      target: SBTCD,
+      abi: convertToAssetsAbi,
+      params: [WAD],
+    }),
+    sdk.api.abi.call({
+      chain: 'ethereum',
+      target: SBTCD,
+      abi: convertToAssetsAbi,
+      params: [WAD],
+      block: olderBlock,
+    }),
+  ];
+  const [nowRes, oldRes] = await Promise.all(calls);
+  const nowVal = BigInt(nowRes.output);
+  const oldVal = BigInt(oldRes.output);
+  if (oldVal <= 0n || nowVal <= 0n) return 0;
+  const ratioScaled = (nowVal * SCALE) / oldVal; // (now/old) × 1e18
+  const ratio = Number(ratioScaled) / 1e18;
+  if (!isFinite(ratio) || ratio <= 0) return 0;
+  return (Math.pow(ratio, 365 / LOOKBACK_DAYS) - 1) * 100;
+}
+
+const apy = async () => {
+  const [totalSupplyRes, oracleRes, latestBlock] = await Promise.all([
+    sdk.api.abi.call({ chain: 'ethereum', target: SBTCD, abi: 'erc20:totalSupply' }),
+    sdk.api.abi.call({ chain: 'ethereum', target: SBTCD_ORACLE, abi: latestRoundDataAbi }),
+    sdk.api.util.getLatestBlock('ethereum'),
+  ]);
+
+  const totalSupply = BigInt(totalSupplyRes.output);    // 18 decimals
+  const priceUsd_e8 = BigInt(oracleRes.output.answer);  // 8 decimals
+  // tvlUsd = totalSupply × price / 10^(18+8). Use BigInt to avoid float overflow on large supply.
+  const tvlUsdScaled = (totalSupply * priceUsd_e8) / 10n ** 18n; // 8-decimal USD
+  const tvlUsd = Number(tvlUsdScaled) / 1e8;
+
+  const apyBase = await computeApyBase(latestBlock.number);
+
+  return [
+    {
+      pool: `${SBTCD.toLowerCase()}-ethereum`,
+      chain: 'Ethereum',
+      project: 'btcd',
+      symbol: 'sBTCD',
+      tvlUsd,
+      apyBase,
+      underlyingTokens: [BTCD],
+      poolMeta: 'BTCD staking vault (8h vesting, 7d cooldown)',
+      url: 'https://app.btcd.com',
+      token: SBTCD,
+    },
+  ];
+};
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: 'https://app.btcd.com',
+};

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -27,8 +27,7 @@ const previewRedeemAbi =
   'function previewRedeem(uint256 shares) view returns (uint256)';
 const totalAssetsAbi = 'function totalAssets() view returns (uint256)';
 const vestingPeriodAbi = 'function vestingPeriod() view returns (uint24)';
-const cooldownDurationAbi =
-  'function cooldownDuration() view returns (uint24)';
+const cooldownDurationAbi = 'function cooldownDuration() view returns (uint24)';
 const latestRoundDataAbi =
   'function latestRoundData() view returns (uint80, int256, uint256, uint256, uint80)';
 

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -1,5 +1,9 @@
-// sBTCD ERC-4626 staking vault: TVL + 30-day simple APR from previewRedeem
-// growth, annualised on 365 days to match btcd.fi's public APY.
+/**
+ * @file Defillama yield-server adapter for the BTCD protocol's sBTCD ERC-4626
+ * staking vault. Publishes a single Ethereum pool entry with TVL in USD and
+ * a 30-day simple APR derived from `previewRedeem(1e18)` growth, annualised
+ * on a 365-day year to match btcd.fi's public APY.
+ */
 
 const sdk = require('@defillama/sdk');
 
@@ -196,9 +200,14 @@ const apy = async () => {
   ];
 };
 
+/**
+ * Defillama yield-server adapter module export.
+ * @property {() => Promise<Array<object>>} apy  Per-cycle pool builder.
+ * @property {string} url  Protocol-root URL surfaced on defillama's project
+ *   page. The per-pool deep link to the staking page lives on the pool
+ *   entry's own `url` field, set inside `apy()`.
+ */
 module.exports = {
   apy,
-  // Protocol-root URL surfaced on defillama's project page. The per-pool
-  // deep link to the staking page lives on the pool entry's own `url` field.
   url: 'https://btcd.fi',
 };

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -28,6 +28,13 @@ const cooldownDurationAbi =
 const latestRoundDataAbi =
   'function latestRoundData() view returns (uint80, int256, uint256, uint256, uint80)';
 
+/**
+ * Format a positive seconds count as a short label using the largest exact
+ * unit (`d`/`h`/`m`/`s`). Returns null for 0, negative, or non-finite inputs
+ * so the caller can drop the label.
+ * @param {number} seconds
+ * @returns {string | null}
+ */
 function formatDuration(seconds) {
   if (!Number.isFinite(seconds) || seconds <= 0) return null;
   if (seconds % 86400 === 0) return `${seconds / 86400}d`;
@@ -36,8 +43,15 @@ function formatDuration(seconds) {
   return `${seconds}s`;
 }
 
-// Mirrors services/vault/sbtcdror/sbtcdrorcalculator.go: pins both share-price
-// reads to real blocks and uses actual block timestamps as the divisor.
+/**
+ * 30-day simple APR from sBTCD share-price growth. Pins both `previewRedeem`
+ * reads to real blocks and uses actual block timestamps as the divisor, the
+ * same shape as services/vault/sbtcdror/sbtcdrorcalculator.go.
+ *
+ * Returns 0 on any RPC failure, a pre-yield lookback, or non-positive growth
+ * so the pool publishes without an APY rather than poisoning the cycle.
+ * @returns {Promise<number>} APR as a percentage (e.g. 11.88 for 11.88%).
+ */
 async function computeApyBase() {
   let latest, old;
   try {
@@ -80,9 +94,18 @@ async function computeApyBase() {
   return ((rate * SECONDS_PER_YEAR) / secondsElapsed) * 100;
 }
 
-// peg = sqrt(BTC_USD / P0) — mirrors SBTCDOracle (services/contracts/
-// price-oracle/src/PriceOracle.sol) but reads Chainlink directly. Returns
-// null on failure so apy() skips the pool instead of publishing a stale peg.
+/**
+ * BTCD/USD spot price using the algorithmic peg
+ *   `peg = sqrt(BTC_USD / P0_USD)`
+ * Mirrors SBTCDOracle (services/contracts/price-oracle/src/PriceOracle.sol)
+ * but reads Chainlink BTC/USD directly so the adapter has no dependency on
+ * the BTCD protocol's own oracle.
+ *
+ * Returns null when the feed read fails or the answer is non-finite/<=0,
+ * which signals `apy()` to skip publishing the pool instead of emitting a
+ * TVL anchored to a hardcoded peg.
+ * @returns {Promise<number | null>} USD price per 1 BTCD, or null on failure.
+ */
 async function btcdPriceUsd() {
   try {
     const r = await sdk.api.abi.call({
@@ -98,6 +121,25 @@ async function btcdPriceUsd() {
   }
 }
 
+/**
+ * Defillama yield-server entrypoint. Reads sBTCD's totalAssets, BTCD/USD peg,
+ * 30-day APR, and live vesting/cooldown parameters in one fan-out, then emits
+ * a single pool entry. Returns an empty array (defillama keeps the prior
+ * snapshot) when TVL or price reads fail so we never publish bogus values.
+ *
+ * @returns {Promise<Array<{
+ *   pool: string,
+ *   chain: string,
+ *   project: string,
+ *   symbol: string,
+ *   tvlUsd: number,
+ *   apyBase: number,
+ *   underlyingTokens: string[],
+ *   poolMeta: string,
+ *   url: string,
+ *   token: string,
+ * }>>}
+ */
 const apy = async () => {
   const [sBtcdAssetsRes, price, sBtcdApyBase, vestingRes, cooldownRes] =
     await Promise.all([
@@ -156,5 +198,7 @@ const apy = async () => {
 
 module.exports = {
   apy,
+  // Protocol-root URL surfaced on defillama's project page. The per-pool
+  // deep link to the staking page lives on the pool entry's own `url` field.
   url: 'https://btcd.fi',
 };

--- a/src/adaptors/btcd/index.js
+++ b/src/adaptors/btcd/index.js
@@ -64,6 +64,20 @@ async function computeApyBase() {
   } catch (e) {
     return 0;
   }
+  if (
+    !latest ||
+    typeof latest.number !== 'number' ||
+    typeof latest.timestamp !== 'number'
+  ) {
+    return 0;
+  }
+  if (
+    !old ||
+    typeof old.block !== 'number' ||
+    typeof old.timestamp !== 'number'
+  ) {
+    return 0;
+  }
   if (old.block < SBTCD_YIELD_TURNED_ON_BLOCK) return 0;
   let nowVal, oldVal;
   try {


### PR DESCRIPTION
Adds the BTCD yield adapter for the Ethereum sBTCD staking vault only.

Exposes the sBTCD ERC-4626 vault
Computes TVL from on-chain totalAssets()
Computes base APY from 30-day previewRedeem() growth
Uses the BTCD underlying token and vault address metadata required by Yield Server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BTCD adapter providing TVL and a 30‑day APY estimate for the sBTCD staking vault and linking to https://btcd.fi (deep-link to stake page).
  * Derives an algorithmic BTC peg from on‑chain price feeds to normalize TVL and APY calculations.
  * Shows vesting/cooldown duration labels on the vault when available.
* **Robustness**
  * Skips pools or reports zero APY when price, TVL, or timing inputs are missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->