### PR TITLE
unexclude amnis-finance, the apy fix it was waiting on is in

### DIFF
--- a/src/utils/exclude.js
+++ b/src/utils/exclude.js
@@ -343,7 +343,6 @@ const excludedProtocols = [
   { id: '450', slug: 'scream' },
   { id: '2805', slug: 'stake.link-index' },
   { id: '6792', slug: 'ploutos-money' },
-  { id: '3667', slug: 'amnis-finance' }, // temp only, until fix is in
   { id: '111', slug: 'aave-v2' },
   { id: '1918', slug: 'aura' }, // winding down
   { id: '4182', slug: 'bakerfi' }, // wound down


### PR DESCRIPTION
amnis-finance was excluded in e5d514da with the note "temp only, until fix is in", and the fix landed the same day (826131c0, amnis finance fix apy); but the exclusion entry was never lifted, so the adapter still exports 0 pools while the protocol sits at ~$4.1M TVL on Aptos.

No adapter changes needed, just removes the exclusion entry.

Local run: 13/13 tests, 1 pool, stAPT $3.46M @ 2.51% apyBase, which lines up with api.amnis.finance/api/v1/stake/info (apr 2.51) and the on-chain stAPT supply × pricePerShare.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a hardcoded protocol exclusion so the affected protocol is no longer blocked by the default exclusion list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->