### PR TITLE
sky-money: new adapter for sky.money-curated Morpho Vault V2 pools

### DIFF
--- a/src/adaptors/sky-money/index.js
+++ b/src/adaptors/sky-money/index.js
@@ -1,0 +1,138 @@
+const sdk = require('@defillama/sdk');
+const axios = require('axios');
+
+const { getPriceApiData } = require('../utils');
+
+const MORPHO_GRAPH_URL = 'https://api.morpho.org/graphql';
+
+const USDS = '0xdC035D45d973E3EC169d2276DDab16f1e407384F';
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+// Morpho Vault V2 products curated by sky.money (Risk Curator). The
+// morpho-blue adapter lists these vaults under Morpho's frontend
+// (`morpho-vault-v2-<address>-<chain>` pool ids); these rows dual-list the
+// same vaults behind the curator's own frontend — the established
+// convention for one row per frontend (e.g. sUSDS on Arbitrum is listed by
+// both sky-lending and spark-savings).
+const VAULTS = [
+  {
+    address: '0xE15fcC81118895b67b6647BBd393182dF44E11E0',
+    asset: USDS,
+    symbol: 'USDS',
+    poolMeta: 'Flagship Vault',
+  },
+  {
+    address: '0x23f5E9c35820f4baB695Ac1F19c203cC3f8e1e11',
+    asset: USDT,
+    symbol: 'USDT',
+    poolMeta: 'Savings Vault',
+  },
+  {
+    address: '0x56bfa6f53669B836D1E0Dfa5e99706b12c373ecf',
+    asset: USDC,
+    symbol: 'USDC',
+    poolMeta: 'Risk Capital Vault',
+  },
+  {
+    address: '0xf42bca228D9bd3e2F8EE65Fec3d21De1063882d4',
+    asset: USDS,
+    symbol: 'USDS',
+    poolMeta: 'Risk Capital Vault',
+  },
+  {
+    address: '0x2bD3A43863c07B6A01581FADa0E1614ca5DF0E3d',
+    asset: USDT,
+    symbol: 'USDT',
+    poolMeta: 'Risk Capital Vault',
+  },
+];
+
+const VAULT_QUERY = `
+  query GetVaultV2($address: String!, $chainId: Int!) {
+    vaultV2ByAddress(address: $address, chainId: $chainId) {
+      netApyDay: avgNetApy(lookback: ONE_DAY)
+      baseApyDay: avgNetApyExcludingRewards(lookback: ONE_DAY)
+      rewards {
+        asset {
+          address
+        }
+        supplyApr
+      }
+    }
+  }
+`;
+
+const fetchVaultState = async (address) => {
+  const res = await axios.post(MORPHO_GRAPH_URL, {
+    query: VAULT_QUERY,
+    variables: { address, chainId: 1 },
+  });
+  return res.data.data.vaultV2ByAddress;
+};
+
+const apy = async () => {
+  const priceKeys = [...new Set(VAULTS.map((v) => `ethereum:${v.asset}`))].join(
+    ','
+  );
+  const [prices, decimalsRes, totalAssetsRes] = await Promise.all([
+    getPriceApiData(`/prices/current/${priceKeys}`).then((r) => r.coins),
+    sdk.api.abi.multiCall({
+      abi: 'erc20:decimals',
+      calls: VAULTS.map((v) => ({ target: v.asset })),
+      chain: 'ethereum',
+    }),
+    sdk.api.abi.multiCall({
+      abi: 'uint256:totalAssets',
+      calls: VAULTS.map((v) => ({ target: v.address })),
+      chain: 'ethereum',
+    }),
+  ]);
+  const decimals = decimalsRes.output.map((o) => o.output);
+  const totalAssets = totalAssetsRes.output.map((o) => o.output);
+
+  const pools = await Promise.all(
+    VAULTS.map(async (vault, i) => {
+      const price = prices[`ethereum:${vault.asset}`]?.price;
+      if (!price) return null;
+
+      const state = await fetchVaultState(vault.address);
+      if (!state || state.netApyDay == null) return null;
+
+      const rewardApr =
+        state.rewards?.reduce(
+          (sum, r) => sum + (r.supplyApr > 0 ? r.supplyApr : 0),
+          0
+        ) || 0;
+      const rewardTokens = (state.rewards || [])
+        .filter((r) => r.supplyApr > 0)
+        .map((r) => r.asset.address);
+
+      const tvlUsd =
+        (totalAssets[i] / Math.pow(10, decimals[i])) * price;
+
+      return {
+        pool: `${vault.address.toLowerCase()}-ethereum`,
+        chain: 'ethereum',
+        project: 'sky-money',
+        symbol: vault.symbol,
+        token: vault.address,
+        poolMeta: vault.poolMeta,
+        tvlUsd,
+        apyBase: (state.baseApyDay ?? 0) * 100,
+        apyReward: rewardApr > 0 ? rewardApr * 100 : null,
+        rewardTokens: rewardTokens.length ? rewardTokens : null,
+        underlyingTokens: [vault.asset],
+        url: `https://app.sky.money/?network=ethereum&widget=vaults&vault_module=morpho&vault=${vault.address}&flow=supply`,
+      };
+    })
+  );
+
+  return pools.filter(Boolean);
+};
+
+module.exports = {
+  protocolId: '7883',
+  apy,
+  url: 'https://app.sky.money/?network=ethereum&widget=vaults',
+};

--- a/src/adaptors/sky-money/index.js
+++ b/src/adaptors/sky-money/index.js
@@ -64,11 +64,17 @@ const VAULT_QUERY = `
 `;
 
 const fetchVaultState = async (address) => {
-  const res = await axios.post(MORPHO_GRAPH_URL, {
-    query: VAULT_QUERY,
-    variables: { address, chainId: 1 },
-  });
-  return res.data.data.vaultV2ByAddress;
+  try {
+    const res = await axios.post(
+      MORPHO_GRAPH_URL,
+      { query: VAULT_QUERY, variables: { address, chainId: 1 } },
+      { timeout: 10000 }
+    );
+    return res.data.data.vaultV2ByAddress;
+  } catch (err) {
+    // one failing vault lookup drops that row only, not the whole adapter
+    return null;
+  }
 };
 
 const apy = async () => {
@@ -97,7 +103,12 @@ const apy = async () => {
       if (!price) return null;
 
       const state = await fetchVaultState(vault.address);
-      if (!state || state.netApyDay == null) return null;
+      if (!state || state.netApyDay == null || state.baseApyDay == null)
+        return null;
+
+      const dec = Number(decimals[i]);
+      const assets = Number(totalAssets[i]);
+      if (!Number.isFinite(dec) || !Number.isFinite(assets)) return null;
 
       const rewardApr =
         state.rewards?.reduce(
@@ -108,8 +119,7 @@ const apy = async () => {
         .filter((r) => r.supplyApr > 0)
         .map((r) => r.asset.address);
 
-      const tvlUsd =
-        (totalAssets[i] / Math.pow(10, decimals[i])) * price;
+      const tvlUsd = (assets / Math.pow(10, dec)) * price;
 
       return {
         pool: `${vault.address.toLowerCase()}-ethereum`,
@@ -119,7 +129,7 @@ const apy = async () => {
         token: vault.address,
         poolMeta: vault.poolMeta,
         tvlUsd,
-        apyBase: (state.baseApyDay ?? 0) * 100,
+        apyBase: state.baseApyDay * 100,
         apyReward: rewardApr > 0 ? rewardApr * 100 : null,
         rewardTokens: rewardTokens.length ? rewardTokens : null,
         underlyingTokens: [vault.asset],


### PR DESCRIPTION
New adapter listing the 5 Morpho Vault V2 products curated by sky.money (protocol `sky-money`, id 7883, already listed on the TVL side as Risk Curator).

- Dual-listing next to the morpho-blue rows (`morpho-vault-v2-<address>-<chain>` ids there; `<address>-ethereum` here) — one row per frontend, same convention as sUSDS-Arbitrum which is listed by both sky-lending and spark-savings with each frontend's own URL
- TVL from on-chain `totalAssets()` × coins.llama.fi asset price; APY from the Morpho API (`avgNetApy` / `avgNetApyExcludingRewards`, ONE_DAY lookback), with reward APR split out and reward tokens declared (USDS — tradable and priced)
- Per-pool URLs deep-link to each vault's page on app.sky.money (the curator's frontend)
- ~$122M combined TVL: USDT Savings $64.6M, USDS Flagship $40.7M, USDC Risk Capital $14.5M + two smaller

Independent of the open sky-lending PRs (#2781/#2782/#2789) — new directory, no shared files.

Suite run from repo root: 42/42 passed, 5 pools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Morpho Vault V2 products curated by sky.money.
  * Displays vault-level APY, reward APY, TVL, and related vault metadata in the app.
  * Includes direct links to each vault’s sky.money page for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->