### PR TITLE
sky-lending: add stUSDS (Expert Mode) pool

### DIFF
--- a/src/adaptors/sky-lending/index.js
+++ b/src/adaptors/sky-lending/index.js
@@ -532,6 +532,54 @@ const susdsAPY = async () => {
   return pools.filter(Boolean);
 };
 
+// stUSDS (Expert mode staked USDS) — same rate-accumulator pattern as sUSDS,
+// the per-second RAY rate getter is str() instead of ssr().
+const stusdsAPY = async () => {
+  const STUSDS = '0x99CD4Ec3f88A45940936F469E4bB72A2A701EEB9';
+  const USDS = '0xdC035D45d973E3EC169d2276DDab16f1e407384F';
+  const strAbi = {
+    inputs: [],
+    name: 'str',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  };
+  const RAY = 1e27;
+
+  const [strRes, totalSupplyRes] = await Promise.all([
+    sdk.api.abi.call({ target: STUSDS, abi: strAbi, chain: 'ethereum' }),
+    sdk.api.abi.call({
+      target: STUSDS,
+      abi: 'erc20:totalSupply',
+      chain: 'ethereum',
+    }),
+  ]);
+
+  const str = strRes.output / RAY;
+  const apyBase = (Math.pow(str, SECONDS_PER_YEAR) - 1) * 100;
+
+  const key = `ethereum:${STUSDS}`;
+  const price = (await getPriceApiData(`/prices/current/${key}`)).coins[key]
+    ?.price;
+  if (!price) return [];
+
+  return [
+    {
+      pool: STUSDS,
+      symbol: 'STUSDS',
+      project: 'sky-lending',
+      chain: 'ethereum',
+      token: STUSDS,
+      poolMeta: 'Expert Mode',
+      tvlUsd: (totalSupplyRes.output / 1e18) * price,
+      apyBase,
+      underlyingTokens: [USDS],
+      isIntrinsicSource: true,
+      url: 'https://app.sky.money/?network=ethereum&widget=expert&expert_module=stusds&flow=supply',
+    },
+  ];
+};
+
 // Staking farms (Synthetix-style StakingRewards).
 const farmsAPY = async () => {
   const USDS = '0xdC035D45d973E3EC169d2276DDab16f1e407384F';
@@ -617,7 +665,12 @@ const farmsAPY = async () => {
 };
 
 const apy = async () => {
-  const pools = await Promise.all([main(), susdsAPY(), farmsAPY()]);
+  const pools = await Promise.all([
+    main(),
+    susdsAPY(),
+    stusdsAPY(),
+    farmsAPY(),
+  ]);
   return pools.flat();
 };
 


### PR DESCRIPTION
Adds the stUSDS pool (Sky's Expert Mode staked-USDS product) to the sky-lending adapter:

- ~$174M TVL, ~7.0% APY — currently not listed by any adapter (only visible indirectly as collateral in Morpho markets and inside Curve LPs)
- APY read on-chain from the contract's `str()` per-second RAY rate accumulator — same mechanism as the existing sUSDS `ssr()` path
- TVL = totalSupply × coins.llama.fi price (`ethereum:0x99CD4Ec3f88A45940936F469E4bB72A2A701EEB9`, priced with confidence 1.0)
- Click-out deep-links to the product page on app.sky.money

Rebased onto current master per review — the branch now carries this single commit only.

Suite run from repo root: 234/234 passed, 20 pools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expert-mode STUSDS APY support on Ethereum, including expert pool metadata and a dedicated pool link when pricing is available.
* **Bug Fixes**
  * Improved APY accuracy by deriving STUSDS yield from on-chain supply and using the latest STUSDS price before presenting the pool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->