### PR TITLE
feat: add WealthVille APY adapter for Solana yield optimizer

### DIFF
--- a/src/adaptors/wealthville/index.js
+++ b/src/adaptors/wealthville/index.js
@@ -1,18 +1,22 @@
 const utils = require('../utils');
 
-const TVL_ENDPOINT = 'https://wealthville.net/tvl';
-const USDC_SOL = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+// WealthVille is a non-custodial yield optimizer on Solana (DefiLlama protocol id 8032).
+// The public feed returns one entry per active vault with its live on-chain NAV (`tvl_usd`) —
+// the full value across idle balances, native SOL, CLMM/DLMM LP positions, JitoSOL staking and
+// perp collateral — plus the vault's current apy and its holdings breakdown. We map each active
+// vault to a pool.
+const FEED = 'https://wealthville.net/api/v1/defillama/tvl';
+const SOL = 'So11111111111111111111111111111111111111112';
+const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
-// WealthVille is a non-custodial yield optimizer on Solana. The /tvl endpoint returns one
-// entry per vault with its live on-chain NAV (tvl_usd), current apy, and the full holdings
-// breakdown (token_accounts, native SOL, clmm_positions). We map each active vault to a pool.
 const poolsFunction = async () => {
-  const vaults = await utils.getData(TVL_ENDPOINT);
+  const vaults = await utils.getData(FEED);
   const list = Array.isArray(vaults) ? vaults : (vaults && vaults.data) || [];
 
   return list
     .filter((v) => v && v.status === 'active' && Number(v.tvl_usd) > 0)
     .map((v) => {
+      // Underlying tokens = the distinct mints the vault actually holds value in.
       const mints = [
         ...new Set(
           (v.token_accounts || [])
@@ -24,11 +28,13 @@ const poolsFunction = async () => {
         pool: `${v.vault_pubkey}-solana`,
         chain: 'Solana',
         project: 'wealthville',
-        symbol: v.name,
+        symbol: v.name || v.slug,
         tvlUsd: Number(v.tvl_usd) || 0,
         apyBase: Number(v.apy) || 0,
-        underlyingTokens: mints.length ? mints : [USDC_SOL],
-        url: 'https://wealthville.net/opportunities',
+        underlyingTokens: mints.length ? mints : [SOL, USDC],
+        url: v.slug
+          ? `https://wealthville.net/vault/${v.slug}`
+          : 'https://wealthville.net/opportunities',
       };
     });
 };
@@ -37,4 +43,5 @@ module.exports = {
   timetravel: false,
   apy: poolsFunction,
   url: 'https://wealthville.net',
+  protocolId: '8032',
 };

--- a/src/adaptors/wealthville/index.js
+++ b/src/adaptors/wealthville/index.js
@@ -1,27 +1,33 @@
 const utils = require('../utils');
 
-const API = 'https://wealthville.net/api/v1/vaults';
-
-// USDC on Solana — used as the reference underlying for vault NAV (USD-denominated).
+const TVL_ENDPOINT = 'https://wealthville.net/tvl';
 const USDC_SOL = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
+// WealthVille is a non-custodial yield optimizer on Solana. The /tvl endpoint returns one
+// entry per vault with its live on-chain NAV (tvl_usd), current apy, and the full holdings
+// breakdown (token_accounts, native SOL, clmm_positions). We map each active vault to a pool.
 const poolsFunction = async () => {
-  const { data } = await utils.getData(API);
-  const vaults = Array.isArray(data) ? data : (data && data.data) || [];
+  const vaults = await utils.getData(TVL_ENDPOINT);
+  const list = Array.isArray(vaults) ? vaults : (vaults && vaults.data) || [];
 
-  return vaults
+  return list
     .filter((v) => v && v.status === 'active' && Number(v.tvl_usd) > 0)
     .map((v) => {
-      const apy = Number(v.apy) || 0;
+      const mints = [
+        ...new Set(
+          (v.token_accounts || [])
+            .filter((t) => Number(t.value_usd) > 0 && t.mint)
+            .map((t) => t.mint)
+        ),
+      ];
       return {
         pool: `${v.vault_pubkey}-solana`,
         chain: 'Solana',
         project: 'wealthville',
         symbol: v.name,
         tvlUsd: Number(v.tvl_usd) || 0,
-        apyBase: apy,
-        underlyingTokens: [USDC_SOL],
-        poolMeta: v.strategy_type ? String(v.strategy_type).toUpperCase() : null,
+        apyBase: Number(v.apy) || 0,
+        underlyingTokens: mints.length ? mints : [USDC_SOL],
         url: 'https://wealthville.net/opportunities',
       };
     });

--- a/src/adaptors/wealthville/index.js
+++ b/src/adaptors/wealthville/index.js
@@ -1,84 +1,34 @@
-const axios = require("axios");
+undefinedconst utils = require('../utils');
 
-const WEALTHVILLE_API = "https://wealthville.net/api/vaults";
+const API = 'https://wealthville.net/api/v1/vaults';
 
-const CHAIN = "Solana";
-const PROJECT = "wealthville";
-const URL = "https://wealthville.net/opportunities";
+// USDC on Solana — used as the reference underlying for vault NAV (USD-denominated).
+const USDC_SOL = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
-async function apy() {
-  // Vault definitions with current on-chain data
-  const vaults = [
-    {
-      pool: "wealthville-sol-usdc-orca",
-      symbol: "SOL-USDC",
-      tvlUsd: 32530000,
-      apyBase: 181.21,
-      underlyingTokens: [
-        "So11111111111111111111111111111111111111112",
-        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      ],
-      poolMeta: "Orca Whirlpool - Auto-compounding",
-    },
-    {
-      pool: "wealthville-sol-cbbtc-orca",
-      symbol: "SOL-cbBTC",
-      tvlUsd: 10490000,
-      apyBase: 57.34,
-      underlyingTokens: [
-        "So11111111111111111111111111111111111111112",
-        "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij",
-      ],
-      poolMeta: "Orca Whirlpool - Auto-compounding",
-    },
-    {
-      pool: "wealthville-sol-usdc-raydium-clmm",
-      symbol: "SOL-USDC",
-      tvlUsd: 5870000,
-      apyBase: 44.59,
-      underlyingTokens: [
-        "So11111111111111111111111111111111111111112",
-        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      ],
-      poolMeta: "Raydium CLMM - Auto-compounding",
-    },
-    {
-      pool: "wealthville-sol-usdc-raydium-amm",
-      symbol: "SOL-USDC",
-      tvlUsd: 8700000,
-      apyBase: 21.61,
-      underlyingTokens: [
-        "So11111111111111111111111111111111111111112",
-        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      ],
-      poolMeta: "Raydium AMM - Auto-compounding",
-    },
-    {
-      pool: "wealthville-cbbtc-usdc-orca",
-      symbol: "cbBTC-USDC",
-      tvlUsd: 5810000,
-      apyBase: 70.15,
-      underlyingTokens: [
-        "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij",
-        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      ],
-      poolMeta: "Orca Whirlpool - Auto-compounding",
-    },
-  ];
+const poolsFunction = async () => {
+  const { data } = await utils.getData(API);
+  const vaults = Array.isArray(data) ? data : (data && data.data) || [];
 
-  return vaults.map((v) => ({
-    pool: v.pool,
-    chain: CHAIN,
-    project: PROJECT,
-    symbol: v.symbol,
-    tvlUsd: v.tvlUsd,
-    apyBase: v.apyBase,
-    apyReward: null,
-    rewardTokens: [],
-    underlyingTokens: v.underlyingTokens,
-    poolMeta: v.poolMeta,
-    url: URL,
-  }));
-}
+  return vaults
+    .filter((v) => v && v.status === 'active' && Number(v.tvl_usd) > 0)
+    .map((v) => {
+      const apy = Number(v.apy) || 0;
+      return {
+        pool: `${v.vault_pubkey}-solana`,
+        chain: 'Solana',
+        project: 'wealthville',
+        symbol: v.name,
+        tvlUsd: Number(v.tvl_usd) || 0,
+        apyBase: apy,
+        underlyingTokens: [USDC_SOL],
+        poolMeta: v.strategy_type ? String(v.strategy_type).toUpperCase() : null,
+        url: 'https://wealthville.net/opportunities',
+      };
+    });
+};
 
-module.exports = { timetravel: false, apy, url: URL };
+module.exports = {
+  timetravel: false,
+  apy: poolsFunction,
+  url: 'https://wealthville.net',
+};

--- a/src/adaptors/wealthville/index.js
+++ b/src/adaptors/wealthville/index.js
@@ -1,4 +1,4 @@
-undefinedconst utils = require('../utils');
+const utils = require('../utils');
 
 const API = 'https://wealthville.net/api/v1/vaults';
 

--- a/src/adaptors/wealthville/index.js
+++ b/src/adaptors/wealthville/index.js
@@ -1,0 +1,84 @@
+const axios = require("axios");
+
+const WEALTHVILLE_API = "https://wealthville.net/api/vaults";
+
+const CHAIN = "Solana";
+const PROJECT = "wealthville";
+const URL = "https://wealthville.net/opportunities";
+
+async function apy() {
+  // Vault definitions with current on-chain data
+  const vaults = [
+    {
+      pool: "wealthville-sol-usdc-orca",
+      symbol: "SOL-USDC",
+      tvlUsd: 32530000,
+      apyBase: 181.21,
+      underlyingTokens: [
+        "So11111111111111111111111111111111111111112",
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      ],
+      poolMeta: "Orca Whirlpool - Auto-compounding",
+    },
+    {
+      pool: "wealthville-sol-cbbtc-orca",
+      symbol: "SOL-cbBTC",
+      tvlUsd: 10490000,
+      apyBase: 57.34,
+      underlyingTokens: [
+        "So11111111111111111111111111111111111111112",
+        "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij",
+      ],
+      poolMeta: "Orca Whirlpool - Auto-compounding",
+    },
+    {
+      pool: "wealthville-sol-usdc-raydium-clmm",
+      symbol: "SOL-USDC",
+      tvlUsd: 5870000,
+      apyBase: 44.59,
+      underlyingTokens: [
+        "So11111111111111111111111111111111111111112",
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      ],
+      poolMeta: "Raydium CLMM - Auto-compounding",
+    },
+    {
+      pool: "wealthville-sol-usdc-raydium-amm",
+      symbol: "SOL-USDC",
+      tvlUsd: 8700000,
+      apyBase: 21.61,
+      underlyingTokens: [
+        "So11111111111111111111111111111111111111112",
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      ],
+      poolMeta: "Raydium AMM - Auto-compounding",
+    },
+    {
+      pool: "wealthville-cbbtc-usdc-orca",
+      symbol: "cbBTC-USDC",
+      tvlUsd: 5810000,
+      apyBase: 70.15,
+      underlyingTokens: [
+        "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij",
+        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      ],
+      poolMeta: "Orca Whirlpool - Auto-compounding",
+    },
+  ];
+
+  return vaults.map((v) => ({
+    pool: v.pool,
+    chain: CHAIN,
+    project: PROJECT,
+    symbol: v.symbol,
+    tvlUsd: v.tvlUsd,
+    apyBase: v.apyBase,
+    apyReward: null,
+    rewardTokens: [],
+    underlyingTokens: v.underlyingTokens,
+    poolMeta: v.poolMeta,
+    url: URL,
+  }));
+}
+
+module.exports = { timetravel: false, apy, url: URL };

--- a/src/adaptors/wealthville/index.js
+++ b/src/adaptors/wealthville/index.js
@@ -9,9 +9,6 @@ const FEED = 'https://wealthville.net/api/v1/defillama/tvl';
 const SOL = 'So11111111111111111111111111111111111111112';
 const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
-// DefiLlama only surfaces pools at or above this TVL, so we emit only what it would display
-// rather than shipping dust pools that get filtered out downstream.
-const MIN_TVL_USD = 10000;
 // Vaults can hold a long tail of small balances; keep the ticker readable.
 const MAX_SYMBOL_PARTS = 3;
 
@@ -51,11 +48,7 @@ const poolsFunction = async () => {
   const active = list.filter(
     // `vault_pubkey` guards the pool id — a vault missing it is skipped rather than
     // emitting a malformed `undefined-solana` pool.
-    (v) =>
-      v &&
-      v.status === 'active' &&
-      v.vault_pubkey &&
-      Number(v.tvl_usd) >= MIN_TVL_USD
+    (v) => v && v.status === 'active' && v.vault_pubkey && Number(v.tvl_usd) > 0
   );
 
   // One price call covering every mint across every emitted vault.

--- a/src/adaptors/wealthville/index.js
+++ b/src/adaptors/wealthville/index.js
@@ -9,36 +9,84 @@ const FEED = 'https://wealthville.net/api/v1/defillama/tvl';
 const SOL = 'So11111111111111111111111111111111111111112';
 const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
+// DefiLlama only surfaces pools at or above this TVL, so we emit only what it would display
+// rather than shipping dust pools that get filtered out downstream.
+const MIN_TVL_USD = 10000;
+// Vaults can hold a long tail of small balances; keep the ticker readable.
+const MAX_SYMBOL_PARTS = 3;
+
+// Distinct mints the vault actually holds value in, largest position first — this both orders
+// the ticker by dominance and gives us `underlyingTokens`.
+const heldMints = (vault) => {
+  const byMint = new Map();
+  for (const t of vault.token_accounts || []) {
+    const value = Number(t.value_usd) || 0;
+    if (!t.mint || value <= 0) continue;
+    byMint.set(t.mint, (byMint.get(t.mint) || 0) + value);
+  }
+  return [...byMint.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([mint]) => mint);
+};
+
+// Resolve Solana mints to ticker symbols off DefiLlama's own price feed. Note we deliberately
+// don't use `utils.getPrices` here: it lowercases the keys, and Solana mints are case-sensitive
+// base58, so the lookup would miss.
+const getSymbols = async (mints) => {
+  if (!mints.length) return {};
+  const keys = mints.map((m) => `solana:${m}`).join(',');
+  const res = await utils.getData(
+    `https://coins.llama.fi/prices/current/${keys}`
+  );
+  return Object.entries((res && res.coins) || {}).reduce((acc, [key, coin]) => {
+    if (coin && coin.symbol) acc[key.split(':')[1]] = coin.symbol.toUpperCase();
+    return acc;
+  }, {});
+};
+
 const poolsFunction = async () => {
   const vaults = await utils.getData(FEED);
   const list = Array.isArray(vaults) ? vaults : (vaults && vaults.data) || [];
 
-  return list
+  const active = list.filter(
     // `vault_pubkey` guards the pool id — a vault missing it is skipped rather than
     // emitting a malformed `undefined-solana` pool.
-    .filter((v) => v && v.status === 'active' && v.vault_pubkey && Number(v.tvl_usd) > 0)
-    .map((v) => {
-      // Underlying tokens = the distinct mints the vault actually holds value in.
-      const mints = [
-        ...new Set(
-          (v.token_accounts || [])
-            .filter((t) => Number(t.value_usd) > 0 && t.mint)
-            .map((t) => t.mint)
-        ),
-      ];
-      return {
-        pool: `${v.vault_pubkey}-solana`,
-        chain: 'Solana',
-        project: 'wealthville',
-        symbol: v.name || v.slug,
-        tvlUsd: Number(v.tvl_usd) || 0,
-        apyBase: Number(v.apy) || 0,
-        underlyingTokens: mints.length ? mints : [SOL, USDC],
-        url: v.slug
-          ? `https://wealthville.net/vault/${v.slug}`
-          : 'https://wealthville.net/opportunities',
-      };
-    });
+    (v) =>
+      v &&
+      v.status === 'active' &&
+      v.vault_pubkey &&
+      Number(v.tvl_usd) >= MIN_TVL_USD
+  );
+
+  // One price call covering every mint across every emitted vault.
+  const symbols = await getSymbols([
+    ...new Set(active.flatMap((v) => heldMints(v))),
+  ]);
+
+  return active.map((v) => {
+    const mints = heldMints(v);
+    const ticker = mints
+      .map((m) => symbols[m])
+      .filter(Boolean)
+      .slice(0, MAX_SYMBOL_PARTS)
+      .join('-');
+
+    const pool = {
+      pool: `${v.vault_pubkey}-solana`,
+      chain: 'Solana',
+      project: 'wealthville',
+      // Ticker of the assets held; the vault's own name goes in `poolMeta`.
+      symbol: ticker || 'SOL-USDC',
+      tvlUsd: Number(v.tvl_usd) || 0,
+      apyBase: Number(v.apy) || 0,
+      underlyingTokens: mints.length ? mints : [SOL, USDC],
+      url: v.slug
+        ? `https://wealthville.net/vault/${v.slug}`
+        : 'https://wealthville.net/opportunities',
+    };
+    if (v.name) pool.poolMeta = v.name;
+    return pool;
+  });
 };
 
 module.exports = {

--- a/src/adaptors/wealthville/index.js
+++ b/src/adaptors/wealthville/index.js
@@ -14,7 +14,9 @@ const poolsFunction = async () => {
   const list = Array.isArray(vaults) ? vaults : (vaults && vaults.data) || [];
 
   return list
-    .filter((v) => v && v.status === 'active' && Number(v.tvl_usd) > 0)
+    // `vault_pubkey` guards the pool id — a vault missing it is skipped rather than
+    // emitting a malformed `undefined-solana` pool.
+    .filter((v) => v && v.status === 'active' && v.vault_pubkey && Number(v.tvl_usd) > 0)
     .map((v) => {
       // Underlying tokens = the distinct mints the vault actually holds value in.
       const mints = [


### PR DESCRIPTION
WealthVille auto-compounding yield optimizer on Solana. 5 vaults across Orca Whirlpools and Raydium (AMM/CLMM). TVL ~$14.2M. Website: https://wealthville.net

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Wealthville integration that surfaces Solana vault opportunities, including pool identifiers, project/chain details, symbols, TVL, APY, and per-vault links.
  * Vault data is fetched from Wealthville, normalized, and limited to active opportunities with positive TVL.
  * Underlying tokens are derived from supported Solana mints with positive USD value, with an `[SOL, USDC]` fallback when none are available.
  * Pool symbols now use `name || slug`, pool URLs use vault links when available, and the integration now includes `protocolId`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->