### PR TITLE
optimized O(n²) pool lookup to O(n) with Map in getPoolsBorrow

### DIFF
--- a/src/api/controllers/enriched.js
+++ b/src/api/controllers/enriched.js
@@ -96,9 +96,10 @@ const getPoolsBorrow = async (req, res) => {
   const lendBorrow = data[1];
 
   // join supply side fields (all enriched fields) onto borrow object
+  const poolsMap = new Map(pools.map((i) => [i.pool, i]));
   const poolsBorrow = lendBorrow
     .map((p) => {
-      const poolSupplySide = pools.find((i) => i.pool === p.pool);
+      const poolSupplySide = poolsMap.get(p.pool);
       if (poolSupplySide === undefined) return null;
 
       return {


### PR DESCRIPTION
getPoolsBorrow was calling pools.find() inside a .map() over lendBorrow -> resulting in O(n²) comparisons on every request. With thousands of pools on both sides this means millions of string comparisons per call. Replaced with a Map keyed by pool id built once before the loop, reducing the join to O(n).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance of pool borrow data retrieval operations for faster response times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->