### PR TITLE
fix(sprinter): add profit deposit ordering and tvl fix

### DIFF
--- a/src/adaptors/sprinter/index.ts
+++ b/src/adaptors/sprinter/index.ts
@@ -16,7 +16,11 @@ const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 
 const DataQuery = gql`
     query DataQuery($from: BigInt = "", $to: BigInt = "") {
-        depositProfits(where: {blockTimestamp_gte: $from, blockTimestamp_lte: $to}) {
+        depositProfits(
+            where: {blockTimestamp_gte: $from, blockTimestamp_lte: $to}
+            orderBy: blockTimestamp
+            orderDirection: desc
+        ) {
             assets
             totalAssets
             blockTimestamp
@@ -52,6 +56,14 @@ async function apy() {
 
   const lastDepositProfit = depositProfits[0];
 
+  const totalAssets = (
+    await sdk.api.abi.call({
+      target: HUB_CONTRACT_ADDRESS,
+      abi: 'function totalAssets() external view returns (uint256)',
+      chain: 'base',
+    })
+  ).output;
+
   const timeDiff =
     new Date(parseInt(lastDepositProfit.blockTimestamp) * 1000).getTime() - startTimestamp;
   const daysInPeriod = Math.max(1, Math.floor(timeDiff / DAY_IN_MS));
@@ -66,7 +78,7 @@ async function apy() {
     pool: HUB_CONTRACT_ADDRESS,
     chain: utils.formatChain("base"),
     symbol: "USDC",
-    tvlUsd: Number(formatUnits(lastDepositProfit.totalAssets, USDC_DECIMALS)),
+    tvlUsd: Number(formatUnits(totalAssets, USDC_DECIMALS)),
     apy: rate * 100,
     underlyingTokens: [USDC_BASE],
   }];


### PR DESCRIPTION
profit deposits weren't ordered and tvl was taken from old profit deposit. This fixes incorrect data seen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TVL calculation to fetch real-time on-chain data instead of cached values, ensuring more accurate and current total value locked reporting.

* **Refactor**
  * Improved data retrieval methods for TVL metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->