### PR TITLE
mint deterministic config ids (uuidv5 of pool key) for new pools

### DIFF
--- a/src/handlers/triggerAdaptor.js
+++ b/src/handlers/triggerAdaptor.js
@@ -1,10 +1,9 @@
-const crypto = require('crypto');
-
 const axios = require('axios');
 
 const utils = require('../adaptors/utils');
 const AppError = require('../utils/appError');
 const exclude = require('../utils/exclude');
+const { derivePoolId } = require('../utils/poolId');
 const { sendMessage } = require('../utils/discordWebhook');
 const { connect } = require('../utils/dbConnection');
 const { upsertAdapterStats } = require('../queries/adapterStats');
@@ -238,8 +237,9 @@ const main = async (body) => {
   const precision = 5;
   const timestamp = new Date(Date.now());
   data = data.map((p) => {
-    // if pool not in mapping -> its a new pool -> create a new uuid, else keep existing one
-    const id = mapping[p.pool] ?? crypto.randomUUID();
+    // if pool not in mapping -> its a new pool -> mint the deterministic uuid
+    // (uuidv5 of the pool key, same derivation as yield-server-v2), else keep existing one
+    const id = mapping[p.pool] ?? derivePoolId(p.pool);
     return {
       ...p,
       config_id: id, // config PK field

--- a/src/utils/poolId.js
+++ b/src/utils/poolId.js
@@ -1,0 +1,38 @@
+const crypto = require('crypto');
+
+// Namespace for deterministic pool UUIDs (RFC 4122 UUIDv5). Must stay identical
+// to YIELD_POOL_NAMESPACE in yield-server-v2 (src/common/poolId.ts) so both
+// pipelines mint the same id for the same adapter pool key.
+const YIELD_POOL_NAMESPACE = 'd2bb36db-2d93-4a4e-8069-60d1bddf6036';
+
+// Used only when a pool key is seen for the first time; existing config rows keep
+// their stored uuid. Manual pool renames update config.pool and keep the uuid, so
+// a stored id is not guaranteed to equal derivePoolId(current key) - never
+// re-derive ids for existing rows.
+const derivePoolId = (pool) => {
+  const namespaceBytes = Buffer.from(
+    YIELD_POOL_NAMESPACE.replace(/-/g, ''),
+    'hex'
+  );
+  const hash = crypto
+    .createHash('sha1')
+    .update(namespaceBytes)
+    .update(String(pool), 'utf8')
+    .digest();
+  hash[6] = (hash[6] & 0x0f) | 0x50;
+  hash[8] = (hash[8] & 0x3f) | 0x80;
+  const hex = hash.subarray(0, 16).toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+    12,
+    16
+  )}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+};
+
+// self-check on module load: pins the derivation to the RFC 4122 reference
+// output (same vector asserted in yield-server-v2 src/common/poolId.test.ts).
+// if the implementation or namespace ever drifts, fail before minting any id.
+if (derivePoolId('aave-v3-WETH') !== '7e0520c4-e3a0-54c5-b3de-ed95d80b7189') {
+  throw new Error('poolId derivation drifted from the shared reference vector');
+}
+
+module.exports = { derivePoolId };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pool identifiers are now generated consistently for pools that aren’t defined in the configuration, preventing the same pool from getting a different ID on each run.
  * Existing configured pools continue to keep their assigned identifiers unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->