### PR TITLE
accountable: add ethereum support and use API TVL

### DIFF
--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -2,7 +2,7 @@ const sdk = require('@defillama/sdk');
 const utils = require('../utils');
 
 const API_URL = 'https://yield.accountable.capital/api/loan';
-const chainIdToName = { 143: 'monad', 4114: 'citrea' };
+const chainIdToName = { 1: 'ethereum', 143: 'monad', 4114: 'citrea' };
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const abis = {
@@ -205,7 +205,10 @@ const apy = async() => {
                 chain: utils.formatChain(chainName),
                 project: 'accountable',
                 symbol: item.asset_symbol,
-                tvlUsd: toUsd(stats.tvl),
+                // Vault size (total deposited), straight from the API. These
+                // credit vaults run ~fully lent, so the on-chain idle-liquidity
+                // figure is ~$0 and would hide them below DefiLlama's thresholds.
+                tvlUsd: item.tvl_in_usd ?? null,
                 apyBase: baseApy,
                 apyReward: totalApyReward,
                 rewardTokens: combinedRewardTokens,


### PR DESCRIPTION
Two small changes to the accountable adapter:

- Add ethereum (chain id 1) to the chain map so ethereum vaults are included.
- Report tvlUsd from the API's tvl_in_usd (total deposited) instead of on-chain idle liquidity, which is ~$0 for these ~fully-lent credit vaults and would otherwise hide them below the TVL thresholds.

Pricing (decimals + price) for totalSupplyUsd/totalBorrowUsd is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ethereum chain support to loan filtering and per-chain processing.

* **Bug Fixes**
  * TVL now uses API-provided values to ensure credit vaults with low on-chain idle liquidity remain visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->