### PR TITLE
Monetrix: support timetravel + rename pool symbol to sUSDM

### DIFF
--- a/src/adaptors/monetrix/index.js
+++ b/src/adaptors/monetrix/index.js
@@ -111,11 +111,18 @@ const apy = async (timestamp = null) => {
   const pricePerShare = ppsNow / 1e6;
 
   // USDM mints/redeems 1:1 against USDC. Prefer a real USDM feed once it exists,
-  // and fall back to USDC (then 1) until USDM pricing is available.
-  const { pricesByAddress } = await utils.getPrices([USDM, USDC], CHAIN);
+  // and fall back to USDC (then 1) until USDM pricing is available. Backfill
+  // runs price the row at the anchor timestamp rather than at "now".
+  const priceKeys = [USDM, USDC]
+    .map((t) => `${CHAIN}:${t.toLowerCase()}`)
+    .join(',');
+  const pricePath = timestamp
+    ? `/prices/historical/${anchor.timestamp}/${priceKeys}`
+    : `/prices/current/${priceKeys}`;
+  const { coins } = await utils.getPriceApiData(pricePath);
   const usdmPrice =
-    pricesByAddress[USDM.toLowerCase()] ??
-    pricesByAddress[USDC.toLowerCase()] ??
+    coins[`${CHAIN}:${USDM.toLowerCase()}`]?.price ??
+    coins[`${CHAIN}:${USDC.toLowerCase()}`]?.price ??
     1;
 
   return [

--- a/src/adaptors/monetrix/index.js
+++ b/src/adaptors/monetrix/index.js
@@ -22,11 +22,22 @@ const ONE_SHARE = '1000000000000';
 const CONVERT_TO_ASSETS_ABI =
   'function convertToAssets(uint256 shares) external view returns (uint256)';
 
-const apy = async () => {
-  const latest = await sdk.api.util.getLatestBlock(CHAIN);
+const apy = async (timestamp = null) => {
+  // Anchor at the requested historical timestamp (timetravel/backfill) or at
+  // the chain head for live runs. All reads below are pinned to this anchor.
+  let anchor;
+  if (timestamp) {
+    // no pool data before real capital entered the vault
+    if (timestamp <= YIELD_START_TIMESTAMP) return [];
+    const at = await sdk.api.util.lookupBlock(timestamp, { chain: CHAIN });
+    anchor = { number: at.block, timestamp: at.timestamp };
+  } else {
+    const latest = await sdk.api.util.getLatestBlock(CHAIN);
+    anchor = { number: latest.number, timestamp: latest.timestamp };
+  }
   // trailing 7-day window, clamped to when yield started during the first week
   const cutoffTimestamp = Math.max(
-    latest.timestamp - WINDOW_SECONDS,
+    anchor.timestamp - WINDOW_SECONDS,
     YIELD_START_TIMESTAMP
   );
   // past = 7-day trailing cutoff; inception = the day yield first accrued
@@ -47,14 +58,14 @@ const apy = async () => {
         target: SUSDM,
         chain: CHAIN,
         abi: 'uint256:totalAssets',
-        block: latest.number,
+        block: anchor.number,
       }),
       sdk.api.abi.call({
         target: SUSDM,
         chain: CHAIN,
         abi: CONVERT_TO_ASSETS_ABI,
         params: [ONE_SHARE],
-        block: latest.number,
+        block: anchor.number,
       }),
       sdk.api.abi.call({
         target: SUSDM,
@@ -77,7 +88,7 @@ const apy = async () => {
 
   const ppsNow = Number(ppsNowRes.output);
   const ppsPast = Number(ppsPastRes.output);
-  const elapsed = Math.max(latest.timestamp - cutoffTimestamp, 86400);
+  const elapsed = Math.max(anchor.timestamp - cutoffTimestamp, 86400);
   const apyBase =
     ppsPast > 0
       ? (Math.pow(ppsNow / ppsPast, SECONDS_PER_YEAR / elapsed) - 1) * 100
@@ -86,7 +97,7 @@ const apy = async () => {
   // since-inception annualized return (from when yield first accrued)
   const ppsInception = Number(ppsInceptionRes.output);
   const elapsedInception = Math.max(
-    latest.timestamp - YIELD_START_TIMESTAMP,
+    anchor.timestamp - YIELD_START_TIMESTAMP,
     86400
   );
   const apyBaseInception =
@@ -112,7 +123,8 @@ const apy = async () => {
       pool: `${SUSDM.toLowerCase()}-${CHAIN}`,
       chain: utils.formatChain(CHAIN),
       project: 'monetrix',
-      symbol: 'USDM',
+      // the pool is the sUSDM staking vault (deposit USDM, receive sUSDM)
+      symbol: 'sUSDM',
       tvlUsd: tvlUnderlying * usdmPrice,
       apyBase,
       apyBaseInception,
@@ -126,7 +138,7 @@ const apy = async () => {
 
 module.exports = {
   protocolId: '8019',
-  timetravel: false,
+  timetravel: true,
   apy,
   url: 'https://www.monetrix.xyz/',
 };


### PR DESCRIPTION
Follow-up to #2740 (merged July 2), two changes:

1) Timetravel support for historical backfill
   apy(timestamp) now anchors every read (block lookup, totalAssets, share-price
   samples, window math) at the requested historical timestamp; live runs still
   use the chain head. Returns [] for timestamps before yield started
   (2026-06-10 13:00 UTC). timetravel is flipped to true.

   Verified locally at historical timestamps:
   - 2026-06-12: tvl $1.05M, apyBase 3.26%
   - 2026-06-17: tvl $1.27M, apyBase 8.12%
   - 2026-06-25: tvl $1.80M, apyBase 11.83%
   - 2026-07-01: tvl $1.86M, apyBase 10.74%

   🙏 Request: once merged, could the monetrix pool be backfilled from
   2026-06-10? The pool was listed on July 2 so it currently has a single
   data point; the chain state is fully queryable back to launch.

2) symbol USDM -> sUSDM
   The pool is the sUSDM staking vault (deposit USDM, receive sUSDM), so the
   listing should show the staked token. Stablecoin classification is
   unaffected. Pool id is unchanged, so no continuity break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for historical APY queries via an optional timestamp, producing time-pinned results and consistent reporting.
  * Updated price-based TVL calculations to use historical pricing when a timestamp is provided.
* **Bug Fixes**
  * Improved APY accuracy by anchoring all on-chain reads and annualization calculations to the block corresponding to the selected timestamp.
  * Returns no APY data for timestamps at or before yield tracking start.
  * Updated displayed pool symbol from **USDM** to **sUSDM**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->