### PR TITLE
chainflip-lending: fix tvlUsd (was Supplied, should be available liquidity) and migrate to on-chain RPC

### DIFF
--- a/src/adaptors/chainflip-lending/index.ts
+++ b/src/adaptors/chainflip-lending/index.ts
@@ -1,39 +1,141 @@
+/**
+ * Chainflip Lending — yield-server adapter (fully on-chain)
+ *
+ * TVL METHODOLOGY (aligned with Aave v3 and Compound v3)
+ * ─────────────────────────────────────────────────────────────────────────
+ * `tvlUsd` must represent idle liquidity: assets deposited by lenders that
+ * are not currently deployed in active loans. This is what Aave v3 calls
+ * "available liquidity" and what Compound v3 tracks as the spread between
+ * totalSupply and totalBorrow in each Comet market.
+ *
+ * The previous adapter forwarded `pool.tvl` from an external indexer API
+ * (explorer-service-processor.chainflip.io/defi-llama/yield). That field
+ * maps to `total_amount` on-chain — the full amount supplied by lenders
+ * including the portion already lent out. In DefiLlama's taxonomy that is
+ * "Supplied", not "TVL". Concrete impact at time of fix:
+ *
+ *   USDT  reported $480 K   →   actual idle liquidity $2.9 K  (util. 99.4 %)
+ *   USDC  reported $148 K   →   actual idle liquidity $4.0 K  (util. 97.3 %)
+ *   BTC   reported $1.29 M  →   actual idle liquidity $1.10 M (util. 14.8 %)
+ *
+ * Fix: tvlUsd is now sourced from cf_lending_pools → available_amount.
+ *
+ * APY METHODOLOGY
+ * ─────────────────────────────────────────────────────────────────────────
+ * Supply APY (apyBase) is derived entirely from on-chain fields returned by
+ * cf_lending_pools:
+ *
+ *   apyBase = (current_interest_rate / 1e6) × (utilisation_rate / 1e6) × 100
+ *
+ * Both fields are Permill values (parts per million; 1 000 000 = 100 %).
+ *
+ * Per cf_lending_config, extra_interest = 0: the network takes no continuous
+ * cut from borrow interest. The network earns only from one-shot fees
+ * (20 % of origination_fee and 20 % of liquidation_fee). Therefore 100 % of
+ * current_interest_rate accrues to lenders, and no deduction is applied.
+ *
+ * This mirrors the Aave v3 formula:
+ *   liquidityRate / RAY × 100
+ *   = variableBorrowRate × utilizationRate × (1 − reserveFactor)
+ *
+ * Known conservatism: one-shot origination fees (1 % per loan, 80 % to
+ * lenders) boost actual lender yield above the formula, especially for BTC
+ * where borrow utilisation is low but loan origination turnover is high.
+ * Deriving that component requires indexing historical loan events, which is
+ * not available from a single chain snapshot — the same limitation that
+ * prevents Aave adapters from including flash-loan fee revenue in apyBase.
+ *
+ * DATA SOURCE
+ * ─────────────────────────────────────────────────────────────────────────
+ * All lending data comes from the Chainflip mainnet Substrate RPC
+ * (https://rpc.chainflip.io) via the cf_lending_pools custom method, which
+ * reads live pallet storage with no intermediary.
+ * Asset prices are fetched from coins.llama.fi using coingecko IDs.
+ * No external indexer or third-party API is used.
+ */
+
 const utils = require('../utils');
 const axios = require('axios');
 
-type Asset = 'Btc' | 'Eth' | 'Sol' | 'Usdc' | 'Usdt';
+const RPC_ENDPOINT = 'https://rpc.chainflip.io';
 
-type Pool = {
-  pool: `boost-pool-btc` | `${Lowercase<Asset>}-chainflip-lending`;
-  asset: Asset;
-  chain: 'bitcoin' | 'ethereum' | 'solana';
-  tvl: number;
-  apy: number;
+/**
+ * Static metadata per lending asset.
+ * Key format: "Chain:ASSET" matching the on-chain RPC asset descriptor.
+ *
+ * decimals: native denomination used by the chain for this asset
+ *   BTC  → satoshis  (8 decimals)
+ *   ETH  → wei       (18 decimals)
+ *   SOL  → lamports  (9 decimals)
+ *   USDT → μUSDT     (6 decimals)
+ *   USDC → μUSDC     (6 decimals)
+ *
+ * Add a new entry here when Chainflip introduces additional lending assets.
+ */
+const ASSET_META: Record<string, {
+  decimals: number;
+  chain: string;
   coingeckoId: string;
   tokenContractAddress: string | null;
+}> = {
+  'Bitcoin:BTC':   { decimals: 8,  chain: 'bitcoin',  coingeckoId: 'bitcoin',  tokenContractAddress: null },
+  'Ethereum:ETH':  { decimals: 18, chain: 'ethereum', coingeckoId: 'ethereum', tokenContractAddress: null },
+  'Solana:SOL':    { decimals: 9,  chain: 'solana',   coingeckoId: 'solana',   tokenContractAddress: null },
+  'Ethereum:USDT': { decimals: 6,  chain: 'ethereum', coingeckoId: 'tether',   tokenContractAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7' },
+  'Ethereum:USDC': { decimals: 6,  chain: 'ethereum', coingeckoId: 'usd-coin', tokenContractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' },
 };
 
+async function cfRpc(method: string, params: unknown[] = []): Promise<any> {
+  const { data } = await axios.post(RPC_ENDPOINT, { jsonrpc: '2.0', method, params, id: 1 });
+  return data.result;
+}
+
 const getPools = async () => {
-  const apyData: { data: Pool[] } = await axios.get(
-    'https://explorer-service-processor.chainflip.io/defi-llama/yield'
+  const onchainPools = await cfRpc('cf_lending_pools', [null, null]);
+
+  // Batch all price requests into a single coins.llama.fi call.
+  const cgIds = [...new Set(
+    onchainPools
+      .map((p: any) => ASSET_META[`${p.asset.chain}:${p.asset.asset}`]?.coingeckoId)
+      .filter(Boolean)
+      .map((id: string) => `coingecko:${id}`)
+  )].join(',');
+
+  const { data: priceData } = await axios.get(
+    `https://coins.llama.fi/prices/current/${cgIds}`
   );
 
-  const lendingPools = apyData.data.filter((d) =>
-    d.pool.endsWith('-chainflip-lending')
-  );
+  return onchainPools
+    .map((pool: any) => {
+      const metaKey = `${pool.asset.chain}:${pool.asset.asset}`;
+      const meta    = ASSET_META[metaKey];
+      if (!meta) return null; // asset not yet in the metadata table — skip
 
-  return lendingPools.map((pool) => ({
-    pool: pool.pool,
-    chain: utils.formatChain(pool.chain),
-    project: 'chainflip-lending',
-    symbol: pool.asset.toUpperCase(),
-    tvlUsd: pool.tvl,
-    apyBase: pool.apy,
-    url: `https://scan.chainflip.io/pools/${pool.asset}/lending`,
-    underlyingTokens: [
-      pool.tokenContractAddress ?? `coingecko:${pool.coingeckoId}`,
-    ],
-  }));
+      // tvlUsd: idle liquidity only (available_amount), not total supplied.
+      // BigInt parse avoids float truncation for ETH amounts in wei which
+      // exceed Number.MAX_SAFE_INTEGER (~9 × 10^15 vs ETH's 10^18 scale).
+      const available = Number(BigInt(pool.available_amount)) / 10 ** meta.decimals;
+      const price     = priceData.coins[`coingecko:${meta.coingeckoId}`]?.price ?? 0;
+
+      // apyBase: instantaneous supply rate from on-chain fields (Permill units).
+      // extra_interest = 0 per cf_lending_config → full rate goes to lenders.
+      const apyBase =
+        (pool.current_interest_rate / 1e6) *
+        (pool.utilisation_rate       / 1e6) *
+        100;
+
+      return {
+        pool:             `${pool.asset.asset.toLowerCase()}-chainflip-lending`,
+        chain:            utils.formatChain(meta.chain),
+        project:          'chainflip-lending',
+        symbol:           pool.asset.asset,
+        tvlUsd:           available * price,
+        apyBase,
+        url:              `https://scan.chainflip.io/pools/${pool.asset.asset.toLowerCase()}/lending`,
+        underlyingTokens: [meta.tokenContractAddress ?? `coingecko:${meta.coingeckoId}`],
+      };
+    })
+    .filter(Boolean);
 };
 
 module.exports = {


### PR DESCRIPTION
# chainflip-lending: fix tvlUsd (was Supplied, should be available liquidity) and migrate to on-chain RPC

## What this PR does

Fixes a methodology error in `tvlUsd` and migrates all data to the Chainflip
Substrate node RPC, removing the dependency on an external indexer API. APY is
now also computed from on-chain fields instead of being forwarded from a
third-party endpoint.

---

## The bug — tvlUsd was reporting Supplied, not TVL

The previous adapter fetched `pool.tvl` from
`https://explorer-service-processor.chainflip.io/defi-llama/yield`.

That field maps to `total_amount` on-chain — the **total amount supplied by
lenders**, including the portion already lent out to borrowers. In DefiLlama's
taxonomy that figure is **Supplied** (= TVL + Borrowed), not TVL.

For a pool with near-full utilisation the error is dramatic:

| Pool | Reported tvlUsd (Supplied ❌) | Correct tvlUsd (Available ✅) | Utilisation |
|---|---|---|---|
| USDT | $480 671 | $2 943 | 99.4 % |
| USDC | $148 479 | $4 046 | 97.3 % |
| BTC  | $1 293 303 | $1 103 036 | 14.8 % |
| ETH  | $67 063 | $66 847 | 0.5 % |
| SOL  | $59 | $59 | 0 % |

**Total overstatement: ~$814 K** across the five pools.

The correct value for `tvlUsd` is the idle liquidity in each pool —
`available_amount` from the on-chain RPC — which is exactly what yield
aggregators display as "available to borrow" or "pool liquidity".

---

## Methodology alignment with Aave v3 and Compound v3

In Aave v3's yield-server adapter, `tvlUsd` for each reserve is the
underlying token balance held by the Pool contract (i.e. liquidity not yet
lent out). In Compound v3 it is `totalSupply - totalBorrow` per Comet market.
Both represent **idle capital**, not total deposits.

Chainflip's equivalent is `pool.available_amount` from `cf_lending_pools`:

```
tvlUsd = available_amount / 10^decimals × price
```

---

## APY methodology

Supply APY is derived from two Permill fields (parts per million, 1 000 000 = 100 %)
returned by `cf_lending_pools`:

```
apyBase = (current_interest_rate / 1e6) × (utilisation_rate / 1e6) × 100
```

Per `cf_lending_config`, `extra_interest = 0`: the network takes no continuous
share of borrow interest. The 100 % of `current_interest_rate` accrues to
lenders. The formula is therefore the direct on-chain equivalent of Aave's
`liquidityRate / RAY × 100`.

The previous adapter forwarded the `apy` field from the external indexer API,
which includes one-shot origination fees (1 % per loan, 80 % to lenders)
accumulated over historical loan origination volume. That component cannot be
derived from a single chain snapshot — the same limitation that prevents Aave
adapters from including flash-loan fee revenue in `apyBase`. The on-chain
formula is conservative and will understate yield for pools with high
origination turnover (most visibly BTC at current low utilisation), but it is
the correct and auditable approach.

---

## Data source

All data comes from a single RPC call to the Chainflip mainnet Substrate node:

```
POST https://rpc.chainflip.io
{ "method": "cf_lending_pools", "params": [null, null] }
```

Returns per-asset: `available_amount`, `total_amount`, `current_interest_rate`,
`utilisation_rate` — everything needed for both `tvlUsd` and `apyBase`.

Asset prices are fetched from `coins.llama.fi` using standard coingecko IDs
(bitcoin, ethereum, solana, tether, usd-coin). No external indexer is used.

---

## Files changed

- `src/adaptors/chainflip-lending/index.ts` — full rewrite

## Test output (live chain data)

```
Pool                      tvlUsd        apyBase   utilisation
btc-chainflip-lending     $1 103 036    0.22 %    14.77 %
eth-chainflip-lending     $66 847       ~0 %       0.47 %
sol-chainflip-lending     $59           0 %        0 %
usdt-chainflip-lending    $2 943        22.29 %   99.39 %
usdc-chainflip-lending    $4 046        13.19 %   97.28 %
```

Note: BTC `apyBase` (0.22 %) reflects the instantaneous interest rate only.
Actual lender yield is higher due to origination fees on short-term loans, but
those require historical chain indexing to quantify — out of scope for a
snapshot adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Chainflip lending metrics to read directly from on-chain data, improving accuracy and freshness.
  * TVL now reflects available liquidity more precisely, with better handling for asset decimals.
  * APY calculations now use on-chain rate information instead of externally reported values.
  * Token display and pricing lookups have been made more reliable across supported assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->