### PR TITLE
rename superstate adapters

### DIFF
--- a/migrations/1780415272973_rename-superstate-ustb-to-invesco-ustb.js
+++ b/migrations/1780415272973_rename-superstate-ustb-to-invesco-ustb.js
@@ -1,0 +1,7 @@
+exports.up = (pgm) => {
+  pgm.sql(`UPDATE config SET project = 'invesco-ustb' WHERE project = 'superstate-ustb'`);
+};
+
+exports.down = (pgm) => {
+  pgm.sql(`UPDATE config SET project = 'superstate-ustb' WHERE project = 'invesco-ustb'`);
+};

--- a/migrations/1780415273020_rename-superstate-uscc-to-bitwise-uscc.js
+++ b/migrations/1780415273020_rename-superstate-uscc-to-bitwise-uscc.js
@@ -1,0 +1,7 @@
+exports.up = (pgm) => {
+  pgm.sql(`UPDATE config SET project = 'bitwise-uscc' WHERE project = 'superstate-uscc'`);
+};
+
+exports.down = (pgm) => {
+  pgm.sql(`UPDATE config SET project = 'superstate-uscc' WHERE project = 'bitwise-uscc'`);
+};

--- a/src/adaptors/bitwise-uscc/index.js
+++ b/src/adaptors/bitwise-uscc/index.js
@@ -8,7 +8,7 @@ const USCC = {
     solana: 'BTRR3sj1Bn2ZjuemgbeQ6SCtf84iXS81CS7UDTSxUCaK',
 };
 const USCC_ORACLE = '0xAfFd8F5578E8590665de561bdE9E7BAdb99300d9';
-const project = 'superstate-uscc';
+const project = 'bitwise-uscc';
 const symbol = 'USCC';
 
 const apy = async () => {

--- a/src/adaptors/invesco-ustb/index.js
+++ b/src/adaptors/invesco-ustb/index.js
@@ -9,7 +9,7 @@ const USTB = {
     solana: 'CCz3SGVziFeLYk2xfEstkiqJfYkjaSWb2GCABYsVcjo2',
 };
 const USTB_ORACLE = '0x289B5036cd942e619E1Ee48670F98d214E745AAC';
-const project = 'superstate-ustb';
+const project = 'invesco-ustb';
 const symbol = 'USTB';
 
 const apy = async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Updated product identifiers and database configurations to align with announced strategic partnerships
- USTB: transitioned from Superstate to Invesco branding across all platform adapters and system records
- USCC: transitioned from Superstate to Bitwise branding across all platform adapters and system records
- All infrastructure updated to ensure consistent and accurate product identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->