### PR TITLE
origami-finance: call origami server vault-apy endpoint

### DIFF
--- a/src/adaptors/origami-finance/index.js
+++ b/src/adaptors/origami-finance/index.js
@@ -141,7 +141,7 @@ async function vaultKindTvl(api, balances, kind, vault) {
     case 'AUTO_STAKING':
       return autoStakingTvl(api, balances, vault);
     default:
-      return undefined;
+      throw new Error(`Unsupported vault kind: ${kind}`);
   }
 }
 
@@ -153,14 +153,10 @@ async function vaultKindTvl(api, balances, kind, vault) {
  */
 async function vaultTvlUsd(api, chain, vault) {
   const balances = new sdk.Balances({ chain });
-  try {
-    for (const kind of vault.vault_kinds) {
-      await vaultKindTvl(api, balances, kind, vault.address);
-    }
-    return Math.max(0, await balances.getUSDValue());
-  } catch {
-    return 0;
+  for (const kind of vault.vault_kinds) {
+    await vaultKindTvl(api, balances, kind, vault.address);
   }
+  return Math.max(0, await balances.getUSDValue());
 }
 
 /**

--- a/src/adaptors/origami-finance/index.js
+++ b/src/adaptors/origami-finance/index.js
@@ -1,123 +1,96 @@
-const { request, gql } = require('graphql-request');
+const axios = require('axios');
 const {
   utils: { getAddress },
 } = require('ethers');
 
-const GRAPH_URLS = {
-  ethereum: {
-    chainId: 1,
-    subgraphUrl: 'https://api.goldsky.com/api/public/project_cmgzm4q1q009c5np2angrczxw/subgraphs/origami-mainnet/prod/gn',
-  },
-  arbitrum: {
-    chainId: 42161,
-    subgraphUrl: 'https://api.goldsky.com/api/public/project_cmgzm4q1q009c5np2angrczxw/subgraphs/origami-arbitrum/prod/gn',
-  },
-  berachain: {
-    chainId: 80094,
-    subgraphUrl: 'https://api.goldsky.com/api/public/project_cmgzm4q1q009c5np2angrczxw/subgraphs/origami-berachain/prod/gn',
-  },
+const API_HOST = 'https://origami-api.automation-templedao.link';
+
+const CHAINS = {
+  ethereum: 1,
+  berachain: 80094,
+  plasma: 9745,
+};
+
+/**
+ * Build the vault-apy request URL for a chain. The endpoint takes a single
+ * url-encoded JSON `input`; omitting `vault` returns every vault on the chain.
+ * @param {number} chainId
+ * @returns {string}
+ */
+function getVaultApyUrl(chainId) {
+  const input = encodeURIComponent(JSON.stringify({ chain: chainId }));
+  return `${API_HOST}/public/external/vault-apy?input=${input}`;
 }
 
-function getSubgraphQuery() {
-  const nowUnix = Math.floor(new Date().getTime() / 1000);
-  return gql`
-  {
-    vaults {
-      id
-      symbol
-      vaultKinds
-      underlyingTokens
-      latestMetrics: metrics(
-        where: {
-          metricsType: LATEST
-        }
-      ) {
-        vaultPriceBasedApr
-        totalTvlUSD
-      }
-
-      averageMetrics: metrics(
-        where: {
-         metricsType_not: LATEST
-        }
-      ) {
-        yieldSpreadApr
-      }
-
-      offchainPoints(
-        where: {
-          and: [
-            {
-              or: [
-                {end: "0"},
-                {end_gte: "${nowUnix}"},
-              ],
-            },
-            {
-              or: [
-                {start: "0"},
-                {start_lte: "${nowUnix}"},
-              ],
-            },
-          ],
-        }
-        orderBy: sortWeight,
-        orderDirection: asc
-      ) {
-        averageMetrics: metrics(
-          where: {
-            metricsType_not: LATEST
-          }
-        ) {
-          apr
-        }
-      }
-    }
-  }`;
-}
-
+/**
+ * Map one endpoint vault into the DefiLlama yield-server pool shape.
+ * @param {string} chain
+ * @param {number} chainId
+ * @param {VaultApy} vault
+ * @returns {Pool}
+ */
 function vaultApy(chain, chainId, vault) {
-  let isLeveraged = vault.vaultKinds.includes("Leverage");
-
-  let totalApr = 0;
-  if (isLeveraged) {
-    const totalPendleBasedAPr = vault.offchainPoints
-      .map(op => parseFloat(op.averageMetrics[0].apr))
-      .reduce((total, apr) => total + apr, 0);
-    totalApr = (parseFloat(vault.averageMetrics[0].yieldSpreadApr) + totalPendleBasedAPr);   
-  } else {
-    totalApr = vault.latestMetrics[0].vaultPriceBasedApr;
-  }
-
-  const result = {
-    pool: `${vault.id}-${chain}`,
+  return {
+    pool: `${vault.address}-${chain}`,
     chain: chain,
     project: 'origami-finance',
     symbol: vault.symbol,
-    tvlUsd: parseFloat(vault.latestMetrics[0].totalTvlUSD),
-    apyBase: (Math.exp(totalApr / 100) - 1) * 100,
-    underlyingTokens: vault.underlyingTokens,
-    url: `https://origami.finance/vaults/${chainId}-${getAddress(vault.id)}/info`,
+    tvlUsd: Math.max(0, vault.total_tvl_usd),
+    apyBase: vault.apy,
+    underlyingTokens: vault.underlying_tokens,
+    url: `https://origami.finance/vaults/${chainId}-${getAddress(
+      vault.address
+    )}/info`,
   };
-  return result;
 }
 
-async function chainApy(chain, config, sgraphQuery) {
-  const chainResults = await request(config.subgraphUrl, sgraphQuery);
-  return chainResults.vaults.map(vault => vaultApy(chain, config.chainId, vault));
+/**
+ * Fetch and map every vault on a single chain.
+ * @param {string} chain
+ * @param {number} chainId
+ * @returns {Promise<Pool[]>}
+ */
+async function chainApy(chain, chainId) {
+  /** @type {{ data: VaultApyResponse }} */
+  const { data } = await axios.get(getVaultApyUrl(chainId));
+  return data.vaults.map((vault) => vaultApy(chain, chainId, vault));
 }
 
 const apy = async () => {
-  const sgraphQuery = getSubgraphQuery();
-
   const results = await Promise.all(
-    Object.keys(GRAPH_URLS).map(async (chainName) => await chainApy(chainName, GRAPH_URLS[chainName], sgraphQuery))
+    Object.entries(CHAINS).map(([chain, chainId]) => chainApy(chain, chainId))
   );
 
   return results.flat();
 };
-  
+
 module.exports = {
   timetravel: false,
   apy,
 };
+
+/**
+ * @typedef {Object} VaultApy
+ * @property {string} address - Vault contract address (lowercased).
+ * @property {string} symbol - Vault token symbol.
+ * @property {number} total_tvl_usd - Vault TVL in USD.
+ * @property {string[]} underlying_tokens - Underlying token addresses.
+ * @property {number} apy - Net APY in percent (already compounded server-side).
+ */
+
+/**
+ * @typedef {Object} VaultApyResponse
+ * @property {VaultApy[]} vaults
+ */
+
+/**
+ * @typedef {Object} Pool
+ * @property {string} pool - Stable unique id: `<vaultAddress>-<chain>`.
+ * @property {string} chain
+ * @property {string} project - Always `origami-finance`.
+ * @property {string} symbol
+ * @property {number} tvlUsd
+ * @property {number} apyBase
+ * @property {string[]} underlyingTokens
+ * @property {string} url
+ */

--- a/src/adaptors/origami-finance/index.js
+++ b/src/adaptors/origami-finance/index.js
@@ -52,16 +52,18 @@ function vaultApy(chain, chainId, vault) {
  */
 async function chainApy(chain, chainId) {
   /** @type {{ data: VaultApyResponse }} */
-  const { data } = await axios.get(getVaultApyUrl(chainId));
+  const { data } = await axios.get(getVaultApyUrl(chainId), {
+    timeout: 10_000,
+  });
   return data.vaults.map((vault) => vaultApy(chain, chainId, vault));
 }
 
 const apy = async () => {
-  const results = await Promise.all(
+  const results = await Promise.allSettled(
     Object.entries(CHAINS).map(([chain, chainId]) => chainApy(chain, chainId))
   );
 
-  return results.flat();
+  return results.flatMap((r) => (r.status === 'fulfilled' ? r.value : []));
 };
 
 module.exports = {

--- a/src/adaptors/origami-finance/index.js
+++ b/src/adaptors/origami-finance/index.js
@@ -188,10 +188,10 @@ async function chainPools(chain, chainId) {
 }
 
 const apy = async () => {
-  const results = await Promise.all(
+  const results = await Promise.allSettled(
     Object.entries(CHAINS).map(([chain, chainId]) => chainPools(chain, chainId))
   );
-  return results.flat();
+  return results.flatMap((r) => (r.status === 'fulfilled' ? r.value : []));
 };
 
 module.exports = {

--- a/src/adaptors/origami-finance/index.js
+++ b/src/adaptors/origami-finance/index.js
@@ -1,3 +1,4 @@
+const sdk = require('@defillama/sdk');
 const axios = require('axios');
 const {
   utils: { getAddress },
@@ -12,8 +13,6 @@ const CHAINS = {
 };
 
 /**
- * Build the vault-apy request URL for a chain. The endpoint takes a single
- * url-encoded JSON `input`; omitting `vault` returns every vault on the chain.
  * @param {number} chainId
  * @returns {string}
  */
@@ -23,47 +22,180 @@ function getVaultApyUrl(chainId) {
 }
 
 /**
- * Map one endpoint vault into the DefiLlama yield-server pool shape.
- * @param {string} chain
- * @param {number} chainId
- * @param {VaultApy} vault
- * @returns {Pool}
+ * @param {string | number | bigint} x
+ * @returns {bigint}
  */
-function vaultApy(chain, chainId, vault) {
-  return {
-    pool: `${vault.address}-${chain}`,
-    chain: chain,
-    project: 'origami-finance',
-    symbol: vault.symbol,
-    tvlUsd: Math.max(0, vault.total_tvl_usd),
-    apyBase: vault.apy,
-    underlyingTokens: vault.underlying_tokens,
-    url: `https://origami.finance/vaults/${chainId}-${getAddress(
-      vault.address
-    )}/info`,
-  };
+const bi = (x) => BigInt(String(x));
+
+/**
+ * @param {ChainApi} api
+ * @param {Balances} balances
+ * @param {string} vault
+ * @returns {Promise<void>}
+ */
+async function leverageTvl(api, balances, vault) {
+  const [reserveToken, al] = await Promise.all([
+    api.call({ abi: 'address:reserveToken', target: vault }),
+    api.call({
+      abi: 'function assetsAndLiabilities() external view returns (uint256 assets, uint256 liabilities, uint256 ratio)',
+      target: vault,
+    }),
+  ]);
+  balances.addToken(reserveToken, bi(al.assets) - bi(al.liabilities));
 }
 
 /**
- * Fetch and map every vault on a single chain.
+ * @param {ChainApi} api
+ * @param {Balances} balances
+ * @param {string} vault
+ * @returns {Promise<void>}
+ */
+async function repricingTvl(api, balances, vault) {
+  const [decimals, supply, reserve, reserveToken] = await Promise.all([
+    api.call({ abi: 'uint8:decimals', target: vault }),
+    api.call({ abi: 'uint256:totalSupply', target: vault }),
+    api.call({ abi: 'uint256:reservesPerShare', target: vault }),
+    api.call({ abi: 'address:reserveToken', target: vault }),
+  ]);
+  const baseToken = await api.call({
+    abi: 'address:baseToken',
+    target: reserveToken,
+  });
+  const bal = (bi(reserve) * bi(supply)) / 10n ** bi(decimals);
+  balances.addToken(baseToken, bal);
+}
+
+/**
+ * @param {ChainApi} api
+ * @param {Balances} balances
+ * @param {string} vault
+ * @returns {Promise<void>}
+ */
+async function erc4626Tvl(api, balances, vault) {
+  const [asset, totalAssets] = await Promise.all([
+    api.call({ abi: 'address:asset', target: vault }),
+    api.call({ abi: 'uint256:totalAssets', target: vault }),
+  ]);
+  balances.addToken(asset, String(totalAssets));
+}
+
+/**
+ * @param {ChainApi} api
+ * @param {Balances} balances
+ * @param {string} vault
+ * @returns {Promise<void>}
+ */
+async function balanceSheetTvl(api, balances, vault) {
+  const [tokens, sheet] = await Promise.all([
+    api.call({
+      abi: 'function tokens() external view returns (address[] assetTokens, address[] liabilityTokens)',
+      target: vault,
+    }),
+    api.call({
+      abi: 'function balanceSheet() external view returns (uint256[] totalAssets, uint256[] totalLiabilities)',
+      target: vault,
+    }),
+  ]);
+  tokens.assetTokens.forEach((token, j) =>
+    balances.addToken(token, String(sheet.totalAssets[j]))
+  );
+  tokens.liabilityTokens.forEach((token, j) =>
+    balances.subtractToken(token, String(sheet.totalLiabilities[j]))
+  );
+}
+
+/**
+ * @param {ChainApi} api
+ * @param {Balances} balances
+ * @param {string} vault
+ * @returns {Promise<void>}
+ */
+async function autoStakingTvl(api, balances, vault) {
+  const [stakingToken, totalSupply] = await Promise.all([
+    api.call({
+      abi: 'function stakingToken() external view returns (address)',
+      target: vault,
+    }),
+    api.call({ abi: 'uint256:totalSupply', target: vault }),
+  ]);
+  balances.addToken(stakingToken, String(totalSupply));
+}
+
+/**
+ * @param {ChainApi} api
+ * @param {Balances} balances
+ * @param {VaultKind} kind
+ * @param {string} vault
+ * @returns {Promise<void>}
+ */
+async function vaultKindTvl(api, balances, kind, vault) {
+  switch (kind) {
+    case 'LEVERAGE':
+      return leverageTvl(api, balances, vault);
+    case 'REPRICING':
+      return repricingTvl(api, balances, vault);
+    case 'ERC4626':
+      return erc4626Tvl(api, balances, vault);
+    case 'BALANCE_SHEET':
+      return balanceSheetTvl(api, balances, vault);
+    case 'AUTO_STAKING':
+      return autoStakingTvl(api, balances, vault);
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * @param {ChainApi} api
+ * @param {string} chain
+ * @param {VaultApy} vault
+ * @returns {Promise<number>}
+ */
+async function vaultTvlUsd(api, chain, vault) {
+  const balances = new sdk.Balances({ chain });
+  try {
+    for (const kind of vault.vault_kinds) {
+      await vaultKindTvl(api, balances, kind, vault.address);
+    }
+    return Math.max(0, await balances.getUSDValue());
+  } catch {
+    return 0;
+  }
+}
+
+/**
  * @param {string} chain
  * @param {number} chainId
  * @returns {Promise<Pool[]>}
  */
-async function chainApy(chain, chainId) {
-  /** @type {{ data: VaultApyResponse }} */
+async function chainPools(chain, chainId) {
+  const api = new sdk.ChainApi({ chain });
   const { data } = await axios.get(getVaultApyUrl(chainId), {
     timeout: 10_000,
   });
-  return data.vaults.map((vault) => vaultApy(chain, chainId, vault));
+
+  const results = await Promise.allSettled(
+    data.vaults.map(async (vault) => ({
+      pool: `${vault.address}-${chain}`,
+      chain: chain,
+      project: 'origami-finance',
+      symbol: vault.symbol,
+      tvlUsd: await vaultTvlUsd(api, chain, vault),
+      apyBase: vault.apy,
+      underlyingTokens: vault.underlying_tokens,
+      url: `https://origami.finance/vaults/${chainId}-${getAddress(
+        vault.address
+      )}/info`,
+    }))
+  );
+  return results.flatMap((r) => (r.status === 'fulfilled' ? r.value : []));
 }
 
 const apy = async () => {
-  const results = await Promise.allSettled(
-    Object.entries(CHAINS).map(([chain, chainId]) => chainApy(chain, chainId))
+  const results = await Promise.all(
+    Object.entries(CHAINS).map(([chain, chainId]) => chainPools(chain, chainId))
   );
-
-  return results.flatMap((r) => (r.status === 'fulfilled' ? r.value : []));
+  return results.flat();
 };
 
 module.exports = {
@@ -71,25 +203,27 @@ module.exports = {
   apy,
 };
 
+/** @typedef {import('@defillama/sdk').ChainApi} ChainApi */
+/** @typedef {import('@defillama/sdk').Balances} Balances */
+
 /**
- * @typedef {Object} VaultApy
- * @property {string} address - Vault contract address (lowercased).
- * @property {string} symbol - Vault token symbol.
- * @property {number} total_tvl_usd - Vault TVL in USD.
- * @property {string[]} underlying_tokens - Underlying token addresses.
- * @property {number} apy - Net APY in percent (already compounded server-side).
+ * @typedef {'ERC4626' | 'REPRICING' | 'LEVERAGE' | 'BALANCE_SHEET' | 'AUTO_STAKING'} VaultKind
  */
 
 /**
- * @typedef {Object} VaultApyResponse
- * @property {VaultApy[]} vaults
+ * @typedef {Object} VaultApy
+ * @property {string} address
+ * @property {string} symbol
+ * @property {VaultKind[]} vault_kinds
+ * @property {string[]} underlying_tokens
+ * @property {number} apy
  */
 
 /**
  * @typedef {Object} Pool
- * @property {string} pool - Stable unique id: `<vaultAddress>-<chain>`.
+ * @property {string} pool
  * @property {string} chain
- * @property {string} project - Always `origami-finance`.
+ * @property {string} project
  * @property {string} symbol
  * @property {number} tvlUsd
  * @property {number} apyBase


### PR DESCRIPTION
Switches the origami-finance yield adapter from the Goldsky subgraph to Origami API.  
The API wraps Ponder indexer onchain data, and upstream  APYs are fetched from sources such as Pendle and Merkle APIs.  

- The new endpoint returns the metrics/details for Origami's OPAL vaults
- Removed `arbitrum` from the adapter and added `plasma`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated Origami vault sourcing to use a single external APY provider endpoint. Multi-chain pool listings now reflect provider APY, include underlying token details, and link directly to each vault. TVL is recalculated on-chain per vault (with non-negative clamping).
* **Bug Fixes**
  * Improved aggregation resilience by isolating failures: individual vault TVL computations that error are skipped, while successful vaults across all configured chains are still included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->