### PR TITLE
chore: rename symbols ton -> gram

### DIFF
--- a/src/adaptors/affluent/index.js
+++ b/src/adaptors/affluent/index.js
@@ -31,7 +31,7 @@ const getAPY = async () => {
         ]);
 
         const merged = [...strategy, ...share];
-        return merged;
+        return merged.filter((p) => Number.isFinite(p.apyBase));
     } catch (err) {
         console.error("getAPY failed:", err);
         return [];
@@ -137,7 +137,7 @@ async function getAssetMap() {
     for (const item of data) {
         let symbol = item.symbol;
 
-        if (symbol === "FactorialTON") {
+        if (symbol === "FactorialTON" || symbol === "TON") {
             symbol = "GRAM";
         }
 

--- a/src/adaptors/affluent/index.js
+++ b/src/adaptors/affluent/index.js
@@ -10,7 +10,7 @@ const LENDING_VAULTS = [
     {
         address: "EQADQ6JcK0NMuNM5uwCcS9bjcn2RTvcxYIZjNlhIhywUrfBN",
         underlying: "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c",
-        symbol: "TON",
+        symbol: "GRAM",
     },
     {
         address: "EQAGtgnr1G0XDilGURcOB3pUhl-Lo__J-TaJP0K4ey8cuSaW",
@@ -138,7 +138,7 @@ async function getAssetMap() {
         let symbol = item.symbol;
 
         if (symbol === "FactorialTON") {
-            symbol = "TON";
+            symbol = "GRAM";
         }
 
         map[item.address] = symbol;

--- a/src/adaptors/daolama/index.js
+++ b/src/adaptors/daolama/index.js
@@ -127,7 +127,7 @@ async function getApy() {
         client,
         'EQCkeTvOSTBwBtP06X2BX7THj_dlX67PhgYRGuKfjWtB9FVb',
         'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c',
-        'TON',
+        'GRAM',
         tonPrice,
         1e9,
         'Main',

--- a/src/adaptors/dedust/index.js
+++ b/src/adaptors/dedust/index.js
@@ -68,15 +68,17 @@ const getApy = async () => {
             const right = assetInfo[rightAddr];
             if (!left || !right) continue;
 
+            const leftSym = left.symbol === 'TON' ? 'GRAM' : left.symbol;
+            const rightSym = right.symbol === 'TON' ? 'GRAM' : right.symbol;
             let symbol;
-            if (left.symbol == 'USDT') {
-                symbol = `${right.symbol}-${left.symbol}`;
-            } else if (right.symbol == 'USDT') {
-                symbol = `${left.symbol}-${right.symbol}`;
-            } else if (left.symbol == 'TON' || left.symbol == 'GRAM') {
-                symbol = `${right.symbol}-${left.symbol}`;
+            if (leftSym == 'USDT') {
+                symbol = `${rightSym}-${leftSym}`;
+            } else if (rightSym == 'USDT') {
+                symbol = `${leftSym}-${rightSym}`;
+            } else if (leftSym == 'GRAM') {
+                symbol = `${rightSym}-${leftSym}`;
             } else {
-                symbol = `${left.symbol}-${right.symbol}`;
+                symbol = `${leftSym}-${rightSym}`;
             }
 
             const aprFees = Number(p.apr_fees) || 0;

--- a/src/adaptors/dedust/index.js
+++ b/src/adaptors/dedust/index.js
@@ -73,7 +73,7 @@ const getApy = async () => {
                 symbol = `${right.symbol}-${left.symbol}`;
             } else if (right.symbol == 'USDT') {
                 symbol = `${left.symbol}-${right.symbol}`;
-            } else if (left.symbol == 'TON') {
+            } else if (left.symbol == 'TON' || left.symbol == 'GRAM') {
                 symbol = `${right.symbol}-${left.symbol}`;
             } else {
                 symbol = `${left.symbol}-${right.symbol}`;

--- a/src/adaptors/evaa-protocol/index.js
+++ b/src/adaptors/evaa-protocol/index.js
@@ -675,7 +675,7 @@ async function getPoolData(
       pool: `evaa-${assetId}-${poolName}-ton`.toLowerCase(),
       chain: 'Ton',
       project: 'evaa-protocol',
-      symbol: tokenSymbol,
+      symbol: tokenSymbol === 'TON' ? 'GRAM' : tokenSymbol,
       tvlUsd: totalSupplyUsd - totalBorrowUsd,
       apyBase: supplyApy * 100,
       apyReward,

--- a/src/adaptors/fiva/index.js
+++ b/src/adaptors/fiva/index.js
@@ -20,6 +20,7 @@ const TON_COINGECKO = {
   stgusd: 'coingecko:usd-coin',
 };
 const resolveTonToken = (symbol, address) => TON_COINGECKO[symbol?.toLowerCase()] || address;
+const renameNativeTon = (symbol) => (symbol === 'TON' ? 'GRAM' : symbol);
 
 function expiryToText(dateIso) {
   return new Date(dateIso)
@@ -39,7 +40,7 @@ function createLpPools(assets) {
       pool: asset.jettons.lp.master_address.toLowerCase(),
       chain: utils.formatChain(TON_CHAIN.chainName),
       project: 'fiva',
-      symbol: asset.jettons.lp.symbol.replace('LP ', ''),
+      symbol: renameNativeTon(asset.jettons.lp.symbol.replace('LP ', '')),
       tvlUsd: asset.pool_liquidity_usd, // Use pool liquidity for LP pools
       apyBase: asset.pool_apr_7d, // Prefer 7-day APR
       apyReward: 0, // No separate reward system visible in API
@@ -57,7 +58,7 @@ function createPtPools(assets) {
       pool: asset.jettons.pt.master_address.toLowerCase(),
       chain: utils.formatChain(TON_CHAIN.chainName),
       project: 'fiva',
-      symbol: asset.jettons.pt.symbol.replace('PT ', ''),
+      symbol: renameNativeTon(asset.jettons.pt.symbol.replace('PT ', '')),
       tvlUsd: asset.asset_tvl_usd,
       apyBase: asset.fixed_apr,
       underlyingTokens: [resolveTonToken(asset.jettons.underlying_jetton.symbol, asset.jettons.underlying_jetton.master_address)],

--- a/src/adaptors/fiva/index.js
+++ b/src/adaptors/fiva/index.js
@@ -12,6 +12,7 @@ const TON_COINGECKO = {
   tston: 'coingecko:the-open-network',
   stton: 'coingecko:the-open-network',
   ton: 'coingecko:the-open-network',
+  gram: 'coingecko:the-open-network',
   usdt: 'coingecko:tether',
   'usd₮': 'coingecko:tether',
   eusdt: 'coingecko:tether',

--- a/src/adaptors/ston.fi/index.js
+++ b/src/adaptors/ston.fi/index.js
@@ -47,7 +47,7 @@ const getApy = async () => {
                 symbol = `${s2}-${s1}`
             } else if (s2 == 'USD₮') {
                 symbol = `${s1}-${s2}`
-            } else if (s1 == 'TON') {
+            } else if (s1 == 'TON' || s1 == 'GRAM') {
                 symbol = `${s2}-${s1}`
             } else {
                 symbol = `${s1}-${s2}`

--- a/src/adaptors/ston.fi/index.js
+++ b/src/adaptors/ston.fi/index.js
@@ -39,8 +39,9 @@ const getApy = async () => {
                 console.error("Can't find symbol", pool_info);
                 return null;
             }
-            const s1 = asset2symbol[pool_info.tokens[0]]
-            const s2 = asset2symbol[pool_info.tokens[1]];
+            const renameNativeTon = (s) => (s === 'TON' ? 'GRAM' : s);
+            const s1 = renameNativeTon(asset2symbol[pool_info.tokens[0]]);
+            const s2 = renameNativeTon(asset2symbol[pool_info.tokens[1]]);
             // use apropriate base-quote order
             let symbol = '';
             if (s1 == 'USD₮') {

--- a/src/adaptors/storm-trade/index.js
+++ b/src/adaptors/storm-trade/index.js
@@ -33,7 +33,7 @@ const getApr = async () => {
         pool: `${vault.address}-ton`.toLowerCase(),
         chain: 'Ton',
         project: 'storm-trade',
-        symbol: vault.config.asset.name,
+        symbol: vault.config.asset.name === 'TON' ? 'GRAM' : vault.config.asset.name,
         tvlUsd:
           ((Number(vault.freeBalance) + Number(vault.lockedBalance)) / 1e9) *
           price,

--- a/src/adaptors/swap.coffee/index.js
+++ b/src/adaptors/swap.coffee/index.js
@@ -7,7 +7,7 @@ function extractPoolSymbol(tokens) {
   const parts = []
 
   for (let asset of tokens) {
-    parts.push(asset["address"]["address"] === "native" ? "TON" : asset["metadata"]["symbol"])
+    parts.push(asset["address"]["address"] === "native" ? "GRAM" : asset["metadata"]["symbol"])
   }
 
   return parts.join("-")

--- a/src/adaptors/tonco/index.js
+++ b/src/adaptors/tonco/index.js
@@ -32,7 +32,7 @@ const getApy = async () => {
         const tvl = pool.totalValueLockedUsd;
 
         poolsInfo[pool.address] = {
-            symbol: pool.name.replace('wTTon', 'TON'),
+            symbol: pool.name.replace('wTTon', 'GRAM'),
             tvl: tvl,
             apyBase: pool.apr,
             underlyingTokens: [Address.parse(pool.jetton0.address).toString(), Address.parse(pool.jetton1.address).toString()]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated token symbol handling to consistently report `GRAM` instead of `TON` across multiple protocol adapters (vaults, pools, and asset resolution), improving consistency in displayed token pairs.
  * Adjusted lending-vault APY aggregation to exclude non-finite APY entries, preventing incorrect or misleading APY values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->