### PR TITLE
fix(strata-markets): add PRIME pools, fix stablecoin flags, update URL

### DIFF
--- a/src/adaptors/checkStablecoin.js
+++ b/src/adaptors/checkStablecoin.js
@@ -24,6 +24,8 @@ const checkStablecoin = (el, stablecoins) => {
     stable = false;
   } else if (el.project === 'archimedes-finance' && symbolLC.includes('usd')) {
     stable = true;
+  } else if (el.project === 'strata-markets') {
+    stable = true;
   } else if (
     el.project === 'aura' &&
     [

--- a/src/adaptors/strata-markets/index.js
+++ b/src/adaptors/strata-markets/index.js
@@ -119,14 +119,14 @@ const apy = async () => {
       loadPool('ethena', 'jrUSDe'),
       loadPool('neutrl', 'srNUSD'),
       loadPool('neutrl', 'jrNUSD'),
-      loadPool('mhyper', 'srmHYPER', { stablecoin: true }),     // [FIX] underlying is USDC
-      loadPool('mhyper', 'jrmHYPER', { stablecoin: true }),     // [FIX] underlying is USDC
-      loadPool('mm1usd', 'srmM1USD', { stablecoin: true }),     // [FIX] underlying is USD-pegged
-      loadPool('mm1usd', 'jrmM1USD', { stablecoin: true }),     // [FIX] underlying is USD-pegged
+      loadPool('mhyper', 'srmHYPER'),
+      loadPool('mhyper', 'jrmHYPER'),
+      loadPool('mm1usd', 'srmM1USD'),
+      loadPool('mm1usd', 'jrmM1USD'),
       loadPool('saturn', 'srUSDat', { poolMeta: 'fixed-rate' }),// [FIX] constant APY by design
       loadPool('saturn', 'jrUSDat'),
-      loadPool('figure', 'srPRIME', { stablecoin: true }),       // [NEW] Figure/PRIME senior (USDC underlying)
-      loadPool('figure', 'jrPRIME', { stablecoin: true }),       // [NEW] Figure/PRIME junior (USDC underlying)
+      loadPool('figure', 'srPRIME'),
+      loadPool('figure', 'jrPRIME'),
     ]);
   } catch (error) {
     console.error('Error fetching APYs:', error);

--- a/src/adaptors/strata-markets/index.js
+++ b/src/adaptors/strata-markets/index.js
@@ -35,6 +35,13 @@ const Addresses = {
     jrUSDat: '0x011e55d2b28306458e37Ca7E997C879BB25A455D',
     underlying: '0x23238f20b894f29041f48D88eE91131C395Aaa71', // USDat
   },
+  // [NEW] Figure/PRIME market
+  figure: {
+    cdo: '0xff408b4843CDD4a33CD49EB2aBe057fE8D71C234',
+    srPRIME: '0x35bFF778d3fc53a561486BF28e761428499232Eb',
+    jrPRIME: '0xF4C91F24E20EE8ed5eda905E501A1136334C2F27',
+    underlying: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC (verified on-chain)
+  },
 };
 
 const getTotalSupply = async (tokenAddress, chain = 'ethereum') => {
@@ -82,7 +89,7 @@ const getAprs = async (cdoAddress, chain = 'ethereum') => {
   }
 };
 
-async function loadPool(tranche, symbol) {
+async function loadPool(tranche, symbol, overrides = {}) {
   const cdo = Addresses[tranche].cdo;
   const vault = Addresses[tranche][symbol];
 
@@ -101,6 +108,7 @@ async function loadPool(tranche, symbol) {
     tvlUsd: totalSupply * price,
     apyBase: apy,
     underlyingTokens: [Addresses[tranche].underlying],
+    ...overrides,
   };
 }
 
@@ -111,12 +119,14 @@ const apy = async () => {
       loadPool('ethena', 'jrUSDe'),
       loadPool('neutrl', 'srNUSD'),
       loadPool('neutrl', 'jrNUSD'),
-      loadPool('mhyper', 'srmHYPER'),
-      loadPool('mhyper', 'jrmHYPER'),
-      loadPool('mm1usd', 'srmM1USD'),
-      loadPool('mm1usd', 'jrmM1USD'),
-      loadPool('saturn', 'srUSDat'),
+      loadPool('mhyper', 'srmHYPER', { stablecoin: true }),     // [FIX] underlying is USDC
+      loadPool('mhyper', 'jrmHYPER', { stablecoin: true }),     // [FIX] underlying is USDC
+      loadPool('mm1usd', 'srmM1USD', { stablecoin: true }),     // [FIX] underlying is USD-pegged
+      loadPool('mm1usd', 'jrmM1USD', { stablecoin: true }),     // [FIX] underlying is USD-pegged
+      loadPool('saturn', 'srUSDat', { poolMeta: 'fixed-rate' }),// [FIX] constant APY by design
       loadPool('saturn', 'jrUSDat'),
+      loadPool('figure', 'srPRIME', { stablecoin: true }),       // [NEW] Figure/PRIME senior (USDC underlying)
+      loadPool('figure', 'jrPRIME', { stablecoin: true }),       // [NEW] Figure/PRIME junior (USDC underlying)
     ]);
   } catch (error) {
     console.error('Error fetching APYs:', error);
@@ -127,5 +137,5 @@ const apy = async () => {
 module.exports = {
   protocolId: '6873',
   apy,
-  url: 'https://strata.money/',
+  url: 'https://strata.markets/',
 };


### PR DESCRIPTION
## Changes

### 1. Add Figure/PRIME yield pools (srPRIME + jrPRIME)
The Figure/PRIME market was already tracked by the TVL adapter and fee adapter but missing from the yield pools. This adds both senior and junior tranches.

| Vault | Address |
|-------|---------|
| CDO | `0xff408b4843CDD4a33CD49EB2aBe057fE8D71C234` |
| srPRIME | `0x35bFF778d3fc53a561486BF28e761428499232Eb` |
| jrPRIME | `0xF4C91F24E20EE8ed5eda905E501A1136334C2F27` |
| Underlying | USDC (`0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`) — verified on-chain via `asset()` |

### 2. Fix stablecoin flags
- **mHYPER** (srmHYPER + jrmHYPER): underlying is USDC → `stablecoin: true`
- **mM1-USD** (srmM1USD + jrmM1USD): underlying is USD-pegged → `stablecoin: true`
- **PRIME** (srPRIME + jrPRIME): underlying is USDC → `stablecoin: true`

### 3. Add poolMeta for srUSDat
The SRUSDAT pool has zero APY variance (sigma=0) because the senior rate is manually set by a keeper per STRC distribution cycle. Added `poolMeta: 'fixed-rate'` to clarify this is by design.

### 4. Update URL
`strata.money` → `strata.markets` (canonical domain, strata.money 301-redirects to strata.markets)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional Strata Markets pools, including PRIME-related tranches (SRPRIME/JRPRIME).
* **Bug Fixes**
  * Improved pool metadata handling to surface more accurate fixed-rate labeling.
  * Updated stablecoin detection to treat Strata Markets pools as stable.
* **Chores**
  * Updated the Strata Markets website link to the new domain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->