### PR TITLE
sky-lending: add USDS->GROVE staking farm pool

### DIFF
--- a/src/adaptors/sky-lending/abiFarm.json
+++ b/src/adaptors/sky-lending/abiFarm.json
@@ -1,0 +1,459 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "_rewardsDistribution",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "_rewardsToken", "type": "address" },
+      { "internalType": "address", "name": "_stakingToken", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerNominated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "PauseChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Recovered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint16",
+        "name": "referral",
+        "type": "uint16"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Referral",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardPaid",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newRewardsDistribution",
+        "type": "address"
+      }
+    ],
+    "name": "RewardsDistributionUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardsDurationUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Staked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdrawn",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "earned",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRewardForDuration",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastPauseTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastTimeRewardApplicable",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastUpdateTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" }
+    ],
+    "name": "nominateNewOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nominatedOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "reward", "type": "uint256" }
+    ],
+    "name": "notifyRewardAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "periodFinish",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "uint256", "name": "tokenAmount", "type": "uint256" }
+    ],
+    "name": "recoverERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardPerToken",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardPerTokenStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "rewards",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardsDistribution",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardsDuration",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardsToken",
+    "outputs": [
+      { "internalType": "contract IERC20", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bool", "name": "_paused", "type": "bool" }],
+    "name": "setPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_rewardsDistribution",
+        "type": "address"
+      }
+    ],
+    "name": "setRewardsDistribution",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_rewardsDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "setRewardsDuration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      { "internalType": "uint16", "name": "referral", "type": "uint16" }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakingToken",
+    "outputs": [
+      { "internalType": "contract IERC20", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "userRewardPerTokenPaid",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/adaptors/sky-lending/index.js
+++ b/src/adaptors/sky-lending/index.js
@@ -534,12 +534,6 @@ const farmsAPY = async () => {
   const USDS = '0xdC035D45d973E3EC169d2276DDab16f1e407384F';
   const farms = [
     {
-      // USDS -> SKY farm
-      address: '0x0650CAF159C5A49f711e8169D4336ECB9b950275',
-      rewardToken: '0x56072C95FAA701256059aa122697B133aDEd9279',
-      rewardSymbol: 'SKY',
-    },
-    {
       // USDS -> GROVE farm
       address: '0x4E41488C19cD35EB4de3083Fc3e204854c75c86a',
       rewardToken: '0xb30FE1CF884b48A22A50D22A9282004f2c5E9406',

--- a/src/adaptors/sky-lending/index.js
+++ b/src/adaptors/sky-lending/index.js
@@ -551,7 +551,8 @@ const farmsAPY = async () => {
     .map((t) => `ethereum:${t}`)
     .join(',');
   const prices = (await getPriceApiData(`/prices/current/${priceKeys}`)).coins;
-  const priceUSDS = prices[`ethereum:${USDS}`].price;
+  const priceUSDS = prices[`ethereum:${USDS}`]?.price;
+  if (!priceUSDS) return [];
 
   return Promise.all(
     farms.map(async (farm) => {

--- a/src/adaptors/sky-lending/index.js
+++ b/src/adaptors/sky-lending/index.js
@@ -4,6 +4,7 @@ const sdk = require('@defillama/sdk');
 const axios = require('axios');
 
 const abiSUSDS = require('./abiSUSDS.json');
+const abiFarm = require('./abiFarm.json');
 const { getPriceApiData } = require('../utils');
 
 const HOUR = 60 * 60;
@@ -528,8 +529,77 @@ const susdsAPY = async () => {
   return pools.filter(Boolean);
 };
 
+// USDS staking farms (Synthetix-style StakingRewards): stake USDS, earn a reward token.
+const farmsAPY = async () => {
+  const USDS = '0xdC035D45d973E3EC169d2276DDab16f1e407384F';
+  const farms = [
+    {
+      // USDS -> SKY farm
+      address: '0x0650CAF159C5A49f711e8169D4336ECB9b950275',
+      rewardToken: '0x56072C95FAA701256059aa122697B133aDEd9279',
+      rewardSymbol: 'SKY',
+    },
+    {
+      // USDS -> GROVE farm
+      address: '0x4E41488C19cD35EB4de3083Fc3e204854c75c86a',
+      rewardToken: '0xb30FE1CF884b48A22A50D22A9282004f2c5E9406',
+      rewardSymbol: 'GROVE',
+    },
+  ];
+
+  const priceKeys = [USDS, ...farms.map((f) => f.rewardToken)]
+    .map((t) => `ethereum:${t}`)
+    .join(',');
+  const prices = (await getPriceApiData(`/prices/current/${priceKeys}`)).coins;
+  const priceUSDS = prices[`ethereum:${USDS}`].price;
+
+  return Promise.all(
+    farms.map(async (farm) => {
+      const [totalSupplyRes, rewardRateRes, periodFinishRes] =
+        await Promise.all([
+          sdk.api.abi.call({
+            target: farm.address,
+            abi: 'erc20:totalSupply',
+          }),
+          sdk.api.abi.call({
+            target: farm.address,
+            abi: abiFarm.find((m) => m.name === 'rewardRate'),
+          }),
+          sdk.api.abi.call({
+            target: farm.address,
+            abi: abiFarm.find((m) => m.name === 'periodFinish'),
+          }),
+        ]);
+
+      const tvlUsd = (totalSupplyRes.output / 1e18) * priceUSDS;
+      const rewardRate = rewardRateRes.output / 1e18;
+      const isActive = Date.now() / 1000 < Number(periodFinishRes.output);
+      const priceReward = prices[`ethereum:${farm.rewardToken}`]?.price;
+      const secPerDay = 86400;
+      const apyReward =
+        isActive && priceReward
+          ? ((rewardRate * secPerDay * 365 * priceReward) / tvlUsd) * 100
+          : 0;
+
+      return {
+        pool: farm.address,
+        chain: 'ethereum',
+        project: 'sky-lending',
+        symbol: 'USDS',
+        token: farm.address,
+        poolMeta: `${farm.rewardSymbol} Farming Pool`,
+        tvlUsd,
+        apyReward,
+        underlyingTokens: [USDS],
+        rewardTokens: [farm.rewardToken],
+        url: `https://app.sky.money/?network=ethereum&widget=rewards&reward=${farm.address}`,
+      };
+    })
+  );
+};
+
 const apy = async () => {
-  const pools = await Promise.all([main(), susdsAPY()]);
+  const pools = await Promise.all([main(), susdsAPY(), farmsAPY()]);
   return pools.flat();
 };
 


### PR DESCRIPTION
Adds the Sky USDS→GROVE staking farm (Synthetix-style StakingRewards, same contract shape as the SPK farm already listed under sparklend) to the sky-lending adapter:

| Farm | Address | TVL | apyReward |
|---|---|---|---|
| USDS→GROVE | `0x4E41488C19cD35EB4de3083Fc3e204854c75c86a` | ~$90M | ~38% (GROVE priced on coins.llama.fi, confidence 0.99) |

- APY calculation mirrors `spkFarm()` in the `sparklend` adapter: `rewardRate × 86400 × 365 × rewardPrice / tvlUsd`, zeroed when `periodFinish` has passed; USDS price lookup guarded so a missing price entry cannot reject the whole `apy()`.
- `abiFarm.json` copied from `sparklend/abiSKYFarm.json` (same ABI).
- Per-pool `url` deep-links to the farm widget on app.sky.money.
- Existing pools (Maker CDP + sUSDS) unchanged — 18 pools total, full jest suite passes (218/218).

History note: the first revision also added the USDS→SKY farm (`0x0650CAF1…0275`), dropped after CI flagged its pool id as owned by the sparklend adapter.