### PR TITLE
sky-lending: dual-list SPK farm + add Base savings pool

### DIFF
--- a/src/adaptors/sky-lending/index.js
+++ b/src/adaptors/sky-lending/index.js
@@ -593,7 +593,7 @@ const farmsAPY = async () => {
       const priceReward = prices[`ethereum:${farm.rewardToken}`]?.price;
       const secPerDay = 86400;
       const apyReward =
-        isActive && priceReward
+        isActive && priceReward && tvlUsd > 0
           ? ((rewardRate * secPerDay * 365 * priceReward) / tvlUsd) * 100
           : 0;
 

--- a/src/adaptors/sky-lending/index.js
+++ b/src/adaptors/sky-lending/index.js
@@ -487,6 +487,12 @@ const susdsAPY = async () => {
       USDS: '0x6491c05a82219b8d1479057361ff1654749b876b',
       url: 'https://app.sky.money/?network=arbitrumone&widget=savings',
     },
+    {
+      chain: 'base',
+      sUSDS: '0x5875eEE11Cf8398102FdAd704C9E96607675467a',
+      USDS: '0x820C137fa70C8691f0e44Dc420a5e53c168921Dc',
+      url: 'https://app.sky.money/?network=base&widget=savings',
+    },
   ];
 
   const priceKeys = configs
@@ -557,6 +563,19 @@ const farmsAPY = async () => {
       poolMeta: 'SKY Staking Engine',
       url: 'https://app.sky.money/?network=ethereum&widget=stake',
     },
+    {
+      // USDS -> SPK farm; the sparklend adapter lists this contract under
+      // the bare-address pool id, so this row uses the `${address}-${chain}`
+      // id form (same convention spark-savings uses next to this adapter's
+      // sUSDS pools)
+      address: '0x173e314C7635B45322cd8Cb14f44b312e079F3af',
+      pool: '0x173e314c7635b45322cd8cb14f44b312e079f3af-ethereum',
+      stakeSymbol: 'USDS',
+      stakeToken: USDS,
+      rewardToken: '0xc20059e0317DE91738d13af027DfC4a50781b066',
+      poolMeta: 'SPK Farming Pool',
+      url: 'https://app.sky.money/?network=ethereum&widget=rewards&reward=0x173e314C7635B45322cd8Cb14f44b312e079F3af',
+    },
   ];
 
   const priceKeys = [
@@ -598,7 +617,7 @@ const farmsAPY = async () => {
           : 0;
 
       return {
-        pool: farm.address,
+        pool: farm.pool ?? farm.address,
         chain: 'ethereum',
         project: 'sky-lending',
         symbol: farm.stakeSymbol,

--- a/src/adaptors/sky-lending/index.js
+++ b/src/adaptors/sky-lending/index.js
@@ -479,11 +479,13 @@ const susdsAPY = async () => {
       chain: 'ethereum',
       sUSDS: ETH_SUSDS,
       USDS: '0xdC035D45d973E3EC169d2276DDab16f1e407384F',
+      url: 'https://app.sky.money/?network=ethereum&widget=savings',
     },
     {
       chain: 'arbitrum',
       sUSDS: '0xddb46999f8891663a8f2828d25298f70416d7610',
       USDS: '0x6491c05a82219b8d1479057361ff1654749b876b',
+      url: 'https://app.sky.money/?network=arbitrumone&widget=savings',
     },
   ];
 
@@ -493,7 +495,7 @@ const susdsAPY = async () => {
   const prices = (await getPriceApiData(`/prices/current/${priceKeys}`)).coins;
 
   const pools = await Promise.all(
-    configs.map(async ({ chain, sUSDS, USDS }) => {
+    configs.map(async ({ chain, sUSDS, USDS, url }) => {
       const totalSupply =
         (
           await sdk.api.abi.call({
@@ -516,6 +518,7 @@ const susdsAPY = async () => {
         tvlUsd: totalSupply * price,
         apyBase,
         underlyingTokens: [USDS],
+        url,
       };
 
       if (chain === 'ethereum') {
@@ -529,27 +532,45 @@ const susdsAPY = async () => {
   return pools.filter(Boolean);
 };
 
-// USDS staking farms (Synthetix-style StakingRewards): stake USDS, earn a reward token.
+// Staking farms (Synthetix-style StakingRewards).
 const farmsAPY = async () => {
   const USDS = '0xdC035D45d973E3EC169d2276DDab16f1e407384F';
+  const SKY = '0x56072C95FAA701256059aa122697B133aDEd9279';
   const farms = [
     {
       // USDS -> GROVE farm
       address: '0x4E41488C19cD35EB4de3083Fc3e204854c75c86a',
+      stakeSymbol: 'USDS',
+      // token used to price the staked balance
+      stakeToken: USDS,
       rewardToken: '0xb30FE1CF884b48A22A50D22A9282004f2c5E9406',
-      rewardSymbol: 'GROVE',
+      poolMeta: 'GROVE Farming Pool',
+      url: 'https://app.sky.money/?network=ethereum&widget=rewards&reward=0x4E41488C19cD35EB4de3083Fc3e204854c75c86a',
+    },
+    {
+      // SKY staking engine -> SKY rewards; the staked token is lsSKY, the
+      // engine's 1:1 wrapper around SKY, so the balance is priced via SKY
+      address: '0xB44c2Fb4181D7cb06BdFf34a46FdFE4A259b40Fc',
+      stakeSymbol: 'SKY',
+      stakeToken: SKY,
+      rewardToken: SKY,
+      poolMeta: 'SKY Staking Engine',
+      url: 'https://app.sky.money/?network=ethereum&widget=stake',
     },
   ];
 
-  const priceKeys = [USDS, ...farms.map((f) => f.rewardToken)]
+  const priceKeys = [
+    ...new Set(farms.flatMap((f) => [f.stakeToken, f.rewardToken])),
+  ]
     .map((t) => `ethereum:${t}`)
     .join(',');
   const prices = (await getPriceApiData(`/prices/current/${priceKeys}`)).coins;
-  const priceUSDS = prices[`ethereum:${USDS}`]?.price;
-  if (!priceUSDS) return [];
 
-  return Promise.all(
+  const pools = await Promise.all(
     farms.map(async (farm) => {
+      const priceStake = prices[`ethereum:${farm.stakeToken}`]?.price;
+      if (!priceStake) return null;
+
       const [totalSupplyRes, rewardRateRes, periodFinishRes] =
         await Promise.all([
           sdk.api.abi.call({
@@ -566,7 +587,7 @@ const farmsAPY = async () => {
           }),
         ]);
 
-      const tvlUsd = (totalSupplyRes.output / 1e18) * priceUSDS;
+      const tvlUsd = (totalSupplyRes.output / 1e18) * priceStake;
       const rewardRate = rewardRateRes.output / 1e18;
       const isActive = Date.now() / 1000 < Number(periodFinishRes.output);
       const priceReward = prices[`ethereum:${farm.rewardToken}`]?.price;
@@ -580,17 +601,19 @@ const farmsAPY = async () => {
         pool: farm.address,
         chain: 'ethereum',
         project: 'sky-lending',
-        symbol: 'USDS',
+        symbol: farm.stakeSymbol,
         token: farm.address,
-        poolMeta: `${farm.rewardSymbol} Farming Pool`,
+        poolMeta: farm.poolMeta,
         tvlUsd,
         apyReward,
-        underlyingTokens: [USDS],
+        underlyingTokens: [farm.stakeToken],
         rewardTokens: [farm.rewardToken],
-        url: `https://app.sky.money/?network=ethereum&widget=rewards&reward=${farm.address}`,
+        url: farm.url,
       };
     })
   );
+
+  return pools.filter(Boolean);
 };
 
 const apy = async () => {


### PR DESCRIPTION
Stacked on #2781 — please merge that one first (this diff includes its commits until then).

Sky products are accessible from both the Sky and Spark frontends, and the two adapter families already dual-list accordingly: **spark-savings lists this adapter's sUSDS pools** on Arbitrum (`0xddb46999…-arbitrum` next to sky-lending's bare `0xddb46999…`) and Base, each row with its own frontend URL. This PR completes the symmetric direction:

| New row | Pool id | TVL | APY |
|---|---|---|---|
| USDS→SPK farm | `0x173e314c…f3af-ethereum` (sparklend owns the bare id) | ~$569M | ~3.6% reward |
| sUSDS Base savings | `0x5875eEE1…467a` bare (spark-savings owns `…-base`) | ~$11.9M | 3.6% base |

- Same `${address}-${chain}` id convention spark-savings uses for its rows next to ours.
- SPK farm APY matches the sparklend row's output (same StakingRewards math).
- Base sUSDS priced on coins.llama.fi (confidence 0.99); SSR apyBase is global, same as the existing ethereum/arbitrum rows.
- Full jest suite: 241/241, 21 pools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple staking farm configurations with clearer pool details and links.
  * Expanded sUSDS APY results to include destination links for supported networks.

* **Bug Fixes**
  * Improved token pricing used for TVL calculations so farm values now reflect the correct staked asset.
  * Updated returned pool information to better match each farm’s actual stake and reward setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->