### PR TITLE
accountable: fix NAV vault APY (use annualized APY from API)

### DIFF
--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -193,19 +193,26 @@ const apy = async() => {
                         ? Number(item.net_apy) - (rewardBoostPct + pointBoostPct)
                         : null;
 
+            // Rewards must be live tokens only (DefiLlama policy). Points (e.g.
+            // ACC, not yet launched) are excluded from apyReward / rewardTokens
+            // and surfaced via poolMeta instead.
             const rewardTokens = Array.from(
-                new Set([
-                    ...(item?.rewards_apy_boost?.boosts_by_token || [])
+                new Set(
+                    (item?.rewards_apy_boost?.boosts_by_token || [])
                         .map((b) => b?.token_address)
                         .filter(Boolean)
-                        .map((addr) => addr.toLowerCase()),
-                    ...(item?.all_points_apy_boost?.boosts_by_points || [])
-                        .map((b) => b?.point_name)
-                        .filter(Boolean),
-                ])
+                        .map((addr) => addr.toLowerCase())
+                )
             );
 
-            const apyReward = rewardTokens.length ? rewardBoostPct + pointBoostPct || null : null;
+            const apyReward = rewardTokens.length ? rewardBoostPct || null : null;
+
+            const pointNames = (item?.all_points_apy_boost?.boosts_by_points || [])
+                .map((b) => b?.point_name)
+                .filter(Boolean);
+            const poolMeta = pointNames.length
+                ? `Earn ${pointNames.join(', ')} Points`
+                : undefined;
 
             return {
                 pool: `${item.loan_address}-${chainName}`.toLowerCase(),
@@ -219,6 +226,7 @@ const apy = async() => {
                 apyBase: baseApy,
                 apyReward,
                 rewardTokens,
+                poolMeta,
                 url: `https://yield.accountable.capital/vaults/${item.loan_address}`,
                 totalSupplyUsd: toUsd(stats.totalAssets) ?? undefined,
                 totalBorrowUsd: toUsd(stats.totalBorrowed) ?? undefined,

--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -10,35 +10,18 @@ const abis = {
     convertToAssets: 'function convertToAssets(uint256 shares) view returns (uint256)',
 };
 
-// The marketplace API rate-limits bursts of per-loan requests (503), so we
-// fetch in small batches with a short retry. Dropping a loan here means its
-// vault never reaches the on-chain multicall, leaving totalSupplyUsd /
-// totalBorrowUsd / underlyingTokens undefined for that pool.
-const fetchLoan = async(id, tries = 3) => {
-    for (let attempt = 0; attempt < tries; attempt++) {
-        try {
-            return await utils.getData(`${API_URL}/${id}`);
-        } catch (e) {
-            if (attempt === tries - 1) throw e;
-            await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
-        }
-    }
-};
-
 const fetchVaultsByLoanIds = async(loanIds) => {
-    const acc = {};
-    const BATCH = 4;
-    for (let i = 0; i < loanIds.length; i += BATCH) {
-        const batch = loanIds.slice(i, i + BATCH);
-        const results = await Promise.allSettled(batch.map((id) => fetchLoan(id)));
-        results.forEach((res, idx) => {
-            if (res.status !== 'fulfilled') return;
-            const vault = res.value.on_chain_loan.loan.vault;
-            if (vault && vault !== ZERO_ADDRESS)
-                acc[batch[idx]] = vault.toLowerCase();
-        });
-    }
-    return acc;
+    const results = await Promise.allSettled(
+        loanIds.map((id) => utils.getData(`${API_URL}/${id}`))
+    );
+
+    return results.reduce((acc, res, idx) => {
+        if (res.status !== 'fulfilled') return acc;
+        const vault = res.value.on_chain_loan.loan.vault;
+        if (vault && vault !== ZERO_ADDRESS)
+            acc[loanIds[idx]] = vault.toLowerCase();
+        return acc;
+    }, {});
 };
 
 const getVaultAddressesFromApi = async() => {

--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -10,8 +10,6 @@ const abis = {
     convertToAssets: 'function convertToAssets(uint256 shares) view returns (uint256)',
 };
 
-const basisPointsToPercent = (value) => Number(value) / 1e4;
-
 const fetchVaultsByLoanIds = async(loanIds) => {
     const results = await Promise.allSettled(
         loanIds.map((id) => utils.getData(`${API_URL}/${id}`))
@@ -90,18 +88,6 @@ const getVaultStats = async(vaults, chain = 'monad') => {
     }, {});
 };
 
-const fetchBreakdowns = async(loanIds) => {
-    const results = await Promise.allSettled(
-        loanIds.map((id) => utils.getData(`${API_URL}/${id}/apy/breakdown`))
-    );
-
-    return results.reduce((acc, res, idx) => {
-        if (res.status !== 'fulfilled') return acc;
-        acc[loanIds[idx]] = res.value || {};
-        return acc;
-    }, {});
-};
-
 const apy = async() => {
     const { items } = await utils.getData(API_URL);
     const activeLoans = items.filter(
@@ -144,8 +130,6 @@ const apy = async() => {
         })
     );
 
-    const breakdowns = await fetchBreakdowns(loanIds);
-
     return Promise.all(
         activeLoans.map(async(item) => {
             const chainName = chainIdToName[item.chain_id];
@@ -159,45 +143,24 @@ const apy = async() => {
                 if (raw == null || decimals == null || priceUsd == null) return null;
                 return (Number(raw) / 10 ** decimals) * priceUsd;
             };
-            const pointBoosts = item?.all_points_apy_boost?.boosts_by_points || [];
+            const rewardBoostPct = Number(item?.rewards_apy_boost?.total_apy_boost_percent ?? 0);
+            const pointBoostPct = Number(item?.all_points_apy_boost?.total_apy_boost_percent ?? 0);
+            const totalApyReward = rewardBoostPct + pointBoostPct || null;
 
-            const breakdown = breakdowns[item.id]?.main || {};
-
-            const interestRate = Number(breakdown?.interest_rate);
-            const perfFeePctRaw = Number(breakdown?.performance_fee_percentage);
-            const perfFeePct =
-                !Number.isNaN(perfFeePctRaw) && perfFeePctRaw > 1 ? perfFeePctRaw / 100 : perfFeePctRaw;
-            const perfFeePoints = Number(breakdown?.performance_fee_points);
-            const netInterest = breakdown?.net_interest_rate;
             const baseApy =
-                netInterest != null
-                    ? Number(netInterest)
-                    : !Number.isNaN(interestRate) && !Number.isNaN(perfFeePct)
-                        ? interestRate * (1 - perfFeePct)
-                        : !Number.isNaN(interestRate) && !Number.isNaN(perfFeePoints)
-                            ? interestRate - perfFeePoints
-                            : basisPointsToPercent(item.apy);
+                item.apy_inception_annualized != null
+                    ? Number(item.apy_inception_annualized)
+                    : item.net_apy != null
+                        ? Number(item.net_apy) - (rewardBoostPct + pointBoostPct)
+                        : null;
 
-            const merklApy = Number(breakdown?.merkl_apy_boost?.total_apr ?? breakdown?.merkle_apy ?? 0);
-            const pointBoostsFromBreakdown = breakdown?.points_apy_boost?.boosts_by_points || pointBoosts;
-            const pointRewardApyFromBreakdown =
-                breakdown?.points_apy_boost?.total_apy_boost_percent ??
-                pointBoostsFromBreakdown.reduce((sum, b) => sum + Number(b?.apy_boost_percent || 0), 0);
-            const pointRewardTokens = pointBoostsFromBreakdown.map((b) => b?.point_name).filter(Boolean);
-
-            const merklTokens =
-                breakdown?.merkl_apy_boost?.tokens?.map((t) => t?.address?.toLowerCase()).filter(Boolean) || [];
-
-            const rewardsBoost = Number(breakdown?.rewards_apy_boost?.total_apy_boost_percent ?? 0);
-            const rewardBoostTokens =
-                breakdown?.rewards_apy_boost?.boosts_by_token
-                    ?.map((b) => b?.token?.address || b?.address || b?.token_address)
-                    .filter(Boolean)
-                    .map((addr) => addr.toLowerCase()) || [];
-
-            const totalApyReward = merklApy + pointRewardApyFromBreakdown + rewardsBoost || null;
-            const combinedRewardTokens = Array.from(
-                new Set([...(merklTokens || []), ...rewardBoostTokens, ...pointRewardTokens])
+            const rewardTokens = Array.from(
+                new Set(
+                    (item?.rewards_apy_boost?.boosts_by_token || [])
+                        .map((b) => b?.token_address)
+                        .filter(Boolean)
+                        .map((addr) => addr.toLowerCase())
+                )
             );
 
             return {
@@ -211,7 +174,7 @@ const apy = async() => {
                 tvlUsd: item.tvl_in_usd ?? null,
                 apyBase: baseApy,
                 apyReward: totalApyReward,
-                rewardTokens: combinedRewardTokens,
+                rewardTokens,
                 url: `https://yield.accountable.capital/vaults/${item.loan_address}`,
                 totalSupplyUsd: toUsd(stats.totalAssets),
                 totalBorrowUsd: toUsd(stats.totalBorrowed),

--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -10,18 +10,35 @@ const abis = {
     convertToAssets: 'function convertToAssets(uint256 shares) view returns (uint256)',
 };
 
-const fetchVaultsByLoanIds = async(loanIds) => {
-    const results = await Promise.allSettled(
-        loanIds.map((id) => utils.getData(`${API_URL}/${id}`))
-    );
+// The marketplace API rate-limits bursts of per-loan requests (503), so we
+// fetch in small batches with a short retry. Dropping a loan here means its
+// vault never reaches the on-chain multicall, leaving totalSupplyUsd /
+// totalBorrowUsd / underlyingTokens undefined for that pool.
+const fetchLoan = async(id, tries = 3) => {
+    for (let attempt = 0; attempt < tries; attempt++) {
+        try {
+            return await utils.getData(`${API_URL}/${id}`);
+        } catch (e) {
+            if (attempt === tries - 1) throw e;
+            await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+        }
+    }
+};
 
-    return results.reduce((acc, res, idx) => {
-        if (res.status !== 'fulfilled') return acc;
-        const vault = res.value.on_chain_loan.loan.vault;
-        if (vault && vault !== ZERO_ADDRESS)
-            acc[loanIds[idx]] = vault.toLowerCase();
-        return acc;
-    }, {});
+const fetchVaultsByLoanIds = async(loanIds) => {
+    const acc = {};
+    const BATCH = 4;
+    for (let i = 0; i < loanIds.length; i += BATCH) {
+        const batch = loanIds.slice(i, i + BATCH);
+        const results = await Promise.allSettled(batch.map((id) => fetchLoan(id)));
+        results.forEach((res, idx) => {
+            if (res.status !== 'fulfilled') return;
+            const vault = res.value.on_chain_loan.loan.vault;
+            if (vault && vault !== ZERO_ADDRESS)
+                acc[batch[idx]] = vault.toLowerCase();
+        });
+    }
+    return acc;
 };
 
 const getVaultAddressesFromApi = async() => {

--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -146,9 +146,17 @@ const apy = async() => {
             const rewardBoostPct = Number(item?.rewards_apy_boost?.total_apy_boost_percent ?? 0);
             const pointBoostPct = Number(item?.all_points_apy_boost?.total_apy_boost_percent ?? 0);
 
+            // Share-price (yield-strategy / NAV) vaults expose rolling-window net
+            // APY. Use the 7d window, falling back to 30d. We do NOT fall back to
+            // since-inception (maintainer caps the horizon at 30d), so a NAV vault
+            // younger than 7d reports no apyBase until a 7d/30d window exists.
+            // A non-null apy_inception_annualized is only the discriminator for NAV
+            // vaults here (contractual open/fixed-term vaults also carry apy_7d, so
+            // it can't be used for detection); they take the net_apy path.
+            const navWindowApy = item.apy_7d ?? item.apy_30d;
             const baseApy =
                 item.apy_inception_annualized != null
-                    ? Number(item.apy_inception_annualized)
+                    ? (navWindowApy != null ? Number(navWindowApy) : null)
                     : item.net_apy != null
                         ? Number(item.net_apy) - (rewardBoostPct + pointBoostPct)
                         : null;

--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -145,7 +145,6 @@ const apy = async() => {
             };
             const rewardBoostPct = Number(item?.rewards_apy_boost?.total_apy_boost_percent ?? 0);
             const pointBoostPct = Number(item?.all_points_apy_boost?.total_apy_boost_percent ?? 0);
-            const totalApyReward = rewardBoostPct + pointBoostPct || null;
 
             const baseApy =
                 item.apy_inception_annualized != null
@@ -166,6 +165,8 @@ const apy = async() => {
                 ])
             );
 
+            const apyReward = rewardTokens.length ? rewardBoostPct + pointBoostPct || null : null;
+
             return {
                 pool: `${item.loan_address}-${chainName}`.toLowerCase(),
                 chain: utils.formatChain(chainName),
@@ -176,7 +177,7 @@ const apy = async() => {
                 // figure is ~$0 and would hide them below DefiLlama's thresholds.
                 tvlUsd: item.tvl_in_usd ?? null,
                 apyBase: baseApy,
-                apyReward: totalApyReward,
+                apyReward,
                 rewardTokens,
                 url: `https://yield.accountable.capital/vaults/${item.loan_address}`,
                 totalSupplyUsd: toUsd(stats.totalAssets) ?? undefined,

--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -155,12 +155,15 @@ const apy = async() => {
                         : null;
 
             const rewardTokens = Array.from(
-                new Set(
-                    (item?.rewards_apy_boost?.boosts_by_token || [])
+                new Set([
+                    ...(item?.rewards_apy_boost?.boosts_by_token || [])
                         .map((b) => b?.token_address)
                         .filter(Boolean)
-                        .map((addr) => addr.toLowerCase())
-                )
+                        .map((addr) => addr.toLowerCase()),
+                    ...(item?.all_points_apy_boost?.boosts_by_points || [])
+                        .map((b) => b?.point_name)
+                        .filter(Boolean),
+                ])
             );
 
             return {
@@ -176,8 +179,8 @@ const apy = async() => {
                 apyReward: totalApyReward,
                 rewardTokens,
                 url: `https://yield.accountable.capital/vaults/${item.loan_address}`,
-                totalSupplyUsd: toUsd(stats.totalAssets),
-                totalBorrowUsd: toUsd(stats.totalBorrowed),
+                totalSupplyUsd: toUsd(stats.totalAssets) ?? undefined,
+                totalBorrowUsd: toUsd(stats.totalBorrowed) ?? undefined,
                 underlyingTokens: stats.underlying ? [stats.underlying] : undefined,
             };
         })

--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -8,20 +8,44 @@ const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const abis = {
     asset: 'function asset() view returns (address)',
     convertToAssets: 'function convertToAssets(uint256 shares) view returns (uint256)',
+    vault: 'function vault() view returns (address)',
 };
 
-const fetchVaultsByLoanIds = async(loanIds) => {
-    const results = await Promise.allSettled(
-        loanIds.map((id) => utils.getData(`${API_URL}/${id}`))
+// Resolve each loan's vault + underlying on-chain. The loan contract exposes
+// both vault() and asset(), so one multicall per chain replaces a per-loan API
+// request each. The marketplace API rate-limits those bursts (503), and a
+// dropped response previously left the pool with no vault -> no on-chain stats
+// (undefined totalSupplyUsd / totalBorrowUsd / underlyingTokens).
+const fetchLoanMeta = async(loansByChain) => {
+    const map = {};
+    await Promise.all(
+        Object.entries(loansByChain).map(async([chain, loans]) => {
+            const [vaultsRes, assetsRes] = await Promise.all([
+                sdk.api.abi.multiCall({
+                    chain,
+                    abi: abis.vault,
+                    calls: loans.map((l) => ({ target: l.loan_address })),
+                    permitFailure: true,
+                }),
+                sdk.api.abi.multiCall({
+                    chain,
+                    abi: abis.asset,
+                    calls: loans.map((l) => ({ target: l.loan_address })),
+                    permitFailure: true,
+                }),
+            ]);
+            loans.forEach((l, i) => {
+                const vault = vaultsRes.output[i].output;
+                const asset = assetsRes.output[i].output;
+                if (vault && vault !== ZERO_ADDRESS)
+                    map[l.id] = {
+                        vault: vault.toLowerCase(),
+                        asset: asset || null,
+                    };
+            });
+        })
     );
-
-    return results.reduce((acc, res, idx) => {
-        if (res.status !== 'fulfilled') return acc;
-        const vault = res.value.on_chain_loan.loan.vault;
-        if (vault && vault !== ZERO_ADDRESS)
-            acc[loanIds[idx]] = vault.toLowerCase();
-        return acc;
-    }, {});
+    return map;
 };
 
 const getVaultAddressesFromApi = async() => {
@@ -93,16 +117,20 @@ const apy = async() => {
     const activeLoans = items.filter(
         (item) => item.loan_state === 3 && chainIdToName[item.chain_id]
     );
-    const loanIds = activeLoans.map((item) => item.id);
 
-    const loanVaultMap = await fetchVaultsByLoanIds(loanIds);
+    const loansByChain = {};
+    activeLoans.forEach((item) => {
+        const chain = chainIdToName[item.chain_id];
+        (loansByChain[chain] ||= []).push(item);
+    });
+    const loanMetaMap = await fetchLoanMeta(loansByChain);
 
     const vaultsByChain = {};
     activeLoans.forEach((item) => {
-        const vault = loanVaultMap[item.id];
-        if (!vault) return;
+        const meta = loanMetaMap[item.id];
+        if (!meta) return;
         const chain = chainIdToName[item.chain_id];
-        (vaultsByChain[chain] ||= new Set()).add(vault);
+        (vaultsByChain[chain] ||= new Set()).add(meta.vault);
     });
     const vaultStats = {};
     await Promise.all(
@@ -115,10 +143,11 @@ const apy = async() => {
     );
 
     const underlyingsByChain = {};
-    Object.entries(vaultStats).forEach(([key, s]) => {
-        if (!s.underlying) return;
-        const chain = key.split(':')[0];
-        (underlyingsByChain[chain] ||= new Set()).add(s.underlying.toLowerCase());
+    activeLoans.forEach((item) => {
+        const meta = loanMetaMap[item.id];
+        if (!meta?.asset) return;
+        const chain = chainIdToName[item.chain_id];
+        (underlyingsByChain[chain] ||= new Set()).add(meta.asset.toLowerCase());
     });
     const pricesByChainToken = {};
     await Promise.all(
@@ -133,12 +162,15 @@ const apy = async() => {
     return Promise.all(
         activeLoans.map(async(item) => {
             const chainName = chainIdToName[item.chain_id];
-            const vaultAddress = loanVaultMap[item.id];
+            const meta = loanMetaMap[item.id];
+            const vaultAddress = meta?.vault;
             const stats = vaultAddress ? vaultStats[`${chainName}:${vaultAddress}`] || {} : {};
             const d = Number(item.asset_decimals);
             const decimals = Number.isFinite(d) ? d : null;
-            const underlying = stats.underlying?.toLowerCase();
-            const priceUsd = underlying ? pricesByChainToken[`${chainName}:${underlying}`] : undefined;
+            const underlying = meta?.asset || stats.underlying;
+            const priceUsd = underlying
+                ? pricesByChainToken[`${chainName}:${underlying.toLowerCase()}`]
+                : undefined;
             const toUsd = (raw) => {
                 if (raw == null || decimals == null || priceUsd == null) return null;
                 return (Number(raw) / 10 ** decimals) * priceUsd;
@@ -190,7 +222,7 @@ const apy = async() => {
                 url: `https://yield.accountable.capital/vaults/${item.loan_address}`,
                 totalSupplyUsd: toUsd(stats.totalAssets) ?? undefined,
                 totalBorrowUsd: toUsd(stats.totalBorrowed) ?? undefined,
-                underlyingTokens: stats.underlying ? [stats.underlying] : undefined,
+                underlyingTokens: underlying ? [underlying] : undefined,
             };
         })
     );


### PR DESCRIPTION
### What

For NAV / yield-strategy vaults the on-chain interest rate is `0` (returns come from share-price growth), so deriving APY from the per-vault `/apy/breakdown` `main` field — a short, non-annualized window — reported a near-zero / wrong APY (e.g. the Morini vault showed ~1.5% instead of ~24%).

This reads the already-annualized, net-of-fee figures the marketplace API exposes per pool instead:

- **apyBase**: `apy_inception_annualized` for yield-strategy vaults; otherwise `net_apy` minus the reward/points boosts for interest-bearing vaults.
- **apyReward**: sum of `rewards_apy_boost` and `all_points_apy_boost` totals.

It also drops the per-vault `/apy/breakdown` fetch (one fewer request per pool).

### Result

APY now matches the values shown in the Accountable app for every pool (verified against the live API, 0 difference across all active pools). No change to pool filtering, chain support, or TVL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated APY calculation to aggregate boost components directly, removing the extra breakdown-derived data previously used for display.
  * Reworked base APY derivation to use inception or net values adjusted by total boost percentages.
  * APY reward is now only populated when reward items are available, with reward tokens deduplicated and normalized for consistent presentation.
* **Bug Fixes**
  * Improved resilience when fetching vault/loan APY data, reducing rate-limit issues and avoiding missing values in supply/borrow USD display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->