### PR TITLE
add availableBorrowUsd to aave-v3 forks

### DIFF
--- a/src/adaptors/aave-v3/index.js
+++ b/src/adaptors/aave-v3/index.js
@@ -178,7 +178,7 @@ const getApy = async (market) => {
       let availableBorrowUsd = null;
       if (isEthereumGhoFacilitator) {
         availableBorrowUsd = Math.max(borrowCapUsd - totalBorrowUsd, 0);
-      } else if (borrowable) {
+      } else {
         availableBorrowUsd = hasBorrowCap
           ? Math.max(
               Math.min(reserveLiquidityUsd, borrowCapUsd - totalBorrowUsd),
@@ -215,15 +215,12 @@ const getApy = async (market) => {
         underlyingTokens: [pool.tokenAddress],
         totalSupplyUsd,
         totalBorrowUsd,
-        ...(availableBorrowUsd !== null && {
-          borrowCapUsd,
-          availableBorrowUsd,
-        }),
+        availableBorrowUsd,
         apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
         ltv: poolsReservesConfigurationData[i].ltv / 10000,
         url,
         borrowable,
-        // TODO: Remove mintedCoin & rename debtCeilingUsd to borrowCapUsd once v2 is live
+        // TODO: Remove mintedCoin/debtCeiling once v2 is live
         ...(isEthereumGhoFacilitator && {
           debtCeilingUsd: borrowCapUsd,
           mintedCoin: 'GHO',
@@ -266,11 +263,9 @@ const getApyAptos = async () => {
       const tvlUsd = totalSupplyUsd - totalBorrowUsd;
       const borrowCapUsd = Number(r.borrowCap) * priceUsd;
       const hasBorrowCap = Number(r.borrowCap) > 0;
-      const availableBorrowUsd = r.borrowingEnabled
-        ? hasBorrowCap
-          ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
-          : tvlUsd
-        : null;
+      const availableBorrowUsd = hasBorrowCap
+        ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+        : tvlUsd;
 
       return {
         pool: `${r.aTokenAddress}-aptos`.toLowerCase(),
@@ -282,10 +277,7 @@ const getApyAptos = async () => {
         underlyingTokens: [r.underlyingAsset],
         totalSupplyUsd,
         totalBorrowUsd,
-        ...(availableBorrowUsd !== null && {
-          borrowCapUsd,
-          availableBorrowUsd,
-        }),
+        availableBorrowUsd,
         apyBaseBorrow: Number(r.variableBorrowRate) / 1e25,
         ltv: Number(r.baseLTVasCollateral) / 10000,
         url: `https://aptos.aave.com/reserve-overview/?underlyingAsset=${r.underlyingAsset}&marketName=aptos`,

--- a/src/adaptors/amply-finance/index.js
+++ b/src/adaptors/amply-finance/index.js
@@ -49,6 +49,17 @@ const getApy = async (chain) => {
     })
   ).output.map((o) => o.output);
 
+  const poolsReserveCaps = (
+    await sdk.api.abi.multiCall({
+      calls: reserveTokens.map((p) => ({
+        target: protocolDataProvider,
+        params: p.tokenAddress,
+      })),
+      abi: poolAbi.find((m) => m.name === 'getReserveCaps'),
+      chain,
+    })
+  ).output.map((o) => o.output);
+
   const totalSupply = (
     await sdk.api.abi.multiCall({
       chain,
@@ -97,7 +108,12 @@ const getApy = async (chain) => {
     const currentSupply = underlyingBalances[i];
     let tvlUsd = (currentSupply / 10 ** underlyingDecimals[i]) * price;
 
-    totalBorrowUsd = totalSupplyUsd - tvlUsd;
+    const totalBorrowUsd =
+      (Number(p.totalVariableDebt) / 10 ** underlyingDecimals[i]) * price;
+    const borrowCapUsd = Number(poolsReserveCaps[i].borrowCap) * price;
+    const availableBorrowUsd = Number(poolsReserveCaps[i].borrowCap)
+      ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+      : tvlUsd;
 
     return {
       pool: `${aTokens[i].tokenAddress}-${chain}`.toLowerCase(),
@@ -109,6 +125,7 @@ const getApy = async (chain) => {
       underlyingTokens: [pool.tokenAddress],
       totalSupplyUsd,
       totalBorrowUsd,
+      availableBorrowUsd,
       apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
       ltv: poolsReservesConfigurationData[i].ltv / 10000,
       borrowable: poolsReservesConfigurationData[i].borrowingEnabled,

--- a/src/adaptors/avalon-finance/index.js
+++ b/src/adaptors/avalon-finance/index.js
@@ -50,6 +50,17 @@ const getApy = async (market) => {
     })
   ).output.map((o) => o.output);
 
+  const poolsReserveCaps = (
+    await sdk.api.abi.multiCall({
+      calls: reserveTokens.map((p) => ({
+        target: protocolDataProvider,
+        params: p.tokenAddress,
+      })),
+      abi: poolAbi.find((m) => m.name === 'getReserveCaps'),
+      chain,
+    })
+  ).output.map((o) => o.output);
+
   const underlyingBalances = (
     await sdk.api.abi.multiCall({
       chain,
@@ -96,6 +107,10 @@ const getApy = async (market) => {
         BigInt(p.totalStableDebt) + BigInt(p.totalVariableDebt);
       const totalBorrowUsd = toTokenAmount(totalBorrow) * price;
       const totalSupplyUsd = tvlUsd + totalBorrowUsd;
+      const borrowCapUsd = Number(poolsReserveCaps[i].borrowCap) * price;
+      const availableBorrowUsd = Number(poolsReserveCaps[i].borrowCap)
+        ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+        : tvlUsd;
 
       const marketUrlParam =
         market === 'ethereum'
@@ -122,6 +137,7 @@ const getApy = async (market) => {
         underlyingTokens: [pool.tokenAddress],
         totalSupplyUsd,
         totalBorrowUsd,
+        availableBorrowUsd,
         apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
         ltv: poolsReservesConfigurationData[i].ltv / 10000,
         url,

--- a/src/adaptors/colend-protocol/index.js
+++ b/src/adaptors/colend-protocol/index.js
@@ -101,7 +101,7 @@ const fetchMarketData = async (target) => {
     return { apyReward: totalRewardAPY, rewardTokens };
   };
 
-  const [poolsReserveData, poolsReservesConfigurationData, balanceData, decimalsData] = await Promise.all([
+  const [poolsReserveData, poolsReservesConfigurationData, poolsReserveCaps, balanceData, decimalsData] = await Promise.all([
     sdk.api.abi.multiCall({
       calls: reserveTokens.map((p) => ({ target, params: p.tokenAddress })),
       abi: poolAbi.find((m) => m.name === 'getReserveData'),
@@ -110,6 +110,11 @@ const fetchMarketData = async (target) => {
     sdk.api.abi.multiCall({
       calls: reserveTokens.map((p) => ({ target, params: p.tokenAddress })),
       abi: poolAbi.find((m) => m.name === 'getReserveConfigurationData'),
+      chain,
+    }),
+    sdk.api.abi.multiCall({
+      calls: reserveTokens.map((p) => ({ target, params: p.tokenAddress })),
+      abi: poolAbi.find((m) => m.name === 'getReserveCaps'),
       chain,
     }),
     sdk.api.abi.multiCall({
@@ -156,6 +161,10 @@ const fetchMarketData = async (target) => {
       BigInt(p.totalStableDebt) + BigInt(p.totalVariableDebt);
     const totalBorrowUsd = toTokenAmount(totalBorrow) * price;
     const totalSupplyUsd = tvlUsd + totalBorrowUsd;
+    const borrowCapUsd = Number(poolsReserveCaps.output[i].output.borrowCap) * price;
+    const availableBorrowUsd = Number(poolsReserveCaps.output[i].output.borrowCap)
+      ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+      : tvlUsd;
     const marketName = marketNameByDataProvider[target.toLowerCase()];
     const url = `https://app.colend.xyz/reserve-overview/?underlyingAsset=${pool.tokenAddress.toLowerCase()}&marketName=${marketName}`;
 
@@ -186,6 +195,7 @@ const fetchMarketData = async (target) => {
       underlyingTokens: [pool.tokenAddress],
       totalSupplyUsd,
       totalBorrowUsd,
+      availableBorrowUsd,
       apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
       ltv: poolsReservesConfigurationData.output[i].output.ltv / 10000,
       url,

--- a/src/adaptors/extra-finance-xlend/index.js
+++ b/src/adaptors/extra-finance-xlend/index.js
@@ -130,6 +130,17 @@ const getApy = async (market) => {
     })
   ).output.map((o) => o.output);
 
+  const poolsReserveCaps = (
+    await sdk.api.abi.multiCall({
+      calls: reserveTokens.map((p) => ({
+        target: protocolDataProvider,
+        params: p.tokenAddress,
+      })),
+      abi: poolAbi.find((m) => m.name === 'getReserveCaps'),
+      chain,
+    })
+  ).output.map((o) => o.output);
+
   const totalSupply = (
     await sdk.api.abi.multiCall({
       chain,
@@ -196,6 +207,10 @@ const getApy = async (market) => {
         ((Number(p.totalStableDebt) + Number(p.totalVariableDebt)) /
           10 ** underlyingDecimals[i]) *
         price;
+      const borrowCapUsd = Number(poolsReserveCaps[i].borrowCap) * price;
+      const availableBorrowUsd = Number(poolsReserveCaps[i].borrowCap)
+        ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+        : tvlUsd;
 
       const url = `https://xlend.extrafi.io/?underlyingAsset=${pool.tokenAddress.toLowerCase()}&marketName=${market}`;
 
@@ -214,7 +229,7 @@ const getApy = async (market) => {
         underlyingTokens: [pool.tokenAddress],
         totalSupplyUsd,
         totalBorrowUsd,
-        debtCeilingUsd: null,
+        availableBorrowUsd,
         apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
         apyReward,
         apyRewardBorrow,
@@ -222,8 +237,6 @@ const getApy = async (market) => {
         ltv: poolsReservesConfigurationData[i].ltv / 10000,
         url,
         borrowable: poolsReservesConfigurationData[i].borrowingEnabled,
-        mintedCoin: null,
-        poolMeta: null,
       };
     })
     .filter((i) => Boolean(i));

--- a/src/adaptors/hyperlend-pooled/index.js
+++ b/src/adaptors/hyperlend-pooled/index.js
@@ -47,6 +47,17 @@ const getApy = async (market) => {
     })
   ).output.map((o) => o.output);
 
+  const poolsReserveCaps = (
+    await sdk.api.abi.multiCall({
+      calls: reserveTokens.map((p) => ({
+        target: protocolDataProvider[0],
+        params: p.tokenAddress,
+      })),
+      abi: poolAbi.find((m) => m.name === 'getReserveCaps'),
+      chain,
+    })
+  ).output.map((o) => o.output);
+
   const totalSupply = (
     await sdk.api.abi.multiCall({
       chain,
@@ -102,6 +113,11 @@ const getApy = async (market) => {
         ((Number(p.totalStableDebt) + Number(p.totalVariableDebt)) /
           10 ** underlyingDecimals[i]) *
         price;
+      const borrowCapUsd = Number(poolsReserveCaps[i].borrowCap) * price;
+      const hasBorrowCap = Number(poolsReserveCaps[i].borrowCap) > 0;
+      const availableBorrowUsd = hasBorrowCap
+        ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+        : tvlUsd;
 
       const url = `https://app.hyperlend.finance/markets/${pool.tokenAddress}`;
 
@@ -115,6 +131,7 @@ const getApy = async (market) => {
         underlyingTokens: [pool.tokenAddress],
         totalSupplyUsd,
         totalBorrowUsd,
+        availableBorrowUsd,
         apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
         ltv: poolsReservesConfigurationData[i].ltv / 10000,
         url,

--- a/src/adaptors/hypurrfi-pooled/index.js
+++ b/src/adaptors/hypurrfi-pooled/index.js
@@ -25,7 +25,8 @@ const extractConfigBits = (configData) => {
   const frozen = Boolean((data >> 57n) & 1n);
   const borrowingEnabled = Boolean((data >> 58n) & 1n);
   const paused = Boolean((data >> 60n) & 1n);
-  return { ltv, borrowable: active && !frozen && borrowingEnabled && !paused };
+  const borrowCap = Number((data >> 80n) & ((1n << 36n) - 1n));
+  return { ltv, borrowCap, borrowable: active && !frozen && borrowingEnabled && !paused };
 };
 
 const apy = async () => {
@@ -67,10 +68,11 @@ const apy = async () => {
   const symbolResults = symbols.output.map((o) => o.output);
   const decimalResults = decimals.output.map((o) => o.output);
 
-  // 4. Get aToken addresses and their total supply + underlying balances
+  // 4. Get supply, liquidity, and debt token balances
   const aTokenAddresses = reserveDataResults.map((r) => r.aTokenAddress);
 
-  const [aTokenSupply, underlyingBalances] = await Promise.all([
+  const [aTokenSupply, underlyingBalances, stableDebtSupply, variableDebtSupply] =
+    await Promise.all([
     sdk.api.abi.multiCall({
       calls: aTokenAddresses.map((t) => ({ target: t })),
       abi: "erc20:totalSupply",
@@ -84,10 +86,24 @@ const apy = async () => {
       abi: "erc20:balanceOf",
       chain,
     }),
+    sdk.api.abi.multiCall({
+      calls: reserveDataResults.map((r) => ({ target: r.stableDebtTokenAddress })),
+      abi: "erc20:totalSupply",
+      chain,
+    }),
+    sdk.api.abi.multiCall({
+      calls: reserveDataResults.map((r) => ({ target: r.variableDebtTokenAddress })),
+      abi: "erc20:totalSupply",
+      chain,
+    }),
   ]);
 
   const aTokenSupplyResults = aTokenSupply.output.map((o) => o.output);
   const underlyingBalanceResults = underlyingBalances.output.map(
+    (o) => o.output
+  );
+  const stableDebtSupplyResults = stableDebtSupply.output.map((o) => o.output);
+  const variableDebtSupplyResults = variableDebtSupply.output.map(
     (o) => o.output
   );
 
@@ -110,7 +126,11 @@ const apy = async () => {
       const totalSupplyUsd = supply * price;
       const available = underlyingBalanceResults[i] / 10 ** dec;
       const tvlUsd = available * price;
-      const totalBorrowUsd = totalSupplyUsd - tvlUsd;
+      const totalBorrowUsd =
+        ((Number(stableDebtSupplyResults[i]) +
+          Number(variableDebtSupplyResults[i])) /
+          10 ** dec) *
+        price;
 
       const apyBase = aprRayToApyPercent(
         reserveDataResults[i].currentLiquidityRate
@@ -119,9 +139,13 @@ const apy = async () => {
         reserveDataResults[i].currentVariableBorrowRate
       );
 
-      const { ltv, borrowable } = extractConfigBits(
+      const { ltv, borrowCap, borrowable } = extractConfigBits(
         reserveDataResults[i].configuration.data
       );
+      const borrowCapUsd = borrowCap * price;
+      const availableBorrowUsd = borrowCap
+        ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+        : tvlUsd;
 
       return {
         pool: `${aTokenAddresses[i]}-hypurrfi-pooled`.toLowerCase(),
@@ -133,13 +157,11 @@ const apy = async () => {
         underlyingTokens: [asset],
         totalSupplyUsd,
         totalBorrowUsd,
-        debtCeilingUsd: null,
+        availableBorrowUsd,
         apyBaseBorrow,
         ltv: ltv / 10000,
         url: `https://hypurrfi.com/markets/pooled/999/${asset}`,
         borrowable,
-        mintedCoin: null,
-        poolMeta: null,
       };
     })
     .filter(Boolean)

--- a/src/adaptors/kinza-finance/index.js
+++ b/src/adaptors/kinza-finance/index.js
@@ -48,6 +48,17 @@ const apy = async () => {
     })
   ).output.map((o) => o.output);
 
+  const poolsReserveCaps = (
+    await sdk.api.abi.multiCall({
+      calls: reserveTokens.map((p) => ({
+        target,
+        params: p.tokenAddress,
+      })),
+      abi: poolAbi.find((m) => m.name === 'getReserveCaps'),
+      chain,
+    })
+  ).output.map((o) => o.output);
+
   const totalSupplyEthereum = (
     await sdk.api.abi.multiCall({
       chain,
@@ -98,6 +109,14 @@ const apy = async () => {
       const currentSupply = underlyingBalancesEthereum[i];
       const tvlUsd =
         (currentSupply / 10 ** underlyingDecimalsEthereum[i]) * price;
+      const totalBorrowUsd =
+        ((Number(p.totalStableDebt) + Number(p.totalVariableDebt)) /
+          10 ** underlyingDecimalsEthereum[i]) *
+        price;
+      const borrowCapUsd = Number(poolsReserveCaps[i].borrowCap) * price;
+      const availableBorrowUsd = Number(poolsReserveCaps[i].borrowCap)
+        ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+        : tvlUsd;
 
       return {
         pool: `${aTokens[i].tokenAddress}-${chain}`.toLowerCase(),
@@ -108,7 +127,8 @@ const apy = async () => {
         apyBase: (p.liquidityRate / 10 ** 27) * 100,
         underlyingTokens: [pool.tokenAddress],
         totalSupplyUsd,
-        totalBorrowUsd: totalSupplyUsd - tvlUsd,
+        totalBorrowUsd,
+        availableBorrowUsd,
         apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
         ltv: poolsReservesConfigurationData[i].ltv / 10000,
         borrowable: poolsReservesConfigurationData[i].borrowingEnabled,

--- a/src/adaptors/more-markets/index.js
+++ b/src/adaptors/more-markets/index.js
@@ -164,13 +164,16 @@ const apy = async () => {
       liquidityRate,
       variableBorrowRate,
       availableLiquidity,
+      totalPrincipalStableDebt,
       totalScaledVariableDebt,
+      variableBorrowIndex,
       baseLTVasCollateral,
       borrowingEnabled,
       isActive,
       isPaused,
       aTokenAddress,
       variableDebtTokenAddress,
+      borrowCap,
     } = reserve;
 
     // Get price using chain:address format
@@ -203,12 +206,19 @@ const apy = async () => {
 
     // Calculate TVL and borrow amounts
     const liquidity = Number(availableLiquidity) / 10 ** Number(decimals);
-    const borrowed = Number(totalScaledVariableDebt) / 10 ** Number(decimals);
+    const borrowed =
+      (Number(totalPrincipalStableDebt) +
+        (Number(totalScaledVariableDebt) * Number(variableBorrowIndex)) / 1e27) /
+      10 ** Number(decimals);
 
     const liquidityUsd = tokenPrice?.price ? liquidity * tokenPrice.price : 0;
     const borrowedUsd = tokenPrice?.price ? borrowed * tokenPrice.price : 0;
     const totalSupplyUsd = liquidityUsd + borrowedUsd;
     const tvlUsd = liquidityUsd;
+    const borrowCapUsd = Number(borrowCap) * (tokenPrice?.price || 0);
+    const availableBorrowUsd = Number(borrowCap)
+      ? Math.max(Math.min(tvlUsd, borrowCapUsd - borrowedUsd), 0)
+      : tvlUsd;
 
     // Find matching incentive data for this reserve
     const matchingIncentive = incentivesData.find(
@@ -286,13 +296,12 @@ const apy = async () => {
       underlyingTokens: [underlyingAsset],
       totalSupplyUsd,
       totalBorrowUsd: borrowedUsd,
-      debtCeilingUsd: null,
+      availableBorrowUsd,
       apyBaseBorrow: borrowAPY,
       apyRewardBorrow: borrowRewards.apyReward + merkleBorrowApy,
       ltv: Number(baseLTVasCollateral) / 10000,
       url,
       borrowable: borrowingEnabled && isActive && !isPaused,
-      mintedCoin: null,
       poolMeta: `${name} on Flow EVM`,
     };
   });

--- a/src/adaptors/sparklend/index.js
+++ b/src/adaptors/sparklend/index.js
@@ -136,7 +136,14 @@ async function fetchV3Pools(chain) {
       const tvlUsd =
         (currentSupply / 10 ** underlyingDecimalsEthereum[i]) * price;
 
-      const totalBorrowUsd = totalSupplyUsd - tvlUsd;
+      const totalBorrowUsd =
+        ((Number(p.totalStableDebt) + Number(p.totalVariableDebt)) /
+          10 ** underlyingDecimalsEthereum[i]) *
+        price;
+      const borrowCapUsd = Number(reserveCaps[i].borrowCap) * price;
+      const availableBorrowUsd = borrowCap > 0n
+        ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+        : tvlUsd;
       // Omit borrow fields when Spark disables borrowing; cap-reached markets
       // still expose borrow data but are marked as not borrowable.
       const hasBorrowSide = config.borrowingEnabled && config.isActive;
@@ -155,6 +162,7 @@ async function fetchV3Pools(chain) {
         totalSupplyUsd,
         ...(hasBorrowSide && {
           totalBorrowUsd,
+          availableBorrowUsd,
           apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
         }),
         ltv: config.ltv / 10000,

--- a/src/adaptors/superlend/index.js
+++ b/src/adaptors/superlend/index.js
@@ -55,6 +55,17 @@ const getApy = async () => {
     })
   ).output.map((o) => o.output);
 
+  const poolsReserveCaps = (
+    await sdk.api.abi.multiCall({
+      calls: reserveTokens.map((p) => ({
+        target: PROTOCOL_DATA_PROVIDER,
+        params: p.tokenAddress,
+      })),
+      abi: poolAbi.find((m) => m.name === 'getReserveCaps'),
+      chain,
+    })
+  ).output.map((o) => o.output);
+
   const totalSupply = (
     await sdk.api.abi.multiCall({
       chain,
@@ -138,7 +149,14 @@ const getApy = async () => {
       const currentSupply = underlyingBalances[i];
       let tvlUsd = (currentSupply / 10 ** underlyingDecimals[i]) * price;
 
-      totalBorrowUsd = totalSupplyUsd - tvlUsd;
+      const totalBorrowUsd =
+        ((Number(p.totalStableDebt) + Number(p.totalVariableDebt)) /
+          10 ** underlyingDecimals[i]) *
+        price;
+      const borrowCapUsd = Number(poolsReserveCaps[i].borrowCap) * price;
+      const availableBorrowUsd = Number(poolsReserveCaps[i].borrowCap)
+        ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+        : tvlUsd;
 
       const url = `https://markets.superlend.xyz/reserve-overview/?underlyingAsset=${pool.tokenAddress.toLowerCase()}&marketName=etherlink`;
 
@@ -157,13 +175,11 @@ const getApy = async () => {
         rewardTokens: apyReward > 0 ? [APPLE_REWARD_TOKEN] : [],
         totalSupplyUsd,
         totalBorrowUsd,
-        debtCeilingUsd: null,
+        availableBorrowUsd,
         apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
         ltv: poolsReservesConfigurationData[i].ltv / 10000,
         url,
         borrowable: poolsReservesConfigurationData[i].borrowingEnabled,
-        mintedCoin: null,
-        poolMeta: null,
       };
     })
     .filter((i) => Boolean(i));

--- a/src/adaptors/test.js
+++ b/src/adaptors/test.js
@@ -40,7 +40,6 @@ describe(`Running ${process.env.npm_config_adapter} Test`, () => {
       'borrowable',
       'borrowFactor',
       'debtCeilingUsd',
-      'borrowCapUsd',
       'availableBorrowUsd',
       'mintedCoin',
       'borrowToken',
@@ -195,10 +194,6 @@ describe(`Running ${process.env.npm_config_adapter} Test`, () => {
       },
       totalBorrowUsd: {
         type: 'number',
-      },
-      borrowCapUsd: {
-        type: 'number',
-        min: 0,
       },
       availableBorrowUsd: {
         type: 'number',

--- a/src/adaptors/yldr/index.js
+++ b/src/adaptors/yldr/index.js
@@ -31,6 +31,13 @@ async function apy() {
                         .shiftedBy(-(27 + Number(reserve.decimals) + 8))
                         .toNumber();
                     const totalSupplyUsd = tvlUsd + totalBorrowUsd;
+                    const borrowCapUsd = new BigNumber(reserve.borrowCap)
+                        .multipliedBy(reserve.priceInMarketReferenceCurrency)
+                        .shiftedBy(-8)
+                        .toNumber();
+                    const availableBorrowUsd = Number(reserve.borrowCap)
+                        ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
+                        : tvlUsd;
                     return {
                         pool: `${reserve.yTokenAddress}-${chain}`.toLowerCase(),
                         chain: utils.formatChain(chain),
@@ -41,6 +48,7 @@ async function apy() {
                         underlyingTokens: [reserve.underlyingAsset],
                         totalSupplyUsd,
                         totalBorrowUsd,
+                        availableBorrowUsd,
                         apyBaseBorrow:
                             calculateAPY(reserve.variableBorrowRate).toNumber() * 100,
                         ltv: reserve.baseLTVasCollateral / 10000,

--- a/src/handlers/triggerAdaptor.js
+++ b/src/handlers/triggerAdaptor.js
@@ -115,7 +115,6 @@ const main = async (body) => {
     apyRewardBorrowFake: strToNum(p.apyRewardBorrowFake),
     apyBaseInception: strToNum(p.apyBaseInception),
     pricePerShare: strToNum(p.pricePerShare),
-    borrowCapUsd: strToNum(p.borrowCapUsd),
     availableBorrowUsd: strToNum(p.availableBorrowUsd),
   }));
 
@@ -392,10 +391,6 @@ const main = async (body) => {
         p.debtCeilingUsd === undefined || p.debtCeilingUsd === null
           ? null
           : Math.round(p.debtCeilingUsd),
-      borrowCapUsd:
-        p.borrowCapUsd === undefined || p.borrowCapUsd === null
-          ? null
-          : Math.round(p.borrowCapUsd),
       availableBorrowUsd:
         p.availableBorrowUsd === undefined || p.availableBorrowUsd === null
           ? null

--- a/src/queries/yield.js
+++ b/src/queries/yield.js
@@ -349,7 +349,6 @@ const buildInsertYieldQuery = (payload) => {
     { name: 'totalSupplyUsd', def: null },
     { name: 'totalBorrowUsd', def: null },
     { name: 'debtCeilingUsd', def: null },
-    { name: 'borrowCapUsd', def: null },
     { name: 'availableBorrowUsd', def: null },
     { name: 'pricePerShare', def: null },
   ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added available borrow capacity metrics across multiple lending protocols including Aave V3, Sparklend, Superlend, and others, displaying remaining borrowing limits per pool.

* **Improvements**
  * Enhanced accuracy of borrow-related calculations across supported platforms using refined data methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->