### PR TITLE
accountable: fix duplicate 'Points' in poolMeta label

### DIFF
--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -211,7 +211,7 @@ const apy = async() => {
                 .map((b) => b?.point_name)
                 .filter(Boolean);
             const poolMeta = pointNames.length
-                ? `Earn ${pointNames.join(', ')} Points`
+                ? `Earn ${pointNames.map((n) => n.replace(/\s*points?$/i, '')).join(', ')} Points`
                 : undefined;
 
             return {


### PR DESCRIPTION
Follow-up to #2733. The `poolMeta` label appended " Points" unconditionally, so a point whose name already ends in "Points" rendered doubled — e.g. `Earn Aegis Points Points`. Strip a trailing "Point(s)" from each point name before appending, so `ACC` → `Earn ACC Points` and `Aegis Points` → `Earn Aegis Points`. Verified with `npm run test --adapter=accountable`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced formatting of point boost names displayed throughout the interface. Point names now appear without redundant "point(s)" labels, providing a cleaner, more consistent visual presentation. This improvement enhances clarity and readability when users review boost information and point-related details across all point boost displays in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->