### PR TITLE
parallelize block and token price fetches in utils

### DIFF
--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -119,7 +119,9 @@ const getBlocksByTime = async (timestamps, chainString) => {
   const chain = chainString === 'avalanche' ? 'avax' : chainString;
   const responses = await Promise.all(
     timestamps.map((timestamp) =>
-      axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)
+      exports.withRetry(() =>
+        axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)
+      )
     )
   );
   return responses.map((r) => r.data.height);
@@ -254,8 +256,13 @@ exports.tvl = async (dataNow, networkString) => {
   for (let index = 0; index < idsSet.length; index += 50) {
     chunks.push(idsSet.slice(index, index + 50));
   }
-  const chunkResults = await Promise.all(chunks.map(fetchTokenPrices));
-  const prices = Object.assign({}, ...chunkResults);
+  const CONCURRENCY = 5;
+  const prices = {};
+  for (let i = 0; i < chunks.length; i += CONCURRENCY) {
+    const batch = chunks.slice(i, i + CONCURRENCY);
+    const batchResults = await Promise.all(batch.map(fetchTokenPrices));
+    Object.assign(prices, ...batchResults);
+  }
 
   // calc tvl
   for (const el of dataNowCopy) {

--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -117,14 +117,12 @@ exports.withRetry = async (fn, { retries = 3, delayMs = 500 } = {}) => {
 // retrive block based on unixTimestamp array
 const getBlocksByTime = async (timestamps, chainString) => {
   const chain = chainString === 'avalanche' ? 'avax' : chainString;
-  const blocks = [];
-  for (const timestamp of timestamps) {
-    const response = await axios.get(
-      `https://coins.llama.fi/block/${chain}/${timestamp}`
-    );
-    blocks.push(response.data.height);
-  }
-  return blocks;
+  const responses = await Promise.all(
+    timestamps.map((timestamp) =>
+      axios.get(`https://coins.llama.fi/block/${chain}/${timestamp}`)
+    )
+  );
+  return responses.map((r) => r.data.height);
 };
 
 exports.getBlocksByTime = getBlocksByTime;
@@ -252,12 +250,12 @@ exports.tvl = async (dataNow, networkString) => {
     return data.coins;
   };
 
-  const prices = {};
+  const chunks = [];
   for (let index = 0; index < idsSet.length; index += 50) {
-    const chunk = idsSet.slice(index, index + 50);
-    const chunkPrices = await fetchTokenPrices(chunk);
-    Object.assign(prices, chunkPrices);
+    chunks.push(idsSet.slice(index, index + 50));
   }
+  const chunkResults = await Promise.all(chunks.map(fetchTokenPrices));
+  const prices = Object.assign({}, ...chunkResults);
 
   // calc tvl
   for (const el of dataNowCopy) {


### PR DESCRIPTION
Two sequential fetch patterns in utils.js replaced with Promise.all.
getBlocksByTime was awaiting each timestamp fetch one at a time inside a for loop, since each request is independent, all can be fired in parallel.

The token price chunking loop was also sequential -> each 50-token chunk waited for the previous one to complete before starting. Changed to build all chunks first then fetch in parallel with Promise.all, then merge results with Object.assign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved data-fetch performance: block height lookups and token price retrievals are now executed more concurrently and in batched requests, reducing latency and speeding up TVL and historical block queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefiLlama/yield-server/pull/2717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->