### PR TITLE
fix(snowbl-capital): migrate to new vaults (USDC/ETH/BTC)

### DIFF
--- a/src/adaptors/snowbl-capital/index.js
+++ b/src/adaptors/snowbl-capital/index.js
@@ -1,25 +1,62 @@
 const utils = require('../utils');
 
+const CHAIN = 'base';
+
+const vaults = [
+  {
+    address: '0x0e1a8354e10057092ecb7218b784c0c21710db91',
+    symbol: 'USDC',
+    underlyingToken: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    decimals: 6,
+    poolMeta: 'Snowbl Vault USD',
+  },
+  {
+    address: '0xffa67bd20e656f1c7873525df81728e9d26c8ee2',
+    symbol: 'WETH',
+    underlyingToken: '0x4200000000000000000000000000000000000006',
+    decimals: 18,
+    poolMeta: 'Snowbl Vault ETH',
+  },
+  {
+    address: '0xf423393e84ca810e1955a7806d1cd84d18099809',
+    symbol: 'cbBTC',
+    underlyingToken: '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf',
+    decimals: 8,
+    poolMeta: 'Snowbl Vault BTC',
+  },
+];
+
 const apy = async (timestamp) => {
-  const snowblVault = await utils.getERC4626Info(
-    '0xd61bfc9ca1d0d2b03a3dd74e2ab81df8e5f606e8',
-    'base',
-    timestamp
+  const { pricesByAddress } = await utils.getPrices(
+    vaults.map((v) => v.underlyingToken),
+    CHAIN
   );
 
-  const { tvl, ...rest } = snowblVault;
+  return Promise.all(
+    vaults.map(async (v) => {
+      const { tvl, ...rest } = await utils.getERC4626Info(
+        v.address,
+        CHAIN,
+        timestamp
+      );
+      const price = pricesByAddress[v.underlyingToken.toLowerCase()];
+      if (price == null || !Number.isFinite(price)) {
+        throw new Error(
+          `Missing/invalid price for ${v.underlyingToken} on ${CHAIN}`
+        );
+      }
 
-  return [
-    {
-      ...rest,
-      project: 'snowbl-capital',
-      symbol: 'USDC',
-      tvlUsd: tvl / 1e6,
-      underlyingTokens: ['0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'],
-      poolMeta: 'Snowbl Capital USDC Vault',
-      url: 'https://snowbl.capital',
-    },
-  ];
+      return {
+        ...rest,
+        project: 'snowbl-capital',
+        symbol: v.symbol,
+        tvlUsd: (tvl / 10 ** v.decimals) * price,
+        underlyingTokens: [v.underlyingToken],
+        poolMeta: v.poolMeta,
+        url: 'https://snowbl.capital',
+      };
+    })
+  );
 };
 
 module.exports = {


### PR DESCRIPTION
Snowbl Capital migrated its on-chain contracts. The previous single USDC vault `sSnowbl` (`0xd61b…06e8`) is retired.

This returns one pool per new Base ERC-4626 vault, each with its own underlying decimals and USD price:

| Pool | Vault | Underlying | Decimals |
|------|-------|------------|----------|
| USDC | `0x0e1a8354e10057092ecb7218b784c0c21710db91` | USDC  | 6 |
| ETH  | `0xffa67bd20e656f1c7873525df81728e9d26c8ee2` | WETH  | 18 |
| BTC  | `0xf423393e84ca810e1955a7806d1cd84d18099809` | cbBTC | 8 |

Verified locally against Base mainnet — the adapter returns 3 pools with correct TVL and price-per-share.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple Snowbl Capital ERC-4626 vaults (USDC, WETH, cbBTC) on the Base chain.

* **Improvements**
  * Updated APY and TVL calculations to use live underlying token pricing and return accurate per-vault metrics.
  * Added validation to surface an error when required underlying token prices are missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->