### PR TITLE
feat: add DorkFi yield adapter (Algorand + Voi Network)

### DIFF
--- a/src/adaptors/dorkfi/index.js
+++ b/src/adaptors/dorkfi/index.js
@@ -1,0 +1,172 @@
+/**
+ * DorkFi — DefiLlama Yield Server Adapter
+ *
+ * Reports per-market supply and borrow APY for all DorkFi lending pools
+ * on Algorand and Voi Network.
+ *
+ * Interest Rate Model (kinked utilization curve):
+ *   utilization   = totalScaledBorrows / totalScaledDeposits
+ *   borrowRateBPS = borrowRate + utilization × slope   (fields in bps)
+ *   supplyRateBPS = borrowRateBPS × utilization × (1 − reserveFactor)
+ *   APY           = (1 + rateBPS/10000/365)^365 − 1
+ */
+
+const axios = require('axios');
+
+const API_BASE = 'https://dorkfi-api.nautilus.sh';
+const NETWORK  = { algorand: 'algorand-mainnet', voi: 'voi-mainnet' };
+const DL_CHAIN = { algorand: 'Algorand', voi: 'Voi Network' };
+const PROJECT  = 'dorkfi';
+
+// ── Known market → token symbol mapping ──────────────────────────────────────
+// Voi Pool A (47139778) and Pool B (47139781)
+// Algorand Pool A (3333688282) and Pool B (3345940978)
+// Algorand symbols resolved from on-chain ASA metadata
+
+const MARKET_SYMBOLS = {
+  // Voi Pool A
+  41877720: 'VOI',
+  395614:   'aUSDC',
+  420069:   'UNIT',
+  47138068: 'WAD',
+  40153155: 'POW',
+  413153:   'aALGO',
+  40153308: 'aETH',
+  40153368: 'aWBTC',
+  40153415: 'acbBTC',
+  // Voi Pool B
+  300279:   'USDC',
+  412682:   'ALGO',
+  410111:   'USDT',
+  419744:   'AVAX',
+  302222:   'BNB',
+  410811:   'wBTC',
+  798968:   'MATIC',
+  420024:   'LINK',
+  8471125:  'SOL',
+  8324600:  'DOT',
+  828295:   'ADA',
+  770561:   'DOGE',
+  // Algorand Pool A + B — symbols from ASA on-chain metadata
+  3207744109: 'ALGO',
+  3211820549: 'goBTC',
+  3210682240: 'USDC',
+  3220125024: 'UNIT',
+  3080081069: 'POW',
+  3210709899: 'aVOI',
+  3211827406: 'WBTC',
+  3211806149: 'goETH',
+  3211811648: 'WETH',
+  3211838479: 'LINK',
+  3211883276: 'SOL',
+  3211885849: 'DOGE',
+  3490783147: 'tALGO',
+  3490854290: 'tALGO',
+  3211805086: 'FINITE',
+  3346185062: 'FOLKS',
+  3212524778: 'COOP',
+  3212773584: 'HAY',
+  3346408431: 'WAD',
+  3346881192: 'WAD',
+  3211890928: 'HAY',
+  3212768756: 'GOLD$',
+  3212531816: 'SOL',
+  3212534634: 'LINK',
+  3212771255: 'FOLKS',
+  3220347315: 'GOLD$',
+  3333688448: 'WAD',
+  3211740909: 'FINITE',
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function fetchMarketData(chain) {
+  const { data } = await axios.get(`${API_BASE}/market-data/${NETWORK[chain]}`);
+  if (!data.success) throw new Error(`DorkFi API error: ${chain}`);
+  return data.data;
+}
+
+async function fetchAnalyticsTVL(chain) {
+  const { data } = await axios.get(`${API_BASE}/analytics/tvl/${NETWORK[chain]}`);
+  if (!data.success) return {};
+  const map = {};
+  for (const m of data.data.markets || []) map[`${m.appId}:${m.marketId}`] = m.tvl;
+  return map;
+}
+
+function dedup(markets) {
+  const seen = new Map();
+  for (const m of markets) {
+    const key = `${m.appId}:${m.marketId}`;
+    if (!seen.has(key) || m.lastUpdated > seen.get(key).lastUpdated) seen.set(key, m);
+  }
+  return [...seen.values()];
+}
+
+// ── APY calculation ───────────────────────────────────────────────────────────
+
+function bpsToApy(rateBps) {
+  const r = rateBps / 10000;
+  return (Math.pow(1 + r / 365, 365) - 1) * 100;
+}
+
+function computeRates(market) {
+  const totalDep = Number(market.totalScaledDeposits || 0);
+  const totalBor = Number(market.totalScaledBorrows  || 0);
+  if (totalDep === 0) return { borrowApy: 0, supplyApy: 0, utilization: 0 };
+
+  const utilization   = totalBor / totalDep;
+  const borrowRate    = Number(market.borrowRate    || 0);
+  const slope         = Number(market.slope         || 0);
+  const reserveFactor = Number(market.reserveFactor || 0) / 10000;
+
+  const borrowBps = borrowRate + utilization * slope;
+  const supplyBps = borrowBps * utilization * (1 - reserveFactor);
+
+  return {
+    borrowApy:   parseFloat(bpsToApy(borrowBps).toFixed(4)),
+    supplyApy:   parseFloat(bpsToApy(supplyBps).toFixed(4)),
+    utilization,
+  };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+const apy = async () => {
+  const results = [];
+
+  for (const chain of ['algorand', 'voi']) {
+    const [markets, tvlMap] = await Promise.all([
+      fetchMarketData(chain),
+      fetchAnalyticsTVL(chain),
+    ]);
+
+    for (const market of dedup(markets)) {
+      if (Number(market.totalScaledDeposits || 0) === 0) continue;
+
+      const key    = `${market.appId}:${market.marketId}`;
+      const tvlUsd = tvlMap[key] || 0;
+      if (tvlUsd < 1) continue;
+
+      const { borrowApy, supplyApy } = computeRates(market);
+      const symbol = MARKET_SYMBOLS[market.marketId] || `ASA-${market.marketId}`;
+
+      results.push({
+        pool:          `dorkfi-${chain}-${market.appId}-${market.marketId}`,
+        chain:         DL_CHAIN[chain],
+        project:       PROJECT,
+        symbol,
+        tvlUsd,
+        apyBase:       supplyApy,
+        apyBaseBorrow: borrowApy,
+        underlyingTokens: [],
+        poolMeta:      `Pool ${market.appId}`,
+        url:           'https://dork.fi',
+      });
+    }
+  }
+
+  return results;
+};
+
+module.exports = { apy, timeTravel: false, url: 'https://dork.fi' };

--- a/src/adaptors/dorkfi/index.js
+++ b/src/adaptors/dorkfi/index.js
@@ -17,6 +17,7 @@ const API_BASE = 'https://dorkfi-api.nautilus.sh';
 const NETWORK  = { algorand: 'algorand-mainnet', voi: 'voi-mainnet' };
 const DL_CHAIN = { algorand: 'Algorand', voi: 'Voi Network' };
 const PROJECT  = 'dorkfi';
+const REQUEST_TIMEOUT_MS = 30_000;
 
 // ── Known market → token symbol mapping ──────────────────────────────────────
 // Voi Pool A (47139778) and Pool B (47139781)
@@ -81,17 +82,31 @@ const MARKET_SYMBOLS = {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 async function fetchMarketData(chain) {
-  const { data } = await axios.get(`${API_BASE}/market-data/${NETWORK[chain]}`);
-  if (!data.success) throw new Error(`DorkFi API error: ${chain}`);
-  return data.data;
+  try {
+    const { data } = await axios.get(`${API_BASE}/market-data/${NETWORK[chain]}`, {
+      timeout: REQUEST_TIMEOUT_MS,
+    });
+    if (!data.success) return [];
+    return data.data || [];
+  } catch (error) {
+    console.warn(`DorkFi market data unavailable for ${chain}: ${error.message}`);
+    return [];
+  }
 }
 
 async function fetchAnalyticsTVL(chain) {
-  const { data } = await axios.get(`${API_BASE}/analytics/tvl/${NETWORK[chain]}`);
-  if (!data.success) return {};
-  const map = {};
-  for (const m of data.data.markets || []) map[`${m.appId}:${m.marketId}`] = m.tvl;
-  return map;
+  try {
+    const { data } = await axios.get(`${API_BASE}/analytics/tvl/${NETWORK[chain]}`, {
+      timeout: REQUEST_TIMEOUT_MS,
+    });
+    if (!data.success) return {};
+    const map = {};
+    for (const m of data.data.markets || []) map[`${m.appId}:${m.marketId}`] = m.tvl;
+    return map;
+  } catch (error) {
+    console.warn(`DorkFi TVL data unavailable for ${chain}: ${error.message}`);
+    return {};
+  }
 }
 
 function dedup(markets) {
@@ -130,6 +145,10 @@ function computeRates(market) {
   };
 }
 
+function getUnderlyingTokens(market) {
+  return [String(market.marketId)];
+}
+
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 const apy = async () => {
@@ -142,9 +161,13 @@ const apy = async () => {
     ]);
 
     for (const market of dedup(markets)) {
-      if (Number(market.totalScaledDeposits || 0) === 0) continue;
-
       const key    = `${market.appId}:${market.marketId}`;
+      const hasTvl = Object.prototype.hasOwnProperty.call(tvlMap, key);
+      if (!hasTvl) {
+        console.warn(`DorkFi TVL missing for ${chain} market ${key}`);
+        continue;
+      }
+
       const tvlUsd = tvlMap[key] || 0;
       if (tvlUsd < 1) continue;
 
@@ -159,7 +182,7 @@ const apy = async () => {
         tvlUsd,
         apyBase:       supplyApy,
         apyBaseBorrow: borrowApy,
-        underlyingTokens: [],
+        underlyingTokens: getUnderlyingTokens(market),
         poolMeta:      `Pool ${market.appId}`,
         url:           'https://dork.fi',
       });

--- a/src/adaptors/dorkfi/index.js
+++ b/src/adaptors/dorkfi/index.js
@@ -79,6 +79,42 @@ const MARKET_SYMBOLS = {
   3211740909: 'FINITE',
 };
 
+const MARKET_COINGECKO_IDS = {
+  41877720: 'coingecko:voi-network',
+  395614:   'coingecko:aave-v3-usdc',
+  413153:   'coingecko:algorand',
+  40153308: 'coingecko:ethereum',
+  40153368: 'coingecko:wrapped-bitcoin',
+  40153415: 'coingecko:coinbase-wrapped-btc',
+  300279:   'coingecko:usd-coin',
+  412682:   'coingecko:algorand',
+  410111:   'coingecko:tether',
+  419744:   'coingecko:avalanche-2',
+  302222:   'coingecko:binancecoin',
+  410811:   'coingecko:wrapped-bitcoin',
+  798968:   'coingecko:matic-network',
+  420024:   'coingecko:chainlink',
+  8471125:  'coingecko:solana',
+  8324600:  'coingecko:polkadot',
+  828295:   'coingecko:cardano',
+  770561:   'coingecko:dogecoin',
+  3207744109: 'coingecko:algorand',
+  3211820549: 'coingecko:bitcoin',
+  3210682240: 'coingecko:usd-coin',
+  3210709899: 'coingecko:voi-network',
+  3211827406: 'coingecko:wrapped-bitcoin',
+  3211806149: 'coingecko:ethereum',
+  3211811648: 'coingecko:weth',
+  3211838479: 'coingecko:chainlink',
+  3211883276: 'coingecko:solana',
+  3211885849: 'coingecko:dogecoin',
+  3346185062: 'coingecko:folks',
+  3212524778: 'coingecko:coop-coin',
+  3212531816: 'coingecko:solana',
+  3212534634: 'coingecko:chainlink',
+  3212771255: 'coingecko:folks',
+};
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 async function fetchMarketData(chain) {
@@ -146,7 +182,20 @@ function computeRates(market) {
 }
 
 function getUnderlyingTokens(market) {
-  return [String(market.marketId)];
+  return [MARKET_COINGECKO_IDS[market.marketId] || String(market.marketId)];
+}
+
+function getUsdValues(market, totalSupplyUsd) {
+  const totalDep = Number(market.totalScaledDeposits || 0);
+  const totalBor = Number(market.totalScaledBorrows  || 0);
+  const utilization = totalDep === 0 ? 0 : totalBor / totalDep;
+  const totalBorrowUsd = totalSupplyUsd * utilization;
+
+  return {
+    totalSupplyUsd,
+    totalBorrowUsd,
+    availableLiquidityUsd: Math.max(totalSupplyUsd - totalBorrowUsd, 0),
+  };
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -161,6 +210,8 @@ const apy = async () => {
     ]);
 
     for (const market of dedup(markets)) {
+      if (market.paused) continue;
+
       const key    = `${market.appId}:${market.marketId}`;
       const hasTvl = Object.prototype.hasOwnProperty.call(tvlMap, key);
       if (!hasTvl) {
@@ -168,11 +219,14 @@ const apy = async () => {
         continue;
       }
 
-      const tvlUsd = tvlMap[key] || 0;
+      const totalSupplyUsd = Number(tvlMap[key]) || 0;
+      const { totalBorrowUsd, availableLiquidityUsd } = getUsdValues(market, totalSupplyUsd);
+      const tvlUsd = availableLiquidityUsd;
       if (tvlUsd < 1) continue;
 
       const { borrowApy, supplyApy } = computeRates(market);
       const symbol = MARKET_SYMBOLS[market.marketId] || `ASA-${market.marketId}`;
+      const ltv = Number(market.collateralFactor || 0) / 10000;
 
       results.push({
         pool:          `dorkfi-${chain}-${market.appId}-${market.marketId}`,
@@ -182,6 +236,9 @@ const apy = async () => {
         tvlUsd,
         apyBase:       supplyApy,
         apyBaseBorrow: borrowApy,
+        totalSupplyUsd,
+        totalBorrowUsd,
+        ltv,
         underlyingTokens: getUnderlyingTokens(market),
         poolMeta:      `Pool ${market.appId}`,
         url:           'https://dork.fi',
@@ -192,4 +249,4 @@ const apy = async () => {
   return results;
 };
 
-module.exports = { apy, timeTravel: false, url: 'https://dork.fi' };
+module.exports = { apy, timetravel: false, url: 'https://dork.fi', protocolId: 7531 };

--- a/src/adaptors/dorkfi/index.js
+++ b/src/adaptors/dorkfi/index.js
@@ -171,9 +171,25 @@ function bpsToApy(rateBps) {
   return (Math.pow(1 + r / 365, 365) - 1) * 100;
 }
 
+// Balances are stored scaled; the current deposit/debt is scaled * index.
+// Deposits and borrows accrue on separate indices, so borrows grow faster and
+// using the raw scaled figures understates utilization.
+const INDEX_SCALE = 1e18;
+
+function toIndex(value) {
+  const index = Number(value) / INDEX_SCALE;
+  return Number.isFinite(index) && index > 0 ? index : 1;
+}
+
+function getIndexedBalances(market) {
+  return {
+    totalDep: Number(market.totalScaledDeposits || 0) * toIndex(market.depositIndex),
+    totalBor: Number(market.totalScaledBorrows || 0) * toIndex(market.borrowIndex),
+  };
+}
+
 function computeRates(market) {
-  const totalDep = Number(market.totalScaledDeposits || 0);
-  const totalBor = Number(market.totalScaledBorrows || 0);
+  const { totalDep, totalBor } = getIndexedBalances(market);
   if (totalDep === 0) return { borrowApy: 0, supplyApy: 0, utilization: 0 };
 
   const utilization = totalBor / totalDep;
@@ -196,8 +212,7 @@ function getUnderlyingTokens(market) {
 }
 
 function getUsdValues(market, totalSupplyUsd) {
-  const totalDep = Number(market.totalScaledDeposits || 0);
-  const totalBor = Number(market.totalScaledBorrows || 0);
+  const { totalDep, totalBor } = getIndexedBalances(market);
   const utilization = totalDep === 0 ? 0 : totalBor / totalDep;
   const totalBorrowUsd = totalSupplyUsd * utilization;
 

--- a/src/adaptors/dorkfi/index.js
+++ b/src/adaptors/dorkfi/index.js
@@ -14,9 +14,9 @@
 const axios = require('axios');
 
 const API_BASE = 'https://dorkfi-api.nautilus.sh';
-const NETWORK  = { algorand: 'algorand-mainnet', voi: 'voi-mainnet' };
+const NETWORK = { algorand: 'algorand-mainnet', voi: 'voi-mainnet' };
 const DL_CHAIN = { algorand: 'Algorand', voi: 'Voi Network' };
-const PROJECT  = 'dorkfi';
+const PROJECT = 'dorkfi';
 const REQUEST_TIMEOUT_MS = 30_000;
 
 // ── Known market → token symbol mapping ──────────────────────────────────────
@@ -27,27 +27,27 @@ const REQUEST_TIMEOUT_MS = 30_000;
 const MARKET_SYMBOLS = {
   // Voi Pool A
   41877720: 'VOI',
-  395614:   'aUSDC',
-  420069:   'UNIT',
+  395614: 'aUSDC',
+  420069: 'UNIT',
   47138068: 'WAD',
   40153155: 'POW',
-  413153:   'aALGO',
+  413153: 'aALGO',
   40153308: 'aETH',
   40153368: 'aWBTC',
   40153415: 'acbBTC',
   // Voi Pool B
-  300279:   'USDC',
-  412682:   'ALGO',
-  410111:   'USDT',
-  419744:   'AVAX',
-  302222:   'BNB',
-  410811:   'wBTC',
-  798968:   'MATIC',
-  420024:   'LINK',
-  8471125:  'SOL',
-  8324600:  'DOT',
-  828295:   'ADA',
-  770561:   'DOGE',
+  300279: 'USDC',
+  412682: 'ALGO',
+  410111: 'USDT',
+  419744: 'AVAX',
+  302222: 'BNB',
+  410811: 'wBTC',
+  798968: 'MATIC',
+  420024: 'LINK',
+  8471125: 'SOL',
+  8324600: 'DOT',
+  828295: 'ADA',
+  770561: 'DOGE',
   // Algorand Pool A + B — symbols from ASA on-chain metadata
   3207744109: 'ALGO',
   3211820549: 'goBTC',
@@ -81,23 +81,23 @@ const MARKET_SYMBOLS = {
 
 const MARKET_COINGECKO_IDS = {
   41877720: 'coingecko:voi-network',
-  395614:   'coingecko:aave-v3-usdc',
-  413153:   'coingecko:algorand',
+  395614: 'coingecko:aave-v3-usdc',
+  413153: 'coingecko:algorand',
   40153308: 'coingecko:ethereum',
   40153368: 'coingecko:wrapped-bitcoin',
   40153415: 'coingecko:coinbase-wrapped-btc',
-  300279:   'coingecko:usd-coin',
-  412682:   'coingecko:algorand',
-  410111:   'coingecko:tether',
-  419744:   'coingecko:avalanche-2',
-  302222:   'coingecko:binancecoin',
-  410811:   'coingecko:wrapped-bitcoin',
-  798968:   'coingecko:matic-network',
-  420024:   'coingecko:chainlink',
-  8471125:  'coingecko:solana',
-  8324600:  'coingecko:polkadot',
-  828295:   'coingecko:cardano',
-  770561:   'coingecko:dogecoin',
+  300279: 'coingecko:usd-coin',
+  412682: 'coingecko:algorand',
+  410111: 'coingecko:tether',
+  419744: 'coingecko:avalanche-2',
+  302222: 'coingecko:binancecoin',
+  410811: 'coingecko:wrapped-bitcoin',
+  798968: 'coingecko:matic-network',
+  420024: 'coingecko:chainlink',
+  8471125: 'coingecko:solana',
+  8324600: 'coingecko:polkadot',
+  828295: 'coingecko:cardano',
+  770561: 'coingecko:dogecoin',
   3207744109: 'coingecko:algorand',
   3211820549: 'coingecko:bitcoin',
   3210682240: 'coingecko:usd-coin',
@@ -119,25 +119,34 @@ const MARKET_COINGECKO_IDS = {
 
 async function fetchMarketData(chain) {
   try {
-    const { data } = await axios.get(`${API_BASE}/market-data/${NETWORK[chain]}`, {
-      timeout: REQUEST_TIMEOUT_MS,
-    });
+    const { data } = await axios.get(
+      `${API_BASE}/market-data/${NETWORK[chain]}`,
+      {
+        timeout: REQUEST_TIMEOUT_MS,
+      }
+    );
     if (!data.success) return [];
     return data.data || [];
   } catch (error) {
-    console.warn(`DorkFi market data unavailable for ${chain}: ${error.message}`);
+    console.warn(
+      `DorkFi market data unavailable for ${chain}: ${error.message}`
+    );
     return [];
   }
 }
 
 async function fetchAnalyticsTVL(chain) {
   try {
-    const { data } = await axios.get(`${API_BASE}/analytics/tvl/${NETWORK[chain]}`, {
-      timeout: REQUEST_TIMEOUT_MS,
-    });
+    const { data } = await axios.get(
+      `${API_BASE}/analytics/tvl/${NETWORK[chain]}`,
+      {
+        timeout: REQUEST_TIMEOUT_MS,
+      }
+    );
     if (!data.success) return {};
     const map = {};
-    for (const m of data.data.markets || []) map[`${m.appId}:${m.marketId}`] = m.tvl;
+    for (const m of data.data.markets || [])
+      map[`${m.appId}:${m.marketId}`] = m.tvl;
     return map;
   } catch (error) {
     console.warn(`DorkFi TVL data unavailable for ${chain}: ${error.message}`);
@@ -149,7 +158,8 @@ function dedup(markets) {
   const seen = new Map();
   for (const m of markets) {
     const key = `${m.appId}:${m.marketId}`;
-    if (!seen.has(key) || m.lastUpdated > seen.get(key).lastUpdated) seen.set(key, m);
+    if (!seen.has(key) || m.lastUpdated > seen.get(key).lastUpdated)
+      seen.set(key, m);
   }
   return [...seen.values()];
 }
@@ -163,20 +173,20 @@ function bpsToApy(rateBps) {
 
 function computeRates(market) {
   const totalDep = Number(market.totalScaledDeposits || 0);
-  const totalBor = Number(market.totalScaledBorrows  || 0);
+  const totalBor = Number(market.totalScaledBorrows || 0);
   if (totalDep === 0) return { borrowApy: 0, supplyApy: 0, utilization: 0 };
 
-  const utilization   = totalBor / totalDep;
-  const borrowRate    = Number(market.borrowRate    || 0);
-  const slope         = Number(market.slope         || 0);
+  const utilization = totalBor / totalDep;
+  const borrowRate = Number(market.borrowRate || 0);
+  const slope = Number(market.slope || 0);
   const reserveFactor = Number(market.reserveFactor || 0) / 10000;
 
   const borrowBps = borrowRate + utilization * slope;
   const supplyBps = borrowBps * utilization * (1 - reserveFactor);
 
   return {
-    borrowApy:   parseFloat(bpsToApy(borrowBps).toFixed(4)),
-    supplyApy:   parseFloat(bpsToApy(supplyBps).toFixed(4)),
+    borrowApy: parseFloat(bpsToApy(borrowBps).toFixed(4)),
+    supplyApy: parseFloat(bpsToApy(supplyBps).toFixed(4)),
     utilization,
   };
 }
@@ -187,7 +197,7 @@ function getUnderlyingTokens(market) {
 
 function getUsdValues(market, totalSupplyUsd) {
   const totalDep = Number(market.totalScaledDeposits || 0);
-  const totalBor = Number(market.totalScaledBorrows  || 0);
+  const totalBor = Number(market.totalScaledBorrows || 0);
   const utilization = totalDep === 0 ? 0 : totalBor / totalDep;
   const totalBorrowUsd = totalSupplyUsd * utilization;
 
@@ -212,7 +222,7 @@ const apy = async () => {
     for (const market of dedup(markets)) {
       if (market.paused) continue;
 
-      const key    = `${market.appId}:${market.marketId}`;
+      const key = `${market.appId}:${market.marketId}`;
       const hasTvl = Object.prototype.hasOwnProperty.call(tvlMap, key);
       if (!hasTvl) {
         console.warn(`DorkFi TVL missing for ${chain} market ${key}`);
@@ -220,28 +230,30 @@ const apy = async () => {
       }
 
       const totalSupplyUsd = Number(tvlMap[key]) || 0;
-      const { totalBorrowUsd, availableLiquidityUsd } = getUsdValues(market, totalSupplyUsd);
+      const { totalBorrowUsd, availableLiquidityUsd } = getUsdValues(
+        market,
+        totalSupplyUsd
+      );
       const tvlUsd = availableLiquidityUsd;
       if (tvlUsd < 1) continue;
 
       const { borrowApy, supplyApy } = computeRates(market);
-      const symbol = MARKET_SYMBOLS[market.marketId] || `ASA-${market.marketId}`;
+      const symbol =
+        MARKET_SYMBOLS[market.marketId] || `ASA-${market.marketId}`;
       const ltv = Number(market.collateralFactor || 0) / 10000;
 
       results.push({
-        pool:          `dorkfi-${chain}-${market.appId}-${market.marketId}`,
-        chain:         DL_CHAIN[chain],
-        project:       PROJECT,
+        pool: `dorkfi-${chain}-${market.appId}-${market.marketId}`,
+        chain: DL_CHAIN[chain],
+        project: PROJECT,
         symbol,
         tvlUsd,
-        apyBase:       supplyApy,
+        apyBase: supplyApy,
         apyBaseBorrow: borrowApy,
         totalSupplyUsd,
         totalBorrowUsd,
         ltv,
         underlyingTokens: getUnderlyingTokens(market),
-        poolMeta:      `Pool ${market.appId}`,
-        url:           'https://dork.fi',
       });
     }
   }
@@ -249,4 +261,9 @@ const apy = async () => {
   return results;
 };
 
-module.exports = { apy, timetravel: false, url: 'https://dork.fi', protocolId: 7531 };
+module.exports = {
+  apy,
+  timetravel: false,
+  url: 'https://dork.fi',
+  protocolId: 7531,
+};


### PR DESCRIPTION
Adds the DorkFi yield adapter for Algorand and Voi Network.

This supersedes closed PR #2599. That PR was closed as stale while review comments were unresolved, and GitHub would not allow it to be reopened after the branch update.

Updates included here:
- Adds `underlyingTokens` for every DorkFi pool using the on-chain market asset ID as a string.
- Uses on-chain IDs for UNIT and WAD because they are not listed on CoinGecko yet.
- Adds 30s axios request timeouts.
- Handles per-chain market/TVL fetch failures gracefully.
- Detects missing TVL entries explicitly instead of silently treating them as dust.

Validated locally:

```bash
npm run test --adapter=dorkfi
```

Result: 1 test suite passed, 376 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for viewing DorkFi lending market data and TVL across Algorand and Voi.
  - Added estimated supply and borrow APYs based on market utilization.
  - Included market symbols, token details, pool links, TVL, loan-to-value ratios, and total supply and borrow values.
  - Excluded paused, unavailable, or low-liquidity markets from reported results.
  - Added standardized USD liquidity and asset identification for clearer market reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->