### PR TITLE
feat(t3tris-finance): add T3tris Finance APY adapter

### DIFF
--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -43,6 +43,7 @@ const CHAINS = [
   'blast',
   'mantle',
   'mode',
+  'xdai',
   'fantom',
   'sonic',
 ];

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -535,6 +535,11 @@ const main = async () => {
           apyBase7d,
           underlyingTokens: [vault.asset],
           poolMeta,
+          // Oracle PPS: the authoritative share price that only moves on NAV
+          // updates. Using totalAssets/totalSupply would drop on deposit settlement
+          // (supply doubles before totalAssets is revalued), causing false negative
+          // fees in the DefiLlama fee test.
+          pricePerShare: currentSharePrice > 0 ? currentSharePrice : undefined,
           url: `https://app.t3tris.finance/vault/${vault.address}`,
         });
       }

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -19,14 +19,16 @@ const ABI = {
   decimals: 'function decimals() view returns (uint8)',
   symbol: 'function symbol() view returns (string)',
   name: 'function name() view returns (string)',
-  convertToAssets:
-    'function convertToAssets(uint256 shares) view returns (uint256)',
   getPerfFee: 'function getPerfFee() external view returns (uint16)',
   getManagementFee:
     'function getManagementFee() external view returns (uint16 managementFeeBps, uint32 managementFeeDays)',
   getEntryFee: 'function getEntryFee() external view returns (uint16)',
   getExitFee: 'function getExitFee() external view returns (uint16)',
-  isVaultOpen: 'function isVaultOpen() external view returns (bool)',
+  // Oracle: each vault delegates NAV to a SafeOracle updated by a keeper
+  getOracle: 'function getOracle() external view returns (address)',
+  // Oracle PPS in WAD (1e18) — always up-to-date, independent of settlement
+  getLastSavedPricePerShare:
+    'function getLastSavedPricePerShare() external view returns (uint256)',
 };
 
 // Chains where T3tris will be deployed
@@ -71,12 +73,12 @@ const getBlockNumber = async (timestamp, chain) => {
 };
 
 /**
- * Calculate APY from share price change over N days.
- * APY = (currentPrice / historicalPrice - 1) / days * 365 * 100
+ * Calculate APY from oracle PPS change over N days.
+ * Oracle PPS is in WAD (1e18). APY = (current / historical - 1) / days × 365 × 100
  */
-const calcApy = (currentPrice, historicalPrice, days) => {
-  if (!historicalPrice || historicalPrice <= 0 || !currentPrice) return 0;
-  const priceChange = (currentPrice - historicalPrice) / historicalPrice;
+const calcApy = (currentPps, historicalPps, days) => {
+  if (!historicalPps || historicalPps <= 0 || !currentPps) return 0;
+  const priceChange = (currentPps - historicalPps) / historicalPps;
   const apy = (priceChange / days) * 365 * 100;
   // Cap at reasonable bounds
   if (apy > 1000 || apy < 0) return 0;
@@ -85,6 +87,7 @@ const calcApy = (currentPrice, historicalPrice, days) => {
 
 /**
  * Discover all T3tris vaults from the factory on a given chain.
+ * Also fetches each vault's oracle address for PPS lookups.
  */
 const getVaultsForChain = async (chain) => {
   let count;
@@ -112,7 +115,7 @@ const getVaultsForChain = async (chain) => {
   const vaultAddresses = vaultsResult.output;
   if (!vaultAddresses || vaultAddresses.length === 0) return [];
 
-  // Batch-fetch vault metadata
+  // Batch-fetch vault metadata + oracle addresses
   const [
     totalAssetsRes,
     totalSupplyRes,
@@ -124,6 +127,7 @@ const getVaultsForChain = async (chain) => {
     mgmtFeeRes,
     entryFeeRes,
     exitFeeRes,
+    oracleRes,
   ] = await Promise.all([
     multiCall(vaultAddresses, ABI.totalAssets, chain),
     multiCall(vaultAddresses, ABI.totalSupply, chain),
@@ -135,6 +139,7 @@ const getVaultsForChain = async (chain) => {
     multiCall(vaultAddresses, ABI.getManagementFee, chain),
     multiCall(vaultAddresses, ABI.getEntryFee, chain),
     multiCall(vaultAddresses, ABI.getExitFee, chain),
+    multiCall(vaultAddresses, ABI.getOracle, chain),
   ]);
 
   const vaults = vaultAddresses.map((address, i) => {
@@ -144,6 +149,7 @@ const getVaultsForChain = async (chain) => {
     const decimals = decimalsRes.output[i];
     const symbol = symbolRes.output[i];
     const name = nameRes.output[i];
+    const oracle = oracleRes.output[i];
 
     if (
       !totalAssets?.success ||
@@ -163,6 +169,7 @@ const getVaultsForChain = async (chain) => {
       decimals: Number(decimals.output),
       symbol: symbol.output,
       name: name?.success ? name.output : symbol.output,
+      oracle: oracle?.success ? oracle.output : null,
       perfFeeBps: perfFeeRes.output[i]?.success
         ? Number(perfFeeRes.output[i].output)
         : 0,
@@ -187,39 +194,80 @@ const getVaultsForChain = async (chain) => {
 };
 
 /**
- * Get historical share prices (totalAssets/totalSupply) for APY calculation.
+ * Get historical oracle PPS (Price Per Share) for APY calculation.
+ * Uses getLastSavedPricePerShare() on each vault's oracle contract.
+ * The oracle is updated by a keeper independently of settlements,
+ * so PPS reflects current NAV even without recent settlements.
+ * PPS is returned in WAD (1e18 precision).
  */
-const getHistoricalSharePrices = async (vaultAddresses, chain, daysAgo) => {
+const getHistoricalOraclePps = async (vaults, chain, daysAgo) => {
   const timestamp = Math.floor(Date.now() / 1000) - DAY_SECONDS * daysAgo;
   const historicalBlock = await getBlockNumber(timestamp, chain);
 
   if (!historicalBlock) return {};
 
+  // Filter vaults that have an oracle
+  const vaultsWithOracle = vaults.filter((v) => v.oracle);
+  if (vaultsWithOracle.length === 0) return {};
+
+  const oracleAddresses = vaultsWithOracle.map((v) => v.oracle);
+
   try {
-    const [totalAssetsRes, totalSupplyRes] = await Promise.all([
-      multiCall(vaultAddresses, ABI.totalAssets, chain, historicalBlock),
-      multiCall(vaultAddresses, ABI.totalSupply, chain, historicalBlock),
-    ]);
+    const ppsRes = await sdk.api.abi.multiCall({
+      calls: oracleAddresses.map((oracle) => ({ target: oracle })),
+      abi: ABI.getLastSavedPricePerShare,
+      chain,
+      block: historicalBlock,
+      permitFailure: true,
+    });
 
-    const sharePrices = {};
-    for (let i = 0; i < vaultAddresses.length; i++) {
-      const totalAssets = totalAssetsRes.output[i];
-      const totalSupply = totalSupplyRes.output[i];
-
-      if (
-        totalAssets?.success &&
-        totalSupply?.success &&
-        totalSupply.output !== '0'
-      ) {
-        sharePrices[vaultAddresses[i].toLowerCase()] =
-          Number(totalAssets.output) / Number(totalSupply.output);
+    const result = {};
+    for (let i = 0; i < vaultsWithOracle.length; i++) {
+      if (ppsRes.output[i]?.success && ppsRes.output[i].output !== '0') {
+        result[vaultsWithOracle[i].address] =
+          Number(ppsRes.output[i].output) / 1e18;
       }
     }
 
-    return sharePrices;
+    return result;
   } catch (e) {
     console.error(
-      `[t3tris] Error fetching historical data for ${chain} (${daysAgo}d ago):`,
+      `[t3tris] Error fetching historical oracle PPS for ${chain} (${daysAgo}d ago):`,
+      e.message
+    );
+    return {};
+  }
+};
+
+/**
+ * Get current oracle PPS for all vaults.
+ */
+const getCurrentOraclePps = async (vaults, chain) => {
+  const vaultsWithOracle = vaults.filter((v) => v.oracle);
+  if (vaultsWithOracle.length === 0) return {};
+
+  const oracleAddresses = vaultsWithOracle.map((v) => v.oracle);
+
+  try {
+    const ppsRes = await sdk.api.abi.multiCall({
+      calls: oracleAddresses.map((oracle) => ({ target: oracle })),
+      abi: ABI.getLastSavedPricePerShare,
+      chain,
+      permitFailure: true,
+    });
+
+    const result = {};
+    for (let i = 0; i < vaultsWithOracle.length; i++) {
+      if (ppsRes.output[i]?.success && ppsRes.output[i].output !== '0') {
+        result[vaultsWithOracle[i].address] =
+          Number(ppsRes.output[i].output) / 1e18;
+      }
+    }
+
+    return result;
+  } catch (e) {
+    console.error(
+      `[t3tris] Error fetching current oracle PPS for ${chain}:`,
       e.message
     );
     return {};
@@ -239,11 +287,11 @@ const main = async () => {
       const assetAddresses = [...new Set(vaults.map((v) => v.asset))];
       const prices = await utils.getPrices(assetAddresses, chain);
 
-      // Get historical share prices for APY (1d and 7d)
-      const vaultAddresses = vaults.map((v) => v.address);
-      const [historicalPrices1d, historicalPrices7d] = await Promise.all([
-        getHistoricalSharePrices(vaultAddresses, chain, 1),
-        getHistoricalSharePrices(vaultAddresses, chain, 7),
+      // Get oracle PPS: current + historical (1d, 7d) for APY
+      const [currentPps, historicalPps1d, historicalPps7d] = await Promise.all([
+        getCurrentOraclePps(vaults, chain),
+        getHistoricalOraclePps(vaults, chain, 1),
+        getHistoricalOraclePps(vaults, chain, 7),
       ]);
 
       for (const vault of vaults) {
@@ -258,15 +306,17 @@ const main = async () => {
         // Skip negligible vaults
         if (tvlUsd < 100) continue;
 
-        // Current share price: totalAssets / totalSupply
+        // Current oracle PPS (WAD-normalized to float)
+        // Falls back to totalAssets/totalSupply if oracle unavailable
         const currentSharePrice =
-          vault.totalSupply !== '0'
+          currentPps[vault.address] ||
+          (vault.totalSupply !== '0'
             ? Number(vault.totalAssets) / Number(vault.totalSupply)
-            : 0;
+            : 0);
 
-        // APY from share price growth
-        const historicalPrice1d = historicalPrices1d[vault.address];
-        const historicalPrice7d = historicalPrices7d[vault.address];
+        // APY from oracle PPS growth
+        const historicalPrice1d = historicalPps1d[vault.address];
+        const historicalPrice7d = historicalPps7d[vault.address];
         const apyBase = calcApy(currentSharePrice, historicalPrice1d, 1);
         const apyBase7d = calcApy(currentSharePrice, historicalPrice7d, 7);
 

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -33,21 +33,7 @@ const ABI = {
 
 // Chains where T3tris will be deployed
 const CHAINS = [
-  'ethereum',
   'arbitrum',
-  'base',
-  'optimism',
-  'polygon',
-  'avax',
-  'bsc',
-  'linea',
-  'scroll',
-  'blast',
-  'mantle',
-  'mode',
-  'xdai',
-  'fantom',
-  'sonic',
 ];
 
 const DAY_SECONDS = 24 * 3600;
@@ -73,7 +59,7 @@ const multiCall = (targets, abi, chain, block = undefined) =>
 const getBlockNumber = async (timestamp, chain) => {
   try {
     const response = await axios.get(
-      `https://coins.llama.fi/block/${chain}/${timestamp}`
+      `https://coins.llama.fi/block/${chain}/${timestamp}`,
     );
     return response.data.height;
   } catch {
@@ -235,14 +221,20 @@ const getVaultsForChain = async (chain) => {
       perfFeeBps: perfFeeRes.output[i]?.success
         ? Number(perfFeeRes.output[i].output)
         : 0,
-      mgmtFeeBps:
-        mgmtFeeRes.output[i]?.success
-          ? Number(mgmtFeeRes.output[i].output.managementFeeBps || mgmtFeeRes.output[i].output[0] || 0)
-          : 0,
-      mgmtFeeDays:
-        mgmtFeeRes.output[i]?.success
-          ? Number(mgmtFeeRes.output[i].output.managementFeeDays || mgmtFeeRes.output[i].output[1] || 365)
-          : 365,
+      mgmtFeeBps: mgmtFeeRes.output[i]?.success
+        ? Number(
+            mgmtFeeRes.output[i].output.managementFeeBps ||
+              mgmtFeeRes.output[i].output[0] ||
+              0,
+          )
+        : 0,
+      mgmtFeeDays: mgmtFeeRes.output[i]?.success
+        ? Number(
+            mgmtFeeRes.output[i].output.managementFeeDays ||
+              mgmtFeeRes.output[i].output[1] ||
+              365,
+          )
+        : 365,
       entryFeeBps: entryFeeRes.output[i]?.success
         ? Number(entryFeeRes.output[i].output)
         : 0,
@@ -295,7 +287,7 @@ const getHistoricalOraclePps = async (vaults, chain, daysAgo) => {
   } catch (e) {
     console.error(
       `[t3tris] Error fetching historical oracle PPS for ${chain} (${daysAgo}d ago):`,
-      e.message
+      e.message,
     );
     return {};
   }
@@ -330,7 +322,7 @@ const getCurrentOraclePps = async (vaults, chain) => {
   } catch (e) {
     console.error(
       `[t3tris] Error fetching current oracle PPS for ${chain}:`,
-      e.message
+      e.message,
     );
     return {};
   }
@@ -377,14 +369,14 @@ const main = async () => {
 
         // Collect historical PPS at each lookback window for this vault
         const vaultHistoricalPps = historicalPpsArrays.map(
-          (ppsMap) => ppsMap[vault.address] || 0
+          (ppsMap) => ppsMap[vault.address] || 0,
         );
 
         // Smoothed APY: weighted blend across 7d/14d/30d windows
         // This prevents spikes when oracle updates after days of silence
         const { apyBase, apyBase7d } = computeSmoothedApy(
           currentSharePrice,
-          vaultHistoricalPps
+          vaultHistoricalPps,
         );
 
         // Build fee metadata string
@@ -415,7 +407,7 @@ const main = async () => {
     } catch (error) {
       console.error(
         `[t3tris] Error fetching data for ${chain}:`,
-        error.message
+        error.message,
       );
     }
   }

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -4,8 +4,8 @@ const axios = require('axios');
 
 const PROJECT_NAME = 't3tris-finance';
 
-// T3tris protocol factory — deterministic CREATE3 address, same on all chains
-const T3TRIS_FACTORY = '0x7DD63c4eE5CD277B7870155371a6d62A2f7b1652';
+// T3tris protocol v1 proxy — deterministic CREATE3 address, same on all chains
+const T3TRIS_FACTORY = '0x0000000000CC53b5Fd649b80f08b05405779cC71';
 
 // ABIs for the T3tris protocol
 const ABI = {
@@ -19,11 +19,11 @@ const ABI = {
   decimals: 'function decimals() view returns (uint8)',
   symbol: 'function symbol() view returns (string)',
   name: 'function name() view returns (string)',
-  getPerfFee: 'function getPerfFee() external view returns (uint16)',
+  getPerformanceFee: 'function getPerformanceFee() external view returns (uint64)',
   getManagementFee:
-    'function getManagementFee() external view returns (uint16 managementFeeBps, uint32 managementFeeDays)',
-  getEntryFee: 'function getEntryFee() external view returns (uint16)',
-  getExitFee: 'function getExitFee() external view returns (uint16)',
+    'function getManagementFee() external view returns (uint64 managementFeeWad, uint32 managementFeeDays)',
+  getEntryFee: 'function getEntryFee() external view returns (uint64)',
+  getExitFee: 'function getExitFee() external view returns (uint64)',
   // Oracle: each vault delegates NAV to a SafeOracle updated by a keeper
   getOracle: 'function getOracle() external view returns (address)',
   // Oracle PPS in WAD (1e18) — always up-to-date, independent of settlement
@@ -183,7 +183,7 @@ const getVaultsForChain = async (chain) => {
     multiCall(vaultAddresses, ABI.decimals, chain),
     multiCall(vaultAddresses, ABI.symbol, chain),
     multiCall(vaultAddresses, ABI.name, chain),
-    multiCall(vaultAddresses, ABI.getPerfFee, chain),
+    multiCall(vaultAddresses, ABI.getPerformanceFee, chain),
     multiCall(vaultAddresses, ABI.getManagementFee, chain),
     multiCall(vaultAddresses, ABI.getEntryFee, chain),
     multiCall(vaultAddresses, ABI.getExitFee, chain),
@@ -218,15 +218,16 @@ const getVaultsForChain = async (chain) => {
       symbol: symbol.output,
       name: name?.success ? name.output : symbol.output,
       oracle: oracle?.success ? oracle.output : null,
-      perfFeeBps: perfFeeRes.output[i]?.success
-        ? Number(perfFeeRes.output[i].output)
+      // Fees are WAD (1e18 = 100%); store as percentage (wad / 1e16)
+      perfFeePct: perfFeeRes.output[i]?.success
+        ? Number(perfFeeRes.output[i].output) / 1e16
         : 0,
-      mgmtFeeBps: mgmtFeeRes.output[i]?.success
+      mgmtFeePct: mgmtFeeRes.output[i]?.success
         ? Number(
-            mgmtFeeRes.output[i].output.managementFeeBps ||
+            mgmtFeeRes.output[i].output.managementFeeWad ||
               mgmtFeeRes.output[i].output[0] ||
               0,
-          )
+          ) / 1e16
         : 0,
       mgmtFeeDays: mgmtFeeRes.output[i]?.success
         ? Number(
@@ -235,11 +236,11 @@ const getVaultsForChain = async (chain) => {
               365,
           )
         : 365,
-      entryFeeBps: entryFeeRes.output[i]?.success
-        ? Number(entryFeeRes.output[i].output)
+      entryFeePct: entryFeeRes.output[i]?.success
+        ? Number(entryFeeRes.output[i].output) / 1e16
         : 0,
-      exitFeeBps: exitFeeRes.output[i]?.success
-        ? Number(exitFeeRes.output[i].output)
+      exitFeePct: exitFeeRes.output[i]?.success
+        ? Number(exitFeeRes.output[i].output) / 1e16
         : 0,
     };
   });
@@ -381,14 +382,14 @@ const main = async () => {
 
         // Build fee metadata string
         const feeParts = [];
-        if (vault.perfFeeBps > 0)
-          feeParts.push(`Perf: ${(vault.perfFeeBps / 100).toFixed(1)}%`);
-        if (vault.mgmtFeeBps > 0)
-          feeParts.push(`Mgmt: ${(vault.mgmtFeeBps / 100).toFixed(1)}%`);
-        if (vault.entryFeeBps > 0)
-          feeParts.push(`Entry: ${(vault.entryFeeBps / 100).toFixed(2)}%`);
-        if (vault.exitFeeBps > 0)
-          feeParts.push(`Exit: ${(vault.exitFeeBps / 100).toFixed(2)}%`);
+        if (vault.perfFeePct > 0)
+          feeParts.push(`Perf: ${vault.perfFeePct.toFixed(1)}%`);
+        if (vault.mgmtFeePct > 0)
+          feeParts.push(`Mgmt: ${vault.mgmtFeePct.toFixed(1)}%`);
+        if (vault.entryFeePct > 0)
+          feeParts.push(`Entry: ${vault.entryFeePct.toFixed(2)}%`);
+        if (vault.exitFeePct > 0)
+          feeParts.push(`Exit: ${vault.exitFeePct.toFixed(2)}%`);
         const poolMeta = feeParts.length > 0 ? feeParts.join(' | ') : undefined;
 
         pools.push({

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -401,17 +401,13 @@ const main = async () => {
           APY_WINDOW_DAYS,
         );
 
-        // Build fee metadata string
-        const feeParts = [];
-        if (vault.perfFeePct > 0)
-          feeParts.push(`Perf: ${vault.perfFeePct.toFixed(1)}%`);
-        if (vault.mgmtFeePct > 0)
-          feeParts.push(`Mgmt: ${vault.mgmtFeePct.toFixed(1)}%`);
-        if (vault.entryFeePct > 0)
-          feeParts.push(`Entry: ${vault.entryFeePct.toFixed(2)}%`);
-        if (vault.exitFeePct > 0)
-          feeParts.push(`Exit: ${vault.exitFeePct.toFixed(2)}%`);
-        const poolMeta = feeParts.length > 0 ? feeParts.join(' | ') : undefined;
+        // Fee metadata: performance fee, plus management fee when non-zero.
+        const poolMeta =
+          vault.mgmtFeePct > 0
+            ? `perf ${vault.perfFeePct.toFixed(1)}%, mgmt ${vault.mgmtFeePct.toFixed(
+                1,
+              )}%`
+            : `perf ${vault.perfFeePct.toFixed(1)}%`;
 
         pools.push({
           pool: `${vault.address}-${chain}`.toLowerCase(),
@@ -428,7 +424,7 @@ const main = async () => {
           // (supply doubles before totalAssets is revalued), causing false negative
           // fees in the DefiLlama fee test.
           pricePerShare: currentSharePrice > 0 ? currentSharePrice : undefined,
-          url: `https://app.t3tris.finance/vault/${vault.address}`,
+          url: `https://app.t3tris.finance/vaults/${CHAIN_IDS[chain]}/${vault.address}`,
         });
       }
     } catch (error) {

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -26,6 +26,10 @@ const ABI = {
   // Oracle PPS in WAD (1e18) — always up-to-date, independent of settlement
   getLastSavedPricePerShare:
     'function getLastSavedPricePerShare() external view returns (uint256)',
+  // Timestamp of the oracle's last NAV update (setTotalAssets). Used to anchor
+  // the APY lookback windows at the last NAV so the rate is extrapolated.
+  lastValuationTimestamp:
+    'function lastValuationTimestamp() external view returns (uint64)',
 };
 
 // Supported chains: DefiLlama chain name -> ecosystem-API chainId. Arbitrum only
@@ -37,13 +41,13 @@ const CHAINS = Object.keys(CHAIN_IDS);
 const DAY_SECONDS = 24 * 3600;
 
 /**
- * Lookback windows (days) for APY calculation.
- * Using multiple windows smooths out infrequent oracle updates:
- * if the oracle hasn't updated for several days, a single 7d window
- * would show APY=0 then spike when it updates. By blending 7/14/30d,
- * we get a stable annualized rate regardless of oracle update frequency.
+ * Lookback windows (days) for APY calculation, applied relative to each vault's
+ * last NAV (see getAnchoredHistoricalPps). Multiple windows smooth out the
+ * realized rate; the short windows (1/3d) also let freshly-launched vaults —
+ * whose history does not yet reach 7+ days before their last NAV — still report
+ * an APY instead of falling back to zero.
  */
-const LOOKBACK_DAYS = [7, 14, 30];
+const LOOKBACK_DAYS = [1, 3, 7, 14, 30];
 
 const multiCall = (targets, abi, chain, block = undefined) =>
   sdk.api.abi.multiCall({
@@ -154,14 +158,23 @@ const computeSmoothedApy = (currentPps, historicalPpsArray) => {
  * ecosystem API, then fetch each vault's metadata + oracle address on-chain.
  */
 const getVaultsForChain = async (chain) => {
-  // Discover verified, non-blacklisted vaults from the T3tris ecosystem API
+  // Discover verified, non-blacklisted vaults from the T3tris ecosystem API.
+  // Same curation gate as the TVL adapter: a vault must be verified, not
+  // blacklisted, on this chain, and carry a usable address/asset.
   let vaultAddresses;
   try {
     const { data } = await axios.get(VAULTS_API, { timeout: 10000 });
     const chainId = CHAIN_IDS[chain];
     vaultAddresses = (data || [])
       .filter(
-        (v) => v.verified && !v.blacklisted && Number(v.chainId) === chainId,
+        (v) =>
+          v?.verified &&
+          !v?.blacklisted &&
+          Number(v?.chainId) === chainId &&
+          typeof v?.address === 'string' &&
+          v.address &&
+          typeof v?.asset === 'string' &&
+          v.asset,
       )
       .map((v) => v.address);
   } catch {
@@ -253,55 +266,110 @@ const getVaultsForChain = async (chain) => {
     };
   });
 
-  return vaults.filter((v) => v !== null);
+  const vaultsList = vaults.filter((v) => v !== null);
+
+  // Fetch each oracle's last NAV timestamp (setTotalAssets). The APY windows are
+  // anchored at this timestamp so the rate is held (extrapolated) until the next
+  // NAV instead of decaying as flat days accumulate.
+  const oracleVaults = vaultsList.filter((v) => v.oracle);
+  if (oracleVaults.length > 0) {
+    const lvtRes = await multiCall(
+      oracleVaults.map((v) => v.oracle),
+      ABI.lastValuationTimestamp,
+      chain,
+    );
+    oracleVaults.forEach((v, i) => {
+      const out = lvtRes.output[i];
+      v.lastValuationTimestamp = out?.success ? Number(out.output) : 0;
+    });
+  }
+  vaultsList.forEach((v) => {
+    if (v.lastValuationTimestamp === undefined) v.lastValuationTimestamp = 0;
+  });
+
+  return vaultsList;
 };
 
 /**
- * Get historical oracle PPS (Price Per Share) for APY calculation.
- * Uses getLastSavedPricePerShare() on each vault's oracle contract.
- * The oracle is updated by a keeper independently of settlements,
- * so PPS reflects current NAV even without recent settlements.
- * PPS is returned in WAD (1e18 precision).
+ * Historical oracle PPS for the APY windows, anchored at each vault's LAST NAV
+ * update (lastValuationTimestamp) rather than `now`.
+ *
+ * Why: the oracle PPS only moves on a NAV update and is flat in between. If we
+ * anchored the lookback at `now`, then once a vault stops updating the trailing
+ * window would keep absorbing flat days and the APY would steadily decay toward
+ * zero. By anchoring both ends of every window at the last NAV (current PPS is
+ * the value saved at that NAV; historical PPS is read N days before it), the
+ * computed rate is the one realized at the last NAV and stays constant until the
+ * next NAV — i.e. it is extrapolated forward to now.
+ *
+ * Returns { vaultAddr: [pps@(tLast-7d), pps@(tLast-14d), pps@(tLast-30d)] }.
  */
-const getHistoricalOraclePps = async (vaults, chain, daysAgo) => {
-  const timestamp = Math.floor(Date.now() / 1000) - DAY_SECONDS * daysAgo;
-  const historicalBlock = await getBlockNumber(timestamp, chain);
+const getAnchoredHistoricalPps = async (vaults, chain) => {
+  const withOracle = vaults.filter((v) => v.oracle);
+  if (withOracle.length === 0) return {};
 
-  if (!historicalBlock) return {};
+  const nowSec = Math.floor(Date.now() / 1000);
 
-  // Filter vaults that have an oracle
-  const vaultsWithOracle = vaults.filter((v) => v.oracle);
-  if (vaultsWithOracle.length === 0) return {};
-
-  const oracleAddresses = vaultsWithOracle.map((v) => v.oracle);
-
-  try {
-    const ppsRes = await sdk.api.abi.multiCall({
-      calls: oracleAddresses.map((oracle) => ({ target: oracle })),
-      abi: ABI.getLastSavedPricePerShare,
-      chain,
-      block: historicalBlock,
-      permitFailure: true,
+  // One (vault, window) task per lookback, anchored at the vault's last NAV.
+  const tasks = [];
+  for (const v of withOracle) {
+    const anchor =
+      v.lastValuationTimestamp > 0 ? v.lastValuationTimestamp : nowSec;
+    LOOKBACK_DAYS.forEach((d, wIndex) => {
+      tasks.push({
+        vaultAddr: v.address,
+        oracle: v.oracle,
+        wIndex,
+        ts: anchor - DAY_SECONDS * d,
+      });
     });
-
-    const result = {};
-    for (let i = 0; i < vaultsWithOracle.length; i++) {
-      if (ppsRes.output[i]?.success && ppsRes.output[i].output !== '0') {
-        result[vaultsWithOracle[i].address] = toDecimal(
-          ppsRes.output[i].output,
-          18,
-        );
-      }
-    }
-
-    return result;
-  } catch (e) {
-    console.error(
-      `[t3tris] Error fetching historical oracle PPS for ${chain} (${daysAgo}d ago):`,
-      e.message,
-    );
-    return {};
   }
+
+  // Resolve unique timestamps to blocks once.
+  const uniqueTs = [...new Set(tasks.map((t) => t.ts))];
+  const blockByTs = {};
+  await Promise.all(
+    uniqueTs.map(async (ts) => {
+      blockByTs[ts] = await getBlockNumber(ts, chain);
+    }),
+  );
+
+  // Group tasks by historical block and batch the oracle reads per block.
+  const byBlock = {};
+  for (const t of tasks) {
+    const block = blockByTs[t.ts];
+    if (!block) continue;
+    (byBlock[block] = byBlock[block] || []).push(t);
+  }
+
+  const result = {};
+  withOracle.forEach((v) => {
+    result[v.address] = new Array(LOOKBACK_DAYS.length).fill(0);
+  });
+
+  await Promise.all(
+    Object.entries(byBlock).map(async ([block, items]) => {
+      try {
+        const ppsRes = await sdk.api.abi.multiCall({
+          calls: items.map((it) => ({ target: it.oracle })),
+          abi: ABI.getLastSavedPricePerShare,
+          chain,
+          block: Number(block),
+          permitFailure: true,
+        });
+        items.forEach((it, i) => {
+          const o = ppsRes.output[i];
+          if (o?.success && o.output !== '0') {
+            result[it.vaultAddr][it.wIndex] = toDecimal(o.output, 18);
+          }
+        });
+      } catch (e) {
+        // Leave these windows at 0; computeSmoothedApy ignores empty windows.
+      }
+    }),
+  );
+
+  return result;
 };
 
 /**
@@ -354,10 +422,11 @@ const main = async () => {
       const assetAddresses = [...new Set(vaults.map((v) => v.asset))];
       const prices = await utils.getPrices(assetAddresses, chain);
 
-      // Get oracle PPS: current + historical at multiple lookback windows
-      const [currentPps, ...historicalPpsArrays] = await Promise.all([
+      // Current PPS (= value saved at the last NAV) + historical PPS anchored at
+      // each vault's last NAV, so the APY is held (extrapolated) afterwards.
+      const [currentPps, anchoredHist] = await Promise.all([
         getCurrentOraclePps(vaults, chain),
-        ...LOOKBACK_DAYS.map((d) => getHistoricalOraclePps(vaults, chain, d)),
+        getAnchoredHistoricalPps(vaults, chain),
       ]);
 
       for (const vault of vaults) {
@@ -382,10 +451,8 @@ const main = async () => {
             ? ratio1e18(vault.totalAssets, vault.totalSupply)
             : 0);
 
-        // Collect historical PPS at each lookback window for this vault
-        const vaultHistoricalPps = historicalPpsArrays.map(
-          (ppsMap) => ppsMap[vault.address] || 0,
-        );
+        // Historical PPS for this vault, anchored at its last NAV update.
+        const vaultHistoricalPps = anchoredHist[vault.address] || [];
 
         // Smoothed APY: weighted blend across 7d/14d/30d windows
         // This prevents spikes when oracle updates after days of silence

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -41,14 +41,10 @@ const CHAINS = Object.keys(CHAIN_IDS);
 
 const DAY_SECONDS = 24 * 3600;
 
-/**
- * Lookback windows (days) for APY calculation, applied relative to each vault's
- * last NAV (see getAnchoredHistoricalPps). Multiple windows smooth out the
- * realized rate; the short windows (1/3d) also let freshly-launched vaults —
- * whose history does not yet reach 7+ days before their last NAV — still report
- * an APY instead of falling back to zero.
- */
-const LOOKBACK_DAYS = [1, 3, 7, 14, 30];
+// Single lookback window (days) for the APY calculation, applied relative to
+// each vault's last NAV (see getAnchoredHistoricalPps). A fixed window keeps the
+// reported rate consistent across all vaults.
+const APY_WINDOW_DAYS = 7;
 
 const multiCall = (targets, abi, chain, block = undefined) =>
   sdk.api.abi.multiCall({
@@ -89,8 +85,9 @@ const getBlockNumber = async (timestamp, chain) => {
 };
 
 /**
- * Calculate APY from oracle PPS change over N days.
- * Oracle PPS is in WAD (1e18). APY = (current / historical - 1) / days × 365 × 100
+ * Single-window APY from oracle PPS change over `days`.
+ * Oracle PPS is in WAD (1e18). APY = (current / historical - 1) / days × 365 × 100.
+ * Returns 0 for missing data, loss periods, or implausible spikes.
  */
 const calcApy = (currentPps, historicalPps, days) => {
   if (!historicalPps || historicalPps <= 0 || !currentPps) return 0;
@@ -99,85 +96,6 @@ const calcApy = (currentPps, historicalPps, days) => {
   // Cap at reasonable bounds
   if (apy > 1000 || apy < 0) return 0;
   return apy;
-};
-
-/**
- * TVL+time-weighted linear APY, matching the app formula:
- *   APY = YEAR_SECS × Σ(TVLᵢ · rᵢ) / Σ(TVLᵢ · Δtᵢ)
- *   rᵢ   = pps_end / pps_start − 1  (simple per-share growth in interval i)
- *   TVLᵢ = (ta_start + ta_end) / 2  (average totalAssets; cancels if uniform)
- *   Δtᵢ  = elapsed seconds (positive, older→newer)
- *
- * Uses NON-OVERLAPPING intervals anchored at the vault's last NAV:
- *   [LVT−30d → LVT−14d], [LVT−14d → LVT−7d], [LVT−7d → LVT]
- * This avoids double-counting and matches how the app computes the M window.
- *
- * Falls back to a single 3d or 1d interval for vaults < 7 days old.
- * The 1d/3d windows are intentionally excluded from the main blend: a
- * freshly-updated oracle can show a multi-day accrual in one day, which
- * would spike those short windows and corrupt the weighted average.
- *
- * `historicalData` shape: { pps: [1d,3d,7d,14d,30d], ta: [1d,3d,7d,14d,30d] }
- * indexed by LOOKBACK_DAYS = [1, 3, 7, 14, 30].
- */
-const computeTvlWeightedApy = (currentPps, currentTa, historicalData) => {
-  if (!currentPps || currentPps <= 0) return { apyBase: 0, apyBase7d: 0 };
-
-  const YEAR_SECS = 365 * DAY_SECONDS;
-
-  // Sample points, oldest→newest. Indices into LOOKBACK_DAYS=[1,3,7,14,30]:
-  //   2 = 7d, 3 = 14d, 4 = 30d.
-  const candidates = [
-    { daysAgo: 30, pps: historicalData.pps[4], ta: historicalData.ta[4] },
-    { daysAgo: 14, pps: historicalData.pps[3], ta: historicalData.ta[3] },
-    { daysAgo: 7,  pps: historicalData.pps[2], ta: historicalData.ta[2] },
-    { daysAgo: 0,  pps: currentPps,            ta: currentTa            },
-  ];
-
-  // Keep only points with a valid PPS (vault history may be shorter than 30d).
-  const pts = candidates.filter((p) => p.pps > 0);
-
-  // If the oldest valid point is < 7 days ago, the vault is too young for the
-  // long blend — use the freshness fallback (3d then 1d single interval).
-  if (pts.length < 2 || pts[0].daysAgo < 7) {
-    for (const [idx, days] of [[1, 3], [0, 1]]) {
-      const pps = historicalData.pps[idx];
-      if (pps > 0 && Math.abs(pps - currentPps) > 1e-15) {
-        const apy = ((currentPps / pps - 1) / days) * 365 * 100;
-        if (apy > 0 && apy <= 1000) return { apyBase: apy, apyBase7d: apy };
-      }
-    }
-    return { apyBase: 0, apyBase7d: 0 };
-  }
-
-  // TVL+time-weighted accumulation over non-overlapping consecutive intervals.
-  let num = 0;
-  let den = 0;
-  for (let i = 1; i < pts.length; i++) {
-    const older = pts[i - 1];
-    const newer = pts[i];
-    const dt = (older.daysAgo - newer.daysAgo) * DAY_SECONDS; // positive
-    if (dt <= 0 || older.pps <= 0 || newer.pps <= 0) continue;
-    const r = newer.pps / older.pps - 1;
-    // Use average totalAssets as the TVL weight; fall back to 1 when unknown.
-    const tvl = (older.ta + newer.ta) / 2 || 1;
-    num += tvl * r;
-    den += tvl * dt;
-  }
-
-  // apyBase7d: single-interval [LVT−7d → LVT] realized APY.
-  const pps7d = historicalData.pps[2];
-  const raw7d = pps7d > 0 ? ((currentPps / pps7d - 1) / 7) * 365 * 100 : 0;
-  const apyBase7d = raw7d > 0 && raw7d <= 1000 ? raw7d : 0;
-
-  if (den <= 0) return { apyBase: apyBase7d, apyBase7d };
-
-  const apyRaw = (YEAR_SECS * num) / den * 100;
-  // Cap: negative (loss period) → 0; unreasonably large spike → fall back to 7d.
-  const apyBase =
-    apyRaw < 0 ? 0 : apyRaw <= 1000 ? apyRaw : apyBase7d;
-
-  return { apyBase, apyBase7d };
 };
 
 /**
@@ -319,19 +237,18 @@ const getVaultsForChain = async (chain) => {
 };
 
 /**
- * Historical oracle PPS + vault totalAssets for the APY windows, anchored at
- * each vault's LAST NAV update (lastValuationTimestamp) rather than `now`.
+ * Historical oracle PPS for the single APY window, anchored at each vault's
+ * LAST NAV update (lastValuationTimestamp) rather than `now`.
  *
- * Why: the oracle PPS only moves on a NAV update and is flat in between. If we
- * anchored the lookback at `now`, then once a vault stops updating the trailing
- * window would keep absorbing flat days and the APY would steadily decay toward
- * zero. By anchoring both ends of every window at the last NAV (current PPS is
- * the value saved at that NAV; historical PPS is read N days before it), the
- * computed rate is the one realized at the last NAV and stays constant until the
- * next NAV — i.e. it is extrapolated forward to now.
+ * Why anchor at the last NAV: the oracle PPS only moves on a NAV update and is
+ * flat in between. Anchoring both ends of the window at the last NAV (current
+ * PPS is the value saved at that NAV; historical PPS is read APY_WINDOW_DAYS
+ * before it) means the computed rate is the one realized at that NAV and stays
+ * constant until the next NAV, instead of decaying toward zero as flat days
+ * accumulate.
  *
- * Returns { vaultAddr: { pps: [...], ta: [...] } } indexed by LOOKBACK_DAYS.
- * `ta` (totalAssets) is used as the TVL weight in computeTvlWeightedApy.
+ * Returns { vaultAddr: historicalPps } — the PPS APY_WINDOW_DAYS before the
+ * anchor.
  */
 const getAnchoredHistoricalPps = async (vaults, chain) => {
   const withOracle = vaults.filter((v) => v.oracle);
@@ -339,20 +256,16 @@ const getAnchoredHistoricalPps = async (vaults, chain) => {
 
   const nowSec = Math.floor(Date.now() / 1000);
 
-  // One (vault, window) task per lookback, anchored at the vault's last NAV.
-  const tasks = [];
-  for (const v of withOracle) {
+  // One task per vault, anchored APY_WINDOW_DAYS before the vault's last NAV.
+  const tasks = withOracle.map((v) => {
     const anchor =
       v.lastValuationTimestamp > 0 ? v.lastValuationTimestamp : nowSec;
-    LOOKBACK_DAYS.forEach((d, wIndex) => {
-      tasks.push({
-        vaultAddr: v.address,
-        oracle: v.oracle,
-        wIndex,
-        ts: anchor - DAY_SECONDS * d,
-      });
-    });
-  }
+    return {
+      vaultAddr: v.address,
+      oracle: v.oracle,
+      ts: anchor - DAY_SECONDS * APY_WINDOW_DAYS,
+    };
+  });
 
   // Resolve unique timestamps to blocks once.
   const uniqueTs = [...new Set(tasks.map((t) => t.ts))];
@@ -372,47 +285,26 @@ const getAnchoredHistoricalPps = async (vaults, chain) => {
   }
 
   const result = {};
-  withOracle.forEach((v) => {
-    result[v.address] = {
-      pps: new Array(LOOKBACK_DAYS.length).fill(0),
-      ta: new Array(LOOKBACK_DAYS.length).fill(0),
-    };
-  });
 
   await Promise.all(
     Object.entries(byBlock).map(async ([block, items]) => {
       try {
-        // Fetch oracle PPS and vault totalAssets at this historical block.
-        const [ppsRes, taRes] = await Promise.all([
-          sdk.api.abi.multiCall({
-            calls: items.map((it) => ({ target: it.oracle })),
-            abi: ABI.getLastSavedPricePerShare,
-            chain,
-            block: Number(block),
-            permitFailure: true,
-          }),
-          sdk.api.abi.multiCall({
-            calls: items.map((it) => ({ target: it.vaultAddr })),
-            abi: ABI.totalAssets,
-            chain,
-            block: Number(block),
-            permitFailure: true,
-          }),
-        ]);
+        // Fetch oracle PPS at this historical block.
+        const ppsRes = await sdk.api.abi.multiCall({
+          calls: items.map((it) => ({ target: it.oracle })),
+          abi: ABI.getLastSavedPricePerShare,
+          chain,
+          block: Number(block),
+          permitFailure: true,
+        });
         items.forEach((it, i) => {
           const ppsO = ppsRes.output[i];
           if (ppsO?.success && ppsO.output !== '0') {
-            result[it.vaultAddr].pps[it.wIndex] = toDecimal(ppsO.output, 18);
-          }
-          const taO = taRes.output[i];
-          if (taO?.success && taO.output !== '0') {
-            result[it.vaultAddr].ta[it.wIndex] = Number(
-              BigInt(taO.output.toString()),
-            );
+            result[it.vaultAddr] = toDecimal(ppsO.output, 18);
           }
         });
       } catch (e) {
-        // Leave these windows at 0; computeTvlWeightedApy ignores empty windows.
+        // Leave missing; calcApy treats a missing historical PPS as 0 APY.
       }
     }),
   );
@@ -499,18 +391,14 @@ const main = async () => {
             ? ratio1e18(vault.totalAssets, vault.totalSupply)
             : 0);
 
-        // Historical PPS + totalAssets for this vault, anchored at its last NAV.
-        const vaultHistoricalData = anchoredHist[vault.address] || {
-          pps: [],
-          ta: [],
-        };
+        // Historical oracle PPS for the single window, anchored at last NAV.
+        const historicalPps = anchoredHist[vault.address] || 0;
 
-        // TVL+time-weighted linear APY over non-overlapping intervals.
-        // Matches the app formula: YEAR × Σ(TVLᵢ·rᵢ) / Σ(TVLᵢ·Δtᵢ).
-        const { apyBase, apyBase7d } = computeTvlWeightedApy(
+        // Single-window APY (APY_WINDOW_DAYS), consistent across all vaults.
+        const apyBase = calcApy(
           currentSharePrice,
-          Number(vault.totalAssets),
-          vaultHistoricalData,
+          historicalPps,
+          APY_WINDOW_DAYS,
         );
 
         // Build fee metadata string
@@ -529,10 +417,10 @@ const main = async () => {
           pool: `${vault.address}-${chain}`.toLowerCase(),
           chain: utils.formatChain(chain),
           project: PROJECT_NAME,
-          symbol: utils.formatSymbol(vault.symbol),
+          symbol: vault.symbol,
           tvlUsd,
           apyBase,
-          apyBase7d,
+          apyBase7d: apyBase,
           underlyingTokens: [vault.asset],
           poolMeta,
           // Oracle PPS: the authoritative share price that only moves on NAV
@@ -555,6 +443,7 @@ const main = async () => {
 };
 
 module.exports = {
+  protocolId: '8068',
   timetravel: false,
   apy: main,
   url: 'https://t3tris.finance/',

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -52,6 +52,15 @@ const CHAINS = [
 
 const DAY_SECONDS = 24 * 3600;
 
+/**
+ * Lookback windows (days) for APY calculation.
+ * Using multiple windows smooths out infrequent oracle updates:
+ * if the oracle hasn't updated for several days, a single 7d window
+ * would show APY=0 then spike when it updates. By blending 7/14/30d,
+ * we get a stable annualized rate regardless of oracle update frequency.
+ */
+const LOOKBACK_DAYS = [7, 14, 30];
+
 const multiCall = (targets, abi, chain, block = undefined) =>
   sdk.api.abi.multiCall({
     calls: targets.map((target) => ({ target })),
@@ -83,6 +92,59 @@ const calcApy = (currentPps, historicalPps, days) => {
   // Cap at reasonable bounds
   if (apy > 1000 || apy < 0) return 0;
   return apy;
+};
+
+/**
+ * Compute a smoothed APY from multiple lookback windows.
+ *
+ * Problem: the oracle keeper updates PPS every N days (could be 1-14 days).
+ * Between updates the on-chain PPS is frozen, so a single-window APY
+ * oscillates between 0% (stale) and a spike (post-update).
+ *
+ * Solution: compute APY at each lookback (7d, 14d, 30d) and blend them
+ * using inverse-days weighting (shorter = more weight for responsiveness,
+ * longer = stability). Only windows where PPS actually changed are included.
+ *
+ * Weights: 7d → 1/7 ≈ 0.143, 14d → 1/14 ≈ 0.071, 30d → 1/30 ≈ 0.033
+ * So 7d gets ~58% weight, 14d ~29%, 30d ~13% — responsive but stable.
+ *
+ * If only one window is valid, it's used as-is. If none, returns 0.
+ */
+const computeSmoothedApy = (currentPps, historicalPpsArray) => {
+  if (!currentPps || currentPps <= 0) return { apyBase: 0, apyBase7d: 0 };
+
+  // Compute APY per lookback window
+  const validApys = [];
+  for (let i = 0; i < LOOKBACK_DAYS.length; i++) {
+    const histPps = historicalPpsArray[i];
+    if (histPps && histPps > 0 && Math.abs(histPps - currentPps) > 1e-15) {
+      const apy = calcApy(currentPps, histPps, LOOKBACK_DAYS[i]);
+      if (apy > 0) validApys.push({ days: LOOKBACK_DAYS[i], apy });
+    }
+  }
+
+  if (validApys.length === 0) return { apyBase: 0, apyBase7d: 0 };
+
+  // Single valid window → use it directly
+  if (validApys.length === 1) {
+    return { apyBase: validApys[0].apy, apyBase7d: validApys[0].apy };
+  }
+
+  // Weighted average: weight = 1/days (shorter = more weight)
+  let totalWeight = 0;
+  let weightedSum = 0;
+  for (const { days, apy } of validApys) {
+    const w = 1 / days;
+    totalWeight += w;
+    weightedSum += apy * w;
+  }
+  const blendedApy = weightedSum / totalWeight;
+
+  // apyBase7d: prefer the 7d window directly, fallback to blended
+  const sevenDay = validApys.find((a) => a.days === 7);
+  const apyBase7d = sevenDay ? sevenDay.apy : blendedApy;
+
+  return { apyBase: blendedApy, apyBase7d };
 };
 
 /**
@@ -287,11 +349,10 @@ const main = async () => {
       const assetAddresses = [...new Set(vaults.map((v) => v.asset))];
       const prices = await utils.getPrices(assetAddresses, chain);
 
-      // Get oracle PPS: current + historical (1d, 7d) for APY
-      const [currentPps, historicalPps1d, historicalPps7d] = await Promise.all([
+      // Get oracle PPS: current + historical at multiple lookback windows
+      const [currentPps, ...historicalPpsArrays] = await Promise.all([
         getCurrentOraclePps(vaults, chain),
-        getHistoricalOraclePps(vaults, chain, 1),
-        getHistoricalOraclePps(vaults, chain, 7),
+        ...LOOKBACK_DAYS.map((d) => getHistoricalOraclePps(vaults, chain, d)),
       ]);
 
       for (const vault of vaults) {
@@ -314,11 +375,17 @@ const main = async () => {
             ? Number(vault.totalAssets) / Number(vault.totalSupply)
             : 0);
 
-        // APY from oracle PPS growth
-        const historicalPrice1d = historicalPps1d[vault.address];
-        const historicalPrice7d = historicalPps7d[vault.address];
-        const apyBase = calcApy(currentSharePrice, historicalPrice1d, 1);
-        const apyBase7d = calcApy(currentSharePrice, historicalPrice7d, 7);
+        // Collect historical PPS at each lookback window for this vault
+        const vaultHistoricalPps = historicalPpsArrays.map(
+          (ppsMap) => ppsMap[vault.address] || 0
+        );
+
+        // Smoothed APY: weighted blend across 7d/14d/30d windows
+        // This prevents spikes when oracle updates after days of silence
+        const { apyBase, apyBase7d } = computeSmoothedApy(
+          currentSharePrice,
+          vaultHistoricalPps
+        );
 
         // Build fee metadata string
         const feeParts = [];

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -4,15 +4,12 @@ const axios = require('axios');
 
 const PROJECT_NAME = 't3tris-finance';
 
-// T3tris protocol v1 proxy — deterministic CREATE3 address, same on all chains
-const T3TRIS_FACTORY = '0x0000000000CC53b5Fd649b80f08b05405779cC71';
+// T3tris ecosystem API — authoritative list of vaults with curation flags.
+// Only vaults that are `verified` and not `blacklisted` are indexed.
+const VAULTS_API = 'https://ecosystem.t3tris.finance/vaults';
 
-// ABIs for the T3tris protocol
+// ABIs for the T3tris vaults
 const ABI = {
-  getDeployedVaultsCount:
-    'function getDeployedVaultsCount() external view returns (uint256)',
-  getDeployedVaults:
-    'function getDeployedVaults(uint256 fromIndex, uint256 toIndex) external view returns (address[])',
   totalAssets: 'function totalAssets() view returns (uint256)',
   totalSupply: 'function totalSupply() view returns (uint256)',
   asset: 'function asset() view returns (address)',
@@ -31,10 +28,11 @@ const ABI = {
     'function getLastSavedPricePerShare() external view returns (uint256)',
 };
 
-// Chains where T3tris will be deployed
-const CHAINS = [
-  'arbitrum',
-];
+// Supported chains: DefiLlama chain name -> ecosystem-API chainId. Arbitrum only
+// for now (same CREATE3 addresses on every EVM chain); add a chain here once it
+// goes live and the API returns verified vaults for it.
+const CHAIN_IDS = { arbitrum: 42161 };
+const CHAINS = Object.keys(CHAIN_IDS);
 
 const DAY_SECONDS = 24 * 3600;
 
@@ -134,33 +132,25 @@ const computeSmoothedApy = (currentPps, historicalPpsArray) => {
 };
 
 /**
- * Discover all T3tris vaults from the factory on a given chain.
- * Also fetches each vault's oracle address for PPS lookups.
+ * Discover verified, non-blacklisted T3tris vaults for a chain from the
+ * ecosystem API, then fetch each vault's metadata + oracle address on-chain.
  */
 const getVaultsForChain = async (chain) => {
-  let count;
+  // Discover verified, non-blacklisted vaults from the T3tris ecosystem API
+  let vaultAddresses;
   try {
-    const countResult = await sdk.api.abi.call({
-      target: T3TRIS_FACTORY,
-      abi: ABI.getDeployedVaultsCount,
-      chain,
-    });
-    count = Number(countResult.output);
+    const { data } = await axios.get(VAULTS_API);
+    const chainId = CHAIN_IDS[chain];
+    vaultAddresses = (data || [])
+      .filter(
+        (v) => v.verified && !v.blacklisted && Number(v.chainId) === chainId,
+      )
+      .map((v) => v.address);
   } catch {
-    // Factory not deployed on this chain yet
+    // API unreachable
     return [];
   }
 
-  if (count === 0) return [];
-
-  const vaultsResult = await sdk.api.abi.call({
-    target: T3TRIS_FACTORY,
-    abi: ABI.getDeployedVaults,
-    params: [0, count - 1],
-    chain,
-  });
-
-  const vaultAddresses = vaultsResult.output;
   if (!vaultAddresses || vaultAddresses.length === 0) return [];
 
   // Batch-fetch vault metadata + oracle addresses
@@ -419,5 +409,5 @@ const main = async () => {
 module.exports = {
   timetravel: false,
   apy: main,
-  url: 'https://app.t3tris.finance',
+  url: 'https://t3tris.finance/',
 };

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -5,7 +5,8 @@ const axios = require('axios');
 const PROJECT_NAME = 't3tris-finance';
 
 // T3tris ecosystem API — authoritative list of vaults with curation flags.
-// Only vaults that are `verified` and not `blacklisted` are indexed.
+// Only vaults that are `verified`, not `blacklisted`, and not `public: false`
+// are indexed.
 const VAULTS_API = 'https://ecosystem.t3tris.finance/vaults';
 
 // ABIs for the T3tris vaults
@@ -154,13 +155,13 @@ const computeSmoothedApy = (currentPps, historicalPpsArray) => {
 };
 
 /**
- * Discover verified, non-blacklisted T3tris vaults for a chain from the
+ * Discover verified, non-blacklisted, public T3tris vaults for a chain from the
  * ecosystem API, then fetch each vault's metadata + oracle address on-chain.
  */
 const getVaultsForChain = async (chain) => {
-  // Discover verified, non-blacklisted vaults from the T3tris ecosystem API.
-  // Same curation gate as the TVL adapter: a vault must be verified, not
-  // blacklisted, on this chain, and carry a usable address/asset.
+  // Discover verified, non-blacklisted, public vaults from the T3tris ecosystem
+  // API. A vault must be verified, not blacklisted, not `public: false`, on this
+  // chain, and carry a usable address/asset.
   let vaultAddresses;
   try {
     const { data } = await axios.get(VAULTS_API, { timeout: 10000 });
@@ -170,6 +171,7 @@ const getVaultsForChain = async (chain) => {
         (v) =>
           v?.verified &&
           !v?.blacklisted &&
+          v?.public !== false &&
           Number(v?.chainId) === chainId &&
           typeof v?.address === 'string' &&
           v.address &&

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -102,56 +102,82 @@ const calcApy = (currentPps, historicalPps, days) => {
 };
 
 /**
- * Compute a smoothed APY from multiple lookback windows.
+ * TVL+time-weighted linear APY, matching the app formula:
+ *   APY = YEAR_SECS × Σ(TVLᵢ · rᵢ) / Σ(TVLᵢ · Δtᵢ)
+ *   rᵢ   = pps_end / pps_start − 1  (simple per-share growth in interval i)
+ *   TVLᵢ = (ta_start + ta_end) / 2  (average totalAssets; cancels if uniform)
+ *   Δtᵢ  = elapsed seconds (positive, older→newer)
  *
- * Problem: the oracle keeper updates PPS every N days (could be 1-14 days).
- * Between updates the on-chain PPS is frozen, so a single-window APY
- * oscillates between 0% (stale) and a spike (post-update).
+ * Uses NON-OVERLAPPING intervals anchored at the vault's last NAV:
+ *   [LVT−30d → LVT−14d], [LVT−14d → LVT−7d], [LVT−7d → LVT]
+ * This avoids double-counting and matches how the app computes the M window.
  *
- * Solution: compute APY at each lookback (7d, 14d, 30d) and blend them
- * using inverse-days weighting (shorter = more weight for responsiveness,
- * longer = stability). Only windows where PPS actually changed are included.
+ * Falls back to a single 3d or 1d interval for vaults < 7 days old.
+ * The 1d/3d windows are intentionally excluded from the main blend: a
+ * freshly-updated oracle can show a multi-day accrual in one day, which
+ * would spike those short windows and corrupt the weighted average.
  *
- * Weights: 7d → 1/7 ≈ 0.143, 14d → 1/14 ≈ 0.071, 30d → 1/30 ≈ 0.033
- * So 7d gets ~58% weight, 14d ~29%, 30d ~13% — responsive but stable.
- *
- * If only one window is valid, it's used as-is. If none, returns 0.
+ * `historicalData` shape: { pps: [1d,3d,7d,14d,30d], ta: [1d,3d,7d,14d,30d] }
+ * indexed by LOOKBACK_DAYS = [1, 3, 7, 14, 30].
  */
-const computeSmoothedApy = (currentPps, historicalPpsArray) => {
+const computeTvlWeightedApy = (currentPps, currentTa, historicalData) => {
   if (!currentPps || currentPps <= 0) return { apyBase: 0, apyBase7d: 0 };
 
-  // Compute APY per lookback window
-  const validApys = [];
-  for (let i = 0; i < LOOKBACK_DAYS.length; i++) {
-    const histPps = historicalPpsArray[i];
-    if (histPps && histPps > 0 && Math.abs(histPps - currentPps) > 1e-15) {
-      const apy = calcApy(currentPps, histPps, LOOKBACK_DAYS[i]);
-      if (apy > 0) validApys.push({ days: LOOKBACK_DAYS[i], apy });
+  const YEAR_SECS = 365 * DAY_SECONDS;
+
+  // Sample points, oldest→newest. Indices into LOOKBACK_DAYS=[1,3,7,14,30]:
+  //   2 = 7d, 3 = 14d, 4 = 30d.
+  const candidates = [
+    { daysAgo: 30, pps: historicalData.pps[4], ta: historicalData.ta[4] },
+    { daysAgo: 14, pps: historicalData.pps[3], ta: historicalData.ta[3] },
+    { daysAgo: 7,  pps: historicalData.pps[2], ta: historicalData.ta[2] },
+    { daysAgo: 0,  pps: currentPps,            ta: currentTa            },
+  ];
+
+  // Keep only points with a valid PPS (vault history may be shorter than 30d).
+  const pts = candidates.filter((p) => p.pps > 0);
+
+  // If the oldest valid point is < 7 days ago, the vault is too young for the
+  // long blend — use the freshness fallback (3d then 1d single interval).
+  if (pts.length < 2 || pts[0].daysAgo < 7) {
+    for (const [idx, days] of [[1, 3], [0, 1]]) {
+      const pps = historicalData.pps[idx];
+      if (pps > 0 && Math.abs(pps - currentPps) > 1e-15) {
+        const apy = ((currentPps / pps - 1) / days) * 365 * 100;
+        if (apy > 0 && apy <= 1000) return { apyBase: apy, apyBase7d: apy };
+      }
     }
+    return { apyBase: 0, apyBase7d: 0 };
   }
 
-  if (validApys.length === 0) return { apyBase: 0, apyBase7d: 0 };
-
-  // Single valid window → use it directly
-  if (validApys.length === 1) {
-    return { apyBase: validApys[0].apy, apyBase7d: validApys[0].apy };
+  // TVL+time-weighted accumulation over non-overlapping consecutive intervals.
+  let num = 0;
+  let den = 0;
+  for (let i = 1; i < pts.length; i++) {
+    const older = pts[i - 1];
+    const newer = pts[i];
+    const dt = (older.daysAgo - newer.daysAgo) * DAY_SECONDS; // positive
+    if (dt <= 0 || older.pps <= 0 || newer.pps <= 0) continue;
+    const r = newer.pps / older.pps - 1;
+    // Use average totalAssets as the TVL weight; fall back to 1 when unknown.
+    const tvl = (older.ta + newer.ta) / 2 || 1;
+    num += tvl * r;
+    den += tvl * dt;
   }
 
-  // Weighted average: weight = 1/days (shorter = more weight)
-  let totalWeight = 0;
-  let weightedSum = 0;
-  for (const { days, apy } of validApys) {
-    const w = 1 / days;
-    totalWeight += w;
-    weightedSum += apy * w;
-  }
-  const blendedApy = weightedSum / totalWeight;
+  // apyBase7d: single-interval [LVT−7d → LVT] realized APY.
+  const pps7d = historicalData.pps[2];
+  const raw7d = pps7d > 0 ? ((currentPps / pps7d - 1) / 7) * 365 * 100 : 0;
+  const apyBase7d = raw7d > 0 && raw7d <= 1000 ? raw7d : 0;
 
-  // apyBase7d: prefer the 7d window directly, fallback to blended
-  const sevenDay = validApys.find((a) => a.days === 7);
-  const apyBase7d = sevenDay ? sevenDay.apy : blendedApy;
+  if (den <= 0) return { apyBase: apyBase7d, apyBase7d };
 
-  return { apyBase: blendedApy, apyBase7d };
+  const apyRaw = (YEAR_SECS * num) / den * 100;
+  // Cap: negative (loss period) → 0; unreasonably large spike → fall back to 7d.
+  const apyBase =
+    apyRaw < 0 ? 0 : apyRaw <= 1000 ? apyRaw : apyBase7d;
+
+  return { apyBase, apyBase7d };
 };
 
 /**
@@ -293,8 +319,8 @@ const getVaultsForChain = async (chain) => {
 };
 
 /**
- * Historical oracle PPS for the APY windows, anchored at each vault's LAST NAV
- * update (lastValuationTimestamp) rather than `now`.
+ * Historical oracle PPS + vault totalAssets for the APY windows, anchored at
+ * each vault's LAST NAV update (lastValuationTimestamp) rather than `now`.
  *
  * Why: the oracle PPS only moves on a NAV update and is flat in between. If we
  * anchored the lookback at `now`, then once a vault stops updating the trailing
@@ -304,7 +330,8 @@ const getVaultsForChain = async (chain) => {
  * computed rate is the one realized at the last NAV and stays constant until the
  * next NAV — i.e. it is extrapolated forward to now.
  *
- * Returns { vaultAddr: [pps@(tLast-7d), pps@(tLast-14d), pps@(tLast-30d)] }.
+ * Returns { vaultAddr: { pps: [...], ta: [...] } } indexed by LOOKBACK_DAYS.
+ * `ta` (totalAssets) is used as the TVL weight in computeTvlWeightedApy.
  */
 const getAnchoredHistoricalPps = async (vaults, chain) => {
   const withOracle = vaults.filter((v) => v.oracle);
@@ -346,27 +373,46 @@ const getAnchoredHistoricalPps = async (vaults, chain) => {
 
   const result = {};
   withOracle.forEach((v) => {
-    result[v.address] = new Array(LOOKBACK_DAYS.length).fill(0);
+    result[v.address] = {
+      pps: new Array(LOOKBACK_DAYS.length).fill(0),
+      ta: new Array(LOOKBACK_DAYS.length).fill(0),
+    };
   });
 
   await Promise.all(
     Object.entries(byBlock).map(async ([block, items]) => {
       try {
-        const ppsRes = await sdk.api.abi.multiCall({
-          calls: items.map((it) => ({ target: it.oracle })),
-          abi: ABI.getLastSavedPricePerShare,
-          chain,
-          block: Number(block),
-          permitFailure: true,
-        });
+        // Fetch oracle PPS and vault totalAssets at this historical block.
+        const [ppsRes, taRes] = await Promise.all([
+          sdk.api.abi.multiCall({
+            calls: items.map((it) => ({ target: it.oracle })),
+            abi: ABI.getLastSavedPricePerShare,
+            chain,
+            block: Number(block),
+            permitFailure: true,
+          }),
+          sdk.api.abi.multiCall({
+            calls: items.map((it) => ({ target: it.vaultAddr })),
+            abi: ABI.totalAssets,
+            chain,
+            block: Number(block),
+            permitFailure: true,
+          }),
+        ]);
         items.forEach((it, i) => {
-          const o = ppsRes.output[i];
-          if (o?.success && o.output !== '0') {
-            result[it.vaultAddr][it.wIndex] = toDecimal(o.output, 18);
+          const ppsO = ppsRes.output[i];
+          if (ppsO?.success && ppsO.output !== '0') {
+            result[it.vaultAddr].pps[it.wIndex] = toDecimal(ppsO.output, 18);
+          }
+          const taO = taRes.output[i];
+          if (taO?.success && taO.output !== '0') {
+            result[it.vaultAddr].ta[it.wIndex] = Number(
+              BigInt(taO.output.toString()),
+            );
           }
         });
       } catch (e) {
-        // Leave these windows at 0; computeSmoothedApy ignores empty windows.
+        // Leave these windows at 0; computeTvlWeightedApy ignores empty windows.
       }
     }),
   );
@@ -453,14 +499,18 @@ const main = async () => {
             ? ratio1e18(vault.totalAssets, vault.totalSupply)
             : 0);
 
-        // Historical PPS for this vault, anchored at its last NAV update.
-        const vaultHistoricalPps = anchoredHist[vault.address] || [];
+        // Historical PPS + totalAssets for this vault, anchored at its last NAV.
+        const vaultHistoricalData = anchoredHist[vault.address] || {
+          pps: [],
+          ta: [],
+        };
 
-        // Smoothed APY: weighted blend across 7d/14d/30d windows
-        // This prevents spikes when oracle updates after days of silence
-        const { apyBase, apyBase7d } = computeSmoothedApy(
+        // TVL+time-weighted linear APY over non-overlapping intervals.
+        // Matches the app formula: YEAR × Σ(TVLᵢ·rᵢ) / Σ(TVLᵢ·Δtᵢ).
+        const { apyBase, apyBase7d } = computeTvlWeightedApy(
           currentSharePrice,
-          vaultHistoricalPps,
+          Number(vault.totalAssets),
+          vaultHistoricalData,
         );
 
         // Build fee metadata string

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -1,0 +1,312 @@
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+const axios = require('axios');
+
+const PROJECT_NAME = 't3tris-finance';
+
+// T3tris protocol factory — deterministic CREATE3 address, same on all chains
+const T3TRIS_FACTORY = '0x7DD63c4eE5CD277B7870155371a6d62A2f7b1652';
+
+// ABIs for the T3tris protocol
+const ABI = {
+  getDeployedVaultsCount:
+    'function getDeployedVaultsCount() external view returns (uint256)',
+  getDeployedVaults:
+    'function getDeployedVaults(uint256 fromIndex, uint256 toIndex) external view returns (address[])',
+  totalAssets: 'function totalAssets() view returns (uint256)',
+  totalSupply: 'function totalSupply() view returns (uint256)',
+  asset: 'function asset() view returns (address)',
+  decimals: 'function decimals() view returns (uint8)',
+  symbol: 'function symbol() view returns (string)',
+  name: 'function name() view returns (string)',
+  convertToAssets:
+    'function convertToAssets(uint256 shares) view returns (uint256)',
+  getPerfFee: 'function getPerfFee() external view returns (uint16)',
+  getManagementFee:
+    'function getManagementFee() external view returns (uint16 managementFeeBps, uint32 managementFeeDays)',
+  getEntryFee: 'function getEntryFee() external view returns (uint16)',
+  getExitFee: 'function getExitFee() external view returns (uint16)',
+  isVaultOpen: 'function isVaultOpen() external view returns (bool)',
+};
+
+// Chains where T3tris will be deployed
+const CHAINS = [
+  'ethereum',
+  'arbitrum',
+  'base',
+  'optimism',
+  'polygon',
+  'avax',
+  'bsc',
+  'linea',
+  'scroll',
+  'blast',
+  'mantle',
+  'mode',
+  'fantom',
+  'sonic',
+];
+
+const DAY_SECONDS = 24 * 3600;
+
+const multiCall = (targets, abi, chain, block = undefined) =>
+  sdk.api.abi.multiCall({
+    calls: targets.map((target) => ({ target })),
+    abi,
+    chain,
+    block,
+    permitFailure: true,
+  });
+
+const getBlockNumber = async (timestamp, chain) => {
+  try {
+    const response = await axios.get(
+      `https://coins.llama.fi/block/${chain}/${timestamp}`
+    );
+    return response.data.height;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Calculate APY from share price change over N days.
+ * APY = (currentPrice / historicalPrice - 1) / days * 365 * 100
+ */
+const calcApy = (currentPrice, historicalPrice, days) => {
+  if (!historicalPrice || historicalPrice <= 0 || !currentPrice) return 0;
+  const priceChange = (currentPrice - historicalPrice) / historicalPrice;
+  const apy = (priceChange / days) * 365 * 100;
+  // Cap at reasonable bounds
+  if (apy > 1000 || apy < 0) return 0;
+  return apy;
+};
+
+/**
+ * Discover all T3tris vaults from the factory on a given chain.
+ */
+const getVaultsForChain = async (chain) => {
+  let count;
+  try {
+    const countResult = await sdk.api.abi.call({
+      target: T3TRIS_FACTORY,
+      abi: ABI.getDeployedVaultsCount,
+      chain,
+    });
+    count = Number(countResult.output);
+  } catch {
+    // Factory not deployed on this chain yet
+    return [];
+  }
+
+  if (count === 0) return [];
+
+  const vaultsResult = await sdk.api.abi.call({
+    target: T3TRIS_FACTORY,
+    abi: ABI.getDeployedVaults,
+    params: [0, count - 1],
+    chain,
+  });
+
+  const vaultAddresses = vaultsResult.output;
+  if (!vaultAddresses || vaultAddresses.length === 0) return [];
+
+  // Batch-fetch vault metadata
+  const [
+    totalAssetsRes,
+    totalSupplyRes,
+    assetRes,
+    decimalsRes,
+    symbolRes,
+    nameRes,
+    perfFeeRes,
+    mgmtFeeRes,
+    entryFeeRes,
+    exitFeeRes,
+  ] = await Promise.all([
+    multiCall(vaultAddresses, ABI.totalAssets, chain),
+    multiCall(vaultAddresses, ABI.totalSupply, chain),
+    multiCall(vaultAddresses, ABI.asset, chain),
+    multiCall(vaultAddresses, ABI.decimals, chain),
+    multiCall(vaultAddresses, ABI.symbol, chain),
+    multiCall(vaultAddresses, ABI.name, chain),
+    multiCall(vaultAddresses, ABI.getPerfFee, chain),
+    multiCall(vaultAddresses, ABI.getManagementFee, chain),
+    multiCall(vaultAddresses, ABI.getEntryFee, chain),
+    multiCall(vaultAddresses, ABI.getExitFee, chain),
+  ]);
+
+  const vaults = vaultAddresses.map((address, i) => {
+    const totalAssets = totalAssetsRes.output[i];
+    const totalSupply = totalSupplyRes.output[i];
+    const asset = assetRes.output[i];
+    const decimals = decimalsRes.output[i];
+    const symbol = symbolRes.output[i];
+    const name = nameRes.output[i];
+
+    if (
+      !totalAssets?.success ||
+      !totalSupply?.success ||
+      !asset?.success ||
+      !decimals?.success ||
+      !symbol?.success
+    ) {
+      return null;
+    }
+
+    return {
+      address: address.toLowerCase(),
+      totalAssets: totalAssets.output,
+      totalSupply: totalSupply.output,
+      asset: asset.output.toLowerCase(),
+      decimals: Number(decimals.output),
+      symbol: symbol.output,
+      name: name?.success ? name.output : symbol.output,
+      perfFeeBps: perfFeeRes.output[i]?.success
+        ? Number(perfFeeRes.output[i].output)
+        : 0,
+      mgmtFeeBps:
+        mgmtFeeRes.output[i]?.success
+          ? Number(mgmtFeeRes.output[i].output.managementFeeBps || mgmtFeeRes.output[i].output[0] || 0)
+          : 0,
+      mgmtFeeDays:
+        mgmtFeeRes.output[i]?.success
+          ? Number(mgmtFeeRes.output[i].output.managementFeeDays || mgmtFeeRes.output[i].output[1] || 365)
+          : 365,
+      entryFeeBps: entryFeeRes.output[i]?.success
+        ? Number(entryFeeRes.output[i].output)
+        : 0,
+      exitFeeBps: exitFeeRes.output[i]?.success
+        ? Number(exitFeeRes.output[i].output)
+        : 0,
+    };
+  });
+
+  return vaults.filter((v) => v !== null);
+};
+
+/**
+ * Get historical share prices (totalAssets/totalSupply) for APY calculation.
+ */
+const getHistoricalSharePrices = async (vaultAddresses, chain, daysAgo) => {
+  const timestamp = Math.floor(Date.now() / 1000) - DAY_SECONDS * daysAgo;
+  const historicalBlock = await getBlockNumber(timestamp, chain);
+
+  if (!historicalBlock) return {};
+
+  try {
+    const [totalAssetsRes, totalSupplyRes] = await Promise.all([
+      multiCall(vaultAddresses, ABI.totalAssets, chain, historicalBlock),
+      multiCall(vaultAddresses, ABI.totalSupply, chain, historicalBlock),
+    ]);
+
+    const sharePrices = {};
+    for (let i = 0; i < vaultAddresses.length; i++) {
+      const totalAssets = totalAssetsRes.output[i];
+      const totalSupply = totalSupplyRes.output[i];
+
+      if (
+        totalAssets?.success &&
+        totalSupply?.success &&
+        totalSupply.output !== '0'
+      ) {
+        sharePrices[vaultAddresses[i].toLowerCase()] =
+          Number(totalAssets.output) / Number(totalSupply.output);
+      }
+    }
+
+    return sharePrices;
+  } catch (e) {
+    console.error(
+      `[t3tris] Error fetching historical data for ${chain} (${daysAgo}d ago):`,
+      e.message
+    );
+    return {};
+  }
+};
+
+const main = async () => {
+  const pools = [];
+
+  for (const chain of CHAINS) {
+    try {
+      const vaults = await getVaultsForChain(chain);
+
+      if (vaults.length === 0) continue;
+
+      // Get prices for underlying assets
+      const assetAddresses = [...new Set(vaults.map((v) => v.asset))];
+      const prices = await utils.getPrices(assetAddresses, chain);
+
+      // Get historical share prices for APY (1d and 7d)
+      const vaultAddresses = vaults.map((v) => v.address);
+      const [historicalPrices1d, historicalPrices7d] = await Promise.all([
+        getHistoricalSharePrices(vaultAddresses, chain, 1),
+        getHistoricalSharePrices(vaultAddresses, chain, 7),
+      ]);
+
+      for (const vault of vaults) {
+        const price = prices.pricesByAddress[vault.asset];
+        if (!price) continue;
+
+        // Calculate TVL in USD
+        const totalAssetsNormalized =
+          Number(vault.totalAssets) / 10 ** vault.decimals;
+        const tvlUsd = totalAssetsNormalized * price;
+
+        // Skip negligible vaults
+        if (tvlUsd < 100) continue;
+
+        // Current share price: totalAssets / totalSupply
+        const currentSharePrice =
+          vault.totalSupply !== '0'
+            ? Number(vault.totalAssets) / Number(vault.totalSupply)
+            : 0;
+
+        // APY from share price growth
+        const historicalPrice1d = historicalPrices1d[vault.address];
+        const historicalPrice7d = historicalPrices7d[vault.address];
+        const apyBase = calcApy(currentSharePrice, historicalPrice1d, 1);
+        const apyBase7d = calcApy(currentSharePrice, historicalPrice7d, 7);
+
+        // Build fee metadata string
+        const feeParts = [];
+        if (vault.perfFeeBps > 0)
+          feeParts.push(`Perf: ${(vault.perfFeeBps / 100).toFixed(1)}%`);
+        if (vault.mgmtFeeBps > 0)
+          feeParts.push(`Mgmt: ${(vault.mgmtFeeBps / 100).toFixed(1)}%`);
+        if (vault.entryFeeBps > 0)
+          feeParts.push(`Entry: ${(vault.entryFeeBps / 100).toFixed(2)}%`);
+        if (vault.exitFeeBps > 0)
+          feeParts.push(`Exit: ${(vault.exitFeeBps / 100).toFixed(2)}%`);
+        const poolMeta = feeParts.length > 0 ? feeParts.join(' | ') : undefined;
+
+        pools.push({
+          pool: `${vault.address}-${chain}`.toLowerCase(),
+          chain: utils.formatChain(chain),
+          project: PROJECT_NAME,
+          symbol: utils.formatSymbol(vault.symbol),
+          tvlUsd,
+          apyBase,
+          apyBase7d,
+          underlyingTokens: [vault.asset],
+          poolMeta,
+          url: `https://app.t3tris.finance/vault/${vault.address}`,
+        });
+      }
+    } catch (error) {
+      console.error(
+        `[t3tris] Error fetching data for ${chain}:`,
+        error.message
+      );
+    }
+  }
+
+  return pools.filter((p) => utils.keepFinite(p));
+};
+
+module.exports = {
+  timetravel: false,
+  apy: main,
+  url: 'https://app.t3tris.finance',
+};

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -54,10 +54,28 @@ const multiCall = (targets, abi, chain, block = undefined) =>
     permitFailure: true,
   });
 
+// Convert a raw on-chain integer (string/BigInt) to a JS float scaled by
+// `decimals`, without the precision loss of Number(BigInt) on large values
+// (vault/PPS magnitudes routinely exceed Number.MAX_SAFE_INTEGER).
+const toDecimal = (raw, decimals) => {
+  if (raw === undefined || raw === null) return 0;
+  const v = BigInt(raw.toString());
+  const base = 10n ** BigInt(decimals);
+  return Number(v / base) + Number(v % base) / 10 ** Number(decimals);
+};
+
+// Ratio of two raw on-chain integers as a float, computed in BigInt space.
+const ratio1e18 = (numRaw, denRaw) => {
+  const den = BigInt(denRaw.toString());
+  if (den === 0n) return 0;
+  return Number((BigInt(numRaw.toString()) * 10n ** 18n) / den) / 1e18;
+};
+
 const getBlockNumber = async (timestamp, chain) => {
   try {
     const response = await axios.get(
       `https://coins.llama.fi/block/${chain}/${timestamp}`,
+      { timeout: 10000 },
     );
     return response.data.height;
   } catch {
@@ -139,7 +157,7 @@ const getVaultsForChain = async (chain) => {
   // Discover verified, non-blacklisted vaults from the T3tris ecosystem API
   let vaultAddresses;
   try {
-    const { data } = await axios.get(VAULTS_API);
+    const { data } = await axios.get(VAULTS_API, { timeout: 10000 });
     const chainId = CHAIN_IDS[chain];
     vaultAddresses = (data || [])
       .filter(
@@ -269,8 +287,10 @@ const getHistoricalOraclePps = async (vaults, chain, daysAgo) => {
     const result = {};
     for (let i = 0; i < vaultsWithOracle.length; i++) {
       if (ppsRes.output[i]?.success && ppsRes.output[i].output !== '0') {
-        result[vaultsWithOracle[i].address] =
-          Number(ppsRes.output[i].output) / 1e18;
+        result[vaultsWithOracle[i].address] = toDecimal(
+          ppsRes.output[i].output,
+          18,
+        );
       }
     }
 
@@ -304,8 +324,10 @@ const getCurrentOraclePps = async (vaults, chain) => {
     const result = {};
     for (let i = 0; i < vaultsWithOracle.length; i++) {
       if (ppsRes.output[i]?.success && ppsRes.output[i].output !== '0') {
-        result[vaultsWithOracle[i].address] =
-          Number(ppsRes.output[i].output) / 1e18;
+        result[vaultsWithOracle[i].address] = toDecimal(
+          ppsRes.output[i].output,
+          18,
+        );
       }
     }
 
@@ -343,8 +365,10 @@ const main = async () => {
         if (!price) continue;
 
         // Calculate TVL in USD
-        const totalAssetsNormalized =
-          Number(vault.totalAssets) / 10 ** vault.decimals;
+        const totalAssetsNormalized = toDecimal(
+          vault.totalAssets,
+          vault.decimals,
+        );
         const tvlUsd = totalAssetsNormalized * price;
 
         // Skip negligible vaults
@@ -355,7 +379,7 @@ const main = async () => {
         const currentSharePrice =
           currentPps[vault.address] ||
           (vault.totalSupply !== '0'
-            ? Number(vault.totalAssets) / Number(vault.totalSupply)
+            ? ratio1e18(vault.totalAssets, vault.totalSupply)
             : 0);
 
         // Collect historical PPS at each lookback window for this vault


### PR DESCRIPTION
## Protocol info

- **Description**: T3tris is a zero fee, permissionless vault infrastructure.
- **Website**: https://t3tris.finance
- **Category**: Onchain Capital Allocator

## Methodology descriptions

- **TVL**: Total value of assets held across all verified T3tris vaults, including assets deployed in strategies, pending deposits, and claimable redemptions.
- **Fees**: Total yield generated by vault strategies, including depositor yield, curator fees and T3tris treasury profit.
- **Revenue**: Earnings sent to the T3tris treasury. Third-party services are also T3tris revenue but are not observable on-chain.

---

## What this PR adds

A new APY adapter for T3tris Finance vaults on Arbitrum.

### Data sources
- **Vault discovery**: ecosystem API (`ecosystem.t3tris.finance/vaults`) — only verified, non-blacklisted, public vaults
- **APY**: annualized from on-chain oracle PPS over a single fixed 7-day window, anchored at the vault's last oracle valuation timestamp
- **TVL**: `vault.totalAssets()` × asset price (USD)
- **pricePerShare**: oracle `getLastSavedPricePerShare` (immune to settlement-cycle artifacts)

### APY formula
```
APY = (PPS_current / PPS_(LVT−7d) − 1) / 7 × 365 × 100
```
Single fixed 7-day window, consistent across all vaults. The historical price-per-share is read 7 days before the vault's last oracle valuation timestamp (last NAV) and the current PPS is the value saved at that NAV, so the realized rate is held rather than decaying as flat days accumulate.

