### PR TITLE
Add Liquidium ICP pool to yields adapter

### DIFF
--- a/src/adaptors/liquidium/index.js
+++ b/src/adaptors/liquidium/index.js
@@ -5,10 +5,12 @@ const LENDING_CANISTER_ID = 'hyk4r-jqaaa-aaaar-qb4ca-cai'
 const BTC_POOL_CANISTER_ID = 'hkmli-faaaa-aaaar-qb4ba-cai'
 const USDT_POOL_CANISTER_ID = 'hnnn4-iyaaa-aaaar-qb4bq-cai'
 const USDC_POOL_CANISTER_ID = '6sna2-oiaaa-aaaar-qb66q-cai'
+const ICP_POOL_CANISTER_ID = 'r2pk3-4yaaa-aaaar-qb7zq-cai'
 const ALLOWED_POOL_CANISTERS = new Set([
   BTC_POOL_CANISTER_ID,
   USDT_POOL_CANISTER_ID,
   USDC_POOL_CANISTER_ID,
+  ICP_POOL_CANISTER_ID,
 ])
 const RAY = 10n ** 27n
 const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
@@ -18,6 +20,7 @@ const ASSET_META = {
   SOL: { decimals: 9, coingeckoId: 'solana' },
   USDC: { decimals: 6, coingeckoId: 'usd-coin' },
   USDT: { decimals: 6, coingeckoId: 'tether' },
+  ICP: { decimals: 8, coingeckoId: 'internet-computer' },
 }
 
 const STABLES = new Set(['USDC', 'USDT'])
@@ -56,6 +59,7 @@ const CANDID_LABELS = [
   'SOL',
   'USDC',
   'USDT',
+  'ICP',
   'CkAsset',
   'Unknown',
 ]
@@ -195,7 +199,7 @@ async function getSourceData() {
 }
 
 function buildPriceMap(prices) {
-  const priceMap = { BTC: null, SOL: null, USDC: 1, USDT: 1 }
+  const priceMap = { BTC: null, SOL: null, USDC: 1, USDT: 1, ICP: null }
   for (const [pair, priceInt, decimals] of prices) {
     if (!pair.endsWith('_USDT')) continue
     const asset = pair.split('_')[0]


### PR DESCRIPTION
Adds the Liquidium ICP lending pool canister to the Liquidium yields adapter allowlist.

The adapter now maps ICP metadata and accepts the ICP Candid asset label, so the existing APY, TVL, borrow, and underlying token reporting include the new pool.

Related PRs:
- TVL adapter: https://github.com/DefiLlama/DefiLlama-Adapters/pull/19681
- Protocol metadata: https://github.com/DefiLlama/defillama-server/pull/12240

Validation:
- `npm run test --adapter=liquidium`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Internet Computer Protocol (ICP) support to the Liquidium adapter
* ICP pools are now eligible for inclusion in yield and liquidity calculations
* ICP asset pricing is available through multiple pricing mechanisms
* Enhanced adapter coverage with expanded asset support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
