### PR TITLE
Add tizi yield adapter

### DIFF
--- a/src/adaptors/tizi/index.js
+++ b/src/adaptors/tizi/index.js
@@ -8,65 +8,74 @@ const stTD = '0x0CB091e6D9fd696b4CC8571E19e042F456c182Ad';
 const DAY = 24 * 3600;
 
 const apy = async () => {
-  const now = Math.floor(Date.now() / 1e3);
-  const sevenDaysAgo = now - 7 * DAY;
+  try {
+    const now = Math.floor(Date.now() / 1e3);
+    const sevenDaysAgo = now - 7 * DAY;
 
-  const [blockNow, block7d] = await Promise.all([
-    axios.get(`https://coins.llama.fi/block/base/${now}`).then((r) => r.data.height),
-    axios.get(`https://coins.llama.fi/block/base/${sevenDaysAgo}`).then((r) => r.data.height),
-  ]);
+    const [blockNow, block7d] = await Promise.all([
+      axios.get(`https://coins.llama.fi/block/base/${now}`).then((r) => r.data.height),
+      axios.get(`https://coins.llama.fi/block/base/${sevenDaysAgo}`).then((r) => r.data.height),
+    ]);
 
-  const [totalAssets, ppsNow, pps7d] = await Promise.all([
-    sdk.api.abi.call({
-      target: stTD,
-      abi: 'uint256:totalAssets',
-      chain: 'base',
-      block: blockNow,
-    }),
-    sdk.api.abi.call({
-      target: stTD,
-      abi: 'function convertToAssets(uint256) view returns (uint256)',
-      params: ['1000000000000000000'],
-      chain: 'base',
-      block: blockNow,
-    }),
-    sdk.api.abi.call({
-      target: stTD,
-      abi: 'function convertToAssets(uint256) view returns (uint256)',
-      params: ['1000000000000000000'],
-      chain: 'base',
-      block: block7d,
-    }),
-  ]);
+    const [totalAssets, ppsNow, pps7d] = await Promise.all([
+      sdk.api.abi.call({
+        target: stTD,
+        abi: 'uint256:totalAssets',
+        chain: 'base',
+        block: blockNow,
+      }),
+      sdk.api.abi.call({
+        target: stTD,
+        abi: 'function convertToAssets(uint256) view returns (uint256)',
+        params: ['1000000000000000000'],
+        chain: 'base',
+        block: blockNow,
+      }),
+      sdk.api.abi.call({
+        target: stTD,
+        abi: 'function convertToAssets(uint256) view returns (uint256)',
+        params: ['1000000000000000000'],
+        chain: 'base',
+        block: block7d,
+      }),
+    ]);
 
-  const tvlRaw = Number(totalAssets.output) / 1e18;
+    if (totalAssets?.output == null || ppsNow?.output == null || pps7d?.output == null) {
+      return [];
+    }
 
-  const prices = await utils.getPrices([TD], 'base');
-  const tdPrice = prices.pricesByAddress?.[TD.toLowerCase()] ?? 1;
+    const tvlRaw = Number(totalAssets.output) / 1e18;
 
-  const tvlUsd = tvlRaw * tdPrice;
+    const prices = await utils.getPrices([TD], 'base');
+    const tdPrice = prices.pricesByAddress?.[TD.toLowerCase()] ?? 1;
 
-  const priceNow = Number(ppsNow.output) / 1e18;
-  const price7dAgo = Number(pps7d.output) / 1e18;
-  const apyBase = price7dAgo > 0
-    ? ((priceNow / price7dAgo) ** (365 / 7) - 1) * 100
-    : 0;
+    const tvlUsd = tvlRaw * tdPrice;
 
-  return [
-    {
-      pool: stTD,
-      symbol: 'stTD',
-      project: 'tizi',
-      chain: utils.formatChain('base'),
-      tvlUsd,
-      apyBase,
-      pricePerShare: priceNow,
-      underlyingTokens: [TD],
-      token: stTD,
-      isIntrinsicSource: true,
-      searchTokenOverride: 'stTD',
-    },
-  ];
+    const priceNow = Number(ppsNow.output) / 1e18;
+    const price7dAgo = Number(pps7d.output) / 1e18;
+    const apyBase = price7dAgo > 0
+      ? ((priceNow / price7dAgo) ** (365 / 7) - 1) * 100
+      : 0;
+
+    return [
+      {
+        pool: stTD,
+        symbol: 'stTD',
+        project: 'tizi',
+        chain: utils.formatChain('base'),
+        tvlUsd,
+        apyBase,
+        pricePerShare: priceNow,
+        underlyingTokens: [TD],
+        token: stTD,
+        isIntrinsicSource: true,
+        searchTokenOverride: 'stTD',
+      },
+    ];
+  } catch (e) {
+    console.error('tizi adapter error:', e.message);
+    return [];
+  }
 };
 
 module.exports = {

--- a/src/adaptors/tizi/index.js
+++ b/src/adaptors/tizi/index.js
@@ -63,6 +63,8 @@ const apy = async () => {
       pricePerShare: priceNow,
       underlyingTokens: [TD],
       token: stTD,
+      isIntrinsicSource: true,
+      searchTokenOverride: 'stTD',
     },
   ];
 };

--- a/src/adaptors/tizi/index.js
+++ b/src/adaptors/tizi/index.js
@@ -1,68 +1,56 @@
 const sdk = require('@defillama/sdk');
+const axios = require('axios');
 const utils = require('../utils');
 
 const TD = '0x469bbd88eEA8A2D9a5C6c82d9890Cf60962C27e6';
 const stTD = '0x0CB091e6D9fd696b4CC8571E19e042F456c182Ad';
 
-const YEAR_IN_SECONDS = 31536000;
+const DAY = 24 * 3600;
 
 const apy = async () => {
-  const block = await sdk.api.util.getLatestBlock('base');
+  const now = Math.floor(Date.now() / 1e3);
+  const sevenDaysAgo = now - 7 * DAY;
 
-  const [totalAssetsRes, unreleasedRes, releasePeriodRes, lastYieldTimeRes] =
-    await Promise.all([
-      sdk.api.abi.call({
-        target: stTD,
-        abi: 'uint256:totalAssets',
-        chain: 'base',
-      }),
-      sdk.api.abi.call({
-        target: stTD,
-        abi: 'uint256:getUnreleasedAmount',
-        chain: 'base',
-      }),
-      sdk.api.abi.call({
-        target: stTD,
-        abi: 'uint256:releasePeriod',
-        chain: 'base',
-      }),
-      sdk.api.abi.call({
-        target: stTD,
-        abi: 'uint256:lastYieldTime',
-        chain: 'base',
-      }),
-    ]);
+  const [blockNow, block7d] = await Promise.all([
+    axios.get(`https://coins.llama.fi/block/base/${now}`).then((r) => r.data.height),
+    axios.get(`https://coins.llama.fi/block/base/${sevenDaysAgo}`).then((r) => r.data.height),
+  ]);
 
-  const totalAssets = Number(totalAssetsRes.output) / 1e18;
-  const unreleasedAmount = Number(unreleasedRes.output) / 1e18;
-  const releasePeriod = Number(releasePeriodRes.output);
-  const lastYieldTime = Number(lastYieldTimeRes.output);
+  const [totalAssets, ppsNow, pps7d] = await Promise.all([
+    sdk.api.abi.call({
+      target: stTD,
+      abi: 'uint256:totalAssets',
+      chain: 'base',
+      block: blockNow,
+    }),
+    sdk.api.abi.call({
+      target: stTD,
+      abi: 'function convertToAssets(uint256) view returns (uint256)',
+      params: ['1000000000000000000'],
+      chain: 'base',
+      block: blockNow,
+    }),
+    sdk.api.abi.call({
+      target: stTD,
+      abi: 'function convertToAssets(uint256) view returns (uint256)',
+      params: ['1000000000000000000'],
+      chain: 'base',
+      block: block7d,
+    }),
+  ]);
 
-  const tvlUsd = totalAssets;
+  const tvlRaw = Number(totalAssets.output) / 1e18;
 
-  let apyBase = 0;
-  const remainTime = releasePeriod - (block.timestamp - lastYieldTime);
+  const prices = await utils.getPrices([TD], 'base');
+  const tdPrice = prices.pricesByAddress?.[TD.toLowerCase()] ?? 1;
 
-  if (unreleasedAmount > 0 && remainTime > 0 && totalAssets > 0) {
-    const aprBase =
-      (unreleasedAmount * YEAR_IN_SECONDS * 100) / (totalAssets * remainTime);
-    apyBase = utils.aprToApy(aprBase, 365);
-  }
+  const tvlUsd = tvlRaw * tdPrice;
 
-  let pricePerShare;
-  try {
-    pricePerShare =
-      (
-        await sdk.api.abi.call({
-          target: stTD,
-          abi: 'function convertToAssets(uint256 shares) view returns (uint256)',
-          params: ['1000000000000000000'],
-          chain: 'base',
-        })
-      ).output / 1e18;
-  } catch (e) {
-    pricePerShare = null;
-  }
+  const priceNow = Number(ppsNow.output) / 1e18;
+  const price7dAgo = Number(pps7d.output) / 1e18;
+  const apyBase = price7dAgo > 0
+    ? ((priceNow / price7dAgo) ** (365 / 7) - 1) * 100
+    : 0;
 
   return [
     {
@@ -72,8 +60,7 @@ const apy = async () => {
       chain: utils.formatChain('base'),
       tvlUsd,
       apyBase,
-      pricePerShare: pricePerShare > 0 ? +pricePerShare.toFixed(6) : null,
-      poolMeta: '7 days unstaking, 7 days linear release',
+      pricePerShare: priceNow,
       underlyingTokens: [TD],
       token: stTD,
     },
@@ -82,5 +69,6 @@ const apy = async () => {
 
 module.exports = {
   apy,
-  url: 'https://tizi.money/',
+  url: 'https://tizi.money/deposit',
+  protocolId: '7787',
 };

--- a/src/adaptors/tizi/index.js
+++ b/src/adaptors/tizi/index.js
@@ -1,0 +1,86 @@
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+const TD = '0x469bbd88eEA8A2D9a5C6c82d9890Cf60962C27e6';
+const stTD = '0x0CB091e6D9fd696b4CC8571E19e042F456c182Ad';
+
+const YEAR_IN_SECONDS = 31536000;
+
+const apy = async () => {
+  const block = await sdk.api.util.getLatestBlock('base');
+
+  const [totalAssetsRes, unreleasedRes, releasePeriodRes, lastYieldTimeRes] =
+    await Promise.all([
+      sdk.api.abi.call({
+        target: stTD,
+        abi: 'uint256:totalAssets',
+        chain: 'base',
+      }),
+      sdk.api.abi.call({
+        target: stTD,
+        abi: 'uint256:getUnreleasedAmount',
+        chain: 'base',
+      }),
+      sdk.api.abi.call({
+        target: stTD,
+        abi: 'uint256:releasePeriod',
+        chain: 'base',
+      }),
+      sdk.api.abi.call({
+        target: stTD,
+        abi: 'uint256:lastYieldTime',
+        chain: 'base',
+      }),
+    ]);
+
+  const totalAssets = Number(totalAssetsRes.output) / 1e18;
+  const unreleasedAmount = Number(unreleasedRes.output) / 1e18;
+  const releasePeriod = Number(releasePeriodRes.output);
+  const lastYieldTime = Number(lastYieldTimeRes.output);
+
+  const tvlUsd = totalAssets;
+
+  let apyBase = 0;
+  const remainTime = releasePeriod - (block.timestamp - lastYieldTime);
+
+  if (unreleasedAmount > 0 && remainTime > 0 && totalAssets > 0) {
+    const aprBase =
+      (unreleasedAmount * YEAR_IN_SECONDS * 100) / (totalAssets * remainTime);
+    apyBase = utils.aprToApy(aprBase, 365);
+  }
+
+  let pricePerShare;
+  try {
+    pricePerShare =
+      (
+        await sdk.api.abi.call({
+          target: stTD,
+          abi: 'function convertToAssets(uint256 shares) view returns (uint256)',
+          params: ['1000000000000000000'],
+          chain: 'base',
+        })
+      ).output / 1e18;
+  } catch (e) {
+    pricePerShare = null;
+  }
+
+  return [
+    {
+      pool: stTD,
+      symbol: 'stTD',
+      project: 'tizi',
+      chain: utils.formatChain('base'),
+      tvlUsd,
+      apyBase,
+      pricePerShare: pricePerShare > 0 ? +pricePerShare.toFixed(6) : null,
+      poolMeta: '7 days unstaking, 7 days linear release',
+      underlyingTokens: [TD],
+      token: stTD,
+    },
+  ];
+};
+
+module.exports = {
+  apy,
+  url: 'https://tizi.money/',
+};


### PR DESCRIPTION
## Add Tizi yield adapter

**Protocol**: Tizi — yield-bearing stablecoin protocol on Base. Users stake TD (1:1 pegged to USDC) to receive stTD (ERC-4626 vault).

**Contracts**:
- TD: `0x469bbd88eEA8A2D9a5C6c82d9890Cf60962C27e6`  
- stTD: `0x0CB091e6D9fd696b4CC8571E19e042F456c182Ad`

**APY methodology**: Reads contract state directly:
- `APR = (unreleasedAmount × 31536000 × 100) / (totalAssets × remainTime)`
- Sourced from `totalAssets()`, `getUnreleasedAmount()`, `releasePeriod`, `lastYieldTime`
- Converted to APY via daily compounding

**TVL**: `totalAssets()` (TD = $1)

**Pool**: stTD — 7 days unstaking, 7 days linear yield release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tizi protocol integration on Base, enabling users to view updated APY and TVL metrics for tizi pools (including share price information).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->