### PR TITLE
fix: indigo pools all had tvlUsd 0, ada price endpoint is broken

### DIFF
--- a/src/adaptors/indigo/index.js
+++ b/src/adaptors/indigo/index.js
@@ -1,4 +1,5 @@
 const { get, post } = require('./http-helper')
+const utils = require('../utils')
 
 const CARDANO_COINGECKO = {
   iUSD: 'coingecko:iusd',
@@ -66,10 +67,11 @@ async function fetchAssetAnalytics(assetName) {
 }
 
 // Fetch the ADA price in USD
+// (the analytics /api/price endpoint returns 500, which zeroed tvlUsd for every pool)
 async function fetchAdaPriceToUsd() {
   try {
-    const response = await get('https://analytics.indigoprotocol.io/api/price?from=ADA&to=USD');
-    return response.price;
+    const response = await utils.getPriceApiData('/prices/current/coingecko:cardano');
+    return response.coins['coingecko:cardano'].price;
   } catch (error) {
     console.error('Error fetching ADA price:', error);
     return 0;

--- a/src/utils/exclude.js
+++ b/src/utils/exclude.js
@@ -385,7 +385,6 @@ const excludedProtocols = [
   { id: '2992', slug: 'gravita-protocol' },
   { id: '6761', slug: 'sendit' },
   { id: '5746', slug: 'beraborrow' },
-  { id: '2309', slug: 'indigo' },
   { id: '4818', slug: 'bitu-protocol' },
   { id: '3068', slug: 'raft' },
   { id: '6681', slug: 'aimstrong' },


### PR DESCRIPTION
indigo's stability pool APRs were still coming through fine, but every pool had tvlUsd 0, which got it swept into the exclusion list at the end of May.

Root cause: the adapter converts the pools' ADA-denominated TVL to USD via `analytics.indigoprotocol.io/api/price?from=ADA&to=USD`, and that endpoint now returns HTTP 500. The catch swallows it and returns 0, so every pool's TVL multiplies out to 0. The rest of the analytics API (stability-pools, apr, asset analytics) works fine.

Fix: take the ADA price from coins.llama.fi (`coingecko:cardano`) through the existing `getPriceApiData` helper instead, and remove the exclusion entry.

Local run: 45/45 tests, 6 pools, ~$4.1M total (iUSD $2.82M, iBTC $1.10M, iETH $194k + iSOL/iJPY/iEUR dust), matches the ADA totals on their analytics API times the current ADA price, and the protocol page. APRs are passed through from indigo's own apr endpoint, unchanged by this PR.