### PR TITLE
invalid uuid check is returning a plain object instead of sending HTTP response

### DIFF
--- a/src/api/app.js
+++ b/src/api/app.js
@@ -54,8 +54,8 @@ app.use('/', [yieldRoutes, config, median, perp, enriched, lsd, pools]);
 
 function errorHandler (err, req, res, next) {
   console.log(err)
-  res.status(500)
-  res.render('error', { error: err })
+  const statusCode = err.statusCode ?? 500
+  res.status(statusCode).json({ status: err.status ?? 'error', message: err.message })
 }
 
 app.use(errorHandler)

--- a/src/api/controllers/config.js
+++ b/src/api/controllers/config.js
@@ -28,7 +28,7 @@ const getDistinctID = async (req, res) => {
   const response = await conn.query(query);
 
   if (!response) {
-    return new AppError(`Couldn't get data`, 404);
+    throw new AppError(`Couldn't get data`, 404);
   }
 
   res.status(200).json(response);
@@ -54,7 +54,7 @@ const getConfigPool = async (req, res) => {
   const response = await conn.query(query, { configIDs: ids });
 
   if (!response) {
-    return new AppError(`Couldn't get data`, 404);
+    throw new AppError(`Couldn't get data`, 404);
   }
 
   res.status(200).json({
@@ -79,7 +79,7 @@ const getAllPools = async (req, res) => {
   const response = await conn.query(query);
 
   if (!response) {
-    return new AppError(`Couldn't get data`, 404);
+    throw new AppError(`Couldn't get data`, 404);
   }
 
   res.status(200).json(response);

--- a/src/api/controllers/config.js
+++ b/src/api/controllers/config.js
@@ -41,7 +41,7 @@ const getConfigPool = async (req, res) => {
   const valid =
     ids.map((id) => validator.isUUID(id)).reduce((a, b) => a + b, 0) ===
     ids.length;
-  if (!valid) return { status: 'invalid uuid parameter' };
+  if (!valid) return res.status(400).json({ status: 'invalid uuid parameter' });
 
   const query = `
     SELECT


### PR DESCRIPTION
in getConfigPool the invalid uuid early return was doing return { status: 'invalid uuid parameter' } which is just a plain JS object from the async function so express alw ignores this and no HTTP response is ever sent, and the client connection hangs until timeout
fixed by calling res.status(400).json(...) instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid configuration identifiers now immediately return an HTTP 400 JSON response with a clear error message.
  * Configuration-related errors are now propagated to the centralized JSON error handler, ensuring consistent HTTP status codes and JSON {status, message} responses across failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->