### PR TITLE
fix: yieldfi apy always 0, gw.yield.fi vault metrics went empty

### DIFF
--- a/src/adaptors/yieldfi/index.js
+++ b/src/adaptors/yieldfi/index.js
@@ -163,7 +163,11 @@ const fetchLatestAPY = async (tokenSymbol) => {
     }
 
     // First entry is the most recent, apy is already in percent
-    const latestAPY = apyHistory[0].apy;
+    const latestAPY = Number(apyHistory[0].apy);
+    if (!Number.isFinite(latestAPY)) {
+      console.error(`Invalid APY value for ${tokenSymbol}:`, apyHistory[0].apy);
+      return 0;
+    }
     return parseFloat(latestAPY.toFixed(2));
   } catch (error) {
     console.error(`Error fetching APY for ${tokenSymbol}:`, error);

--- a/src/adaptors/yieldfi/index.js
+++ b/src/adaptors/yieldfi/index.js
@@ -149,19 +149,21 @@ const ABIS = {
  */
 const fetchLatestAPY = async (tokenSymbol) => {
   try {
-    const endpoint = `https://gw.yield.fi/vault/api/public/vaults/${tokenSymbol?.toLowerCase()}`;
+    // gw.yield.fi vault metrics stopped returning apy (always null/0),
+    // so read the latest entry from the apy history endpoint instead
+    const endpoint = `https://ctrl.yield.fi/t/apy/${tokenSymbol?.toLowerCase()}/apyHistory`;
 
     const response = await fetch(endpoint);
 
     const data = await response.json();
-    const _apy = data?.data?.vault?.metrics?.apy;
-    if (!_apy) {
+    const apyHistory = data?.apy_history;
+    if (!Array.isArray(apyHistory) || apyHistory.length === 0) {
       console.error(`No APY history data found for ${tokenSymbol}`);
       return 0;
     }
 
-    // Convert APY from decimal to percentage
-    const latestAPY = _apy * 100;
+    // First entry is the most recent, apy is already in percent
+    const latestAPY = apyHistory[0].apy;
     return parseFloat(latestAPY.toFixed(2));
   } catch (error) {
     console.error(`Error fetching APY for ${tokenSymbol}:`, error);

--- a/src/utils/exclude.js
+++ b/src/utils/exclude.js
@@ -494,7 +494,6 @@ const excludedProtocols = [
   { id: '831', slug: 'vvs-standard' },
   { id: '2743', slug: 'yama-finance' },
   { id: '686', slug: 'yel-finance' },
-  { id: '5588', slug: 'yieldfi' },
   { id: '3941', slug: 'yldr' },
   { id: '2143', slug: 'zircon-gamma' },
   { id: '1229', slug: 'looksrare' },


### PR DESCRIPTION
yieldfi has been exporting 0 pools since around June, which is why it ended up in the exclusion list, but the protocol is alive with ~$10.5M TVL.

Root cause: #2322 switched APY sourcing from `ctrl.yield.fi/t/apy/<vault>/apyHistory` to `gw.yield.fi/vault/api/public/vaults/<vault>`, and that endpoint has since stopped returning APY data, `metrics` is null for every vault (checked yusd, yhlp and the vaults listing), so `fetchLatestAPY` returns 0 and every pool gets dropped.

The old ctrl endpoint is still live and fresh (yusd 9.03% / vyusd 9.13% / yeth 5% / vyeth 7% / ybtc 2.5% / vybtc 4%, all dated yesterday), so this switches `fetchLatestAPY` back to it. Values there are already in percent, so the `* 100` from the gw version is gone too. Also removes the exclusion entry so the adapter runs again.

yPrism/yHLP/yValos/yPYMN aren't supported by the ctrl endpoint, but they return 0 APY on gw as well and their TVL is dust, so behaviour for those is unchanged (dropped).

Local run: 41/41 tests, 6 pools, yUSD $10.7M @ 9.03%, vyUSD $2.78M @ 9.13%, yETH $1.29M, yBTC $0.99M, vyETH $229k, vyBTC $1.7k, matching the vault stats on yield.fi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated YieldFi APY retrieval to use the latest value from the current APY history source, improving accuracy.
  * Added validation to ensure APY data is present and numeric before displaying it, with safe fallback on invalid responses.
* **Configuration**
  * Re-enabled YieldFi by removing it from the excluded protocol list, allowing it to be included where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->