### PR TITLE
add pareto-credit adapter ($201M RWA lending, no yields listing)

### DIFF
--- a/src/adaptors/pareto-credit/index.js
+++ b/src/adaptors/pareto-credit/index.js
@@ -92,7 +92,7 @@ const apy = async () => {
       apyBase: aprs[i] / 1e18,
       underlyingTokens: [token],
       pricePerShare: sharePrices[i] / 10 ** decimals[i],
-      url: `https://app.pareto.credit/vault#${vault}`,
+      url: `https://app.pareto.credit/vault#${tranches[i]}`,
     };
   });
 

--- a/src/adaptors/pareto-credit/index.js
+++ b/src/adaptors/pareto-credit/index.js
@@ -63,9 +63,13 @@ const apy = async () => {
     multiCall('uint256:getContractValue', vaultCalls),
   ]);
 
-  const [aprs, trancheNames, symbols, decimals] = await Promise.all([
+  const [aprs, sharePrices, trancheNames, symbols, decimals] = await Promise.all([
     multiCall(
       'function getApr(address) view returns (uint256)',
+      vaults.map((target, i) => ({ target, params: [tranches[i]] }))
+    ),
+    multiCall(
+      'function virtualPrice(address) view returns (uint256)',
       vaults.map((target, i) => ({ target, params: [tranches[i]] }))
     ),
     multiCall('string:name', tranches.map((target) => ({ target }))),
@@ -89,11 +93,13 @@ const apy = async () => {
       pool: `${vault}-${CHAIN}`.toLowerCase(),
       chain: utils.formatChain(CHAIN),
       project: 'pareto-credit',
-      symbol: utils.formatSymbol(symbols[i]),
+      symbol: symbols[i],
       poolMeta: vaultName(trancheNames[i], symbols[i]),
       tvlUsd,
       apyBase: aprs[i] / 1e18,
       underlyingTokens: [token],
+      pricePerShare: sharePrices[i] / 10 ** decimals[i],
+      url: `https://app.pareto.credit/vault/${vault}`,
     };
   });
 

--- a/src/adaptors/pareto-credit/index.js
+++ b/src/adaptors/pareto-credit/index.js
@@ -1,20 +1,15 @@
 const sdk = require('@defillama/sdk');
 const utils = require('../utils');
 
-// Pareto credit vaults are IdleCDO-style epoch contracts (single AA tranche in
-// practice, BB supply is 0 on every live vault). TVL comes from the vault's
-// getContractValue (denominated in the underlying token) and the advertised
-// rate from getApr(AATranche), which the manager sets per epoch.
 const CHAIN = 'ethereum';
 const FACTORY = '0x59aabDAd8FDaBD227CC71543B128765f93906626';
 const FACTORY_START_BLOCK = 22938055;
 
-// vaults deployed before the factory existed
 const LEGACY_VAULTS = [
-  '0xf6223C567F21E33e859ED7A045773526E9E3c2D5', // Fasanara
-  '0x4462eD748B8F7985A4aC6b538Dfc105Fce2dD165', // Bastion
-  '0x14B8E918848349D1e71e806a52c13D4e0d3246E0', // Adaptive Frontier
-  '0x433D5B175148dA32Ffe1e1A37a939E1b7e79be4d', // FalconX
+  '0xf6223C567F21E33e859ED7A045773526E9E3c2D5',
+  '0x4462eD748B8F7985A4aC6b538Dfc105Fce2dD165',
+  '0x14B8E918848349D1e71e806a52c13D4e0d3246E0',
+  '0x433D5B175148dA32Ffe1e1A37a939E1b7e79be4d',
 ];
 
 const multiCall = async (abi, calls) =>
@@ -27,7 +22,6 @@ const multiCall = async (abi, calls) =>
     })
   ).output.map((o) => o.output);
 
-// "Pareto AA Tranche - FalconXUSDC" -> "FalconX", "IdleCDO AA Tranche - idle_Fasanara" -> "Fasanara"
 const vaultName = (trancheName, tokenSymbol) => {
   if (!trancheName) return undefined;
   let name = trancheName.split(' - ').pop();
@@ -98,7 +92,7 @@ const apy = async () => {
       apyBase: aprs[i] / 1e18,
       underlyingTokens: [token],
       pricePerShare: sharePrices[i] / 10 ** decimals[i],
-      url: `https://app.pareto.credit/vault/${vault}`,
+      url: `https://app.pareto.credit/vault#${vault}`,
     };
   });
 

--- a/src/adaptors/pareto-credit/index.js
+++ b/src/adaptors/pareto-credit/index.js
@@ -1,0 +1,108 @@
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+// Pareto credit vaults are IdleCDO-style epoch contracts (single AA tranche in
+// practice, BB supply is 0 on every live vault). TVL comes from the vault's
+// getContractValue (denominated in the underlying token) and the advertised
+// rate from getApr(AATranche), which the manager sets per epoch.
+const CHAIN = 'ethereum';
+const FACTORY = '0x59aabDAd8FDaBD227CC71543B128765f93906626';
+const FACTORY_START_BLOCK = 22938055;
+
+// vaults deployed before the factory existed
+const LEGACY_VAULTS = [
+  '0xf6223C567F21E33e859ED7A045773526E9E3c2D5', // Fasanara
+  '0x4462eD748B8F7985A4aC6b538Dfc105Fce2dD165', // Bastion
+  '0x14B8E918848349D1e71e806a52c13D4e0d3246E0', // Adaptive Frontier
+  '0x433D5B175148dA32Ffe1e1A37a939E1b7e79be4d', // FalconX
+];
+
+const multiCall = async (abi, calls) =>
+  (
+    await sdk.api.abi.multiCall({
+      chain: CHAIN,
+      abi,
+      calls,
+      permitFailure: true,
+    })
+  ).output.map((o) => o.output);
+
+// "Pareto AA Tranche - FalconXUSDC" -> "FalconX", "IdleCDO AA Tranche - idle_Fasanara" -> "Fasanara"
+const vaultName = (trancheName, tokenSymbol) => {
+  if (!trancheName) return undefined;
+  return trancheName
+    .split(' - ')
+    .pop()
+    .replace(new RegExp(`${tokenSymbol}$`), '')
+    .replace(/^idle_/, '')
+    .trim();
+};
+
+const apy = async () => {
+  const currentBlock = await sdk.api.util.getLatestBlock(CHAIN);
+  const deployEvents = await sdk.getEventLogs({
+    chain: CHAIN,
+    target: FACTORY,
+    eventAbi: 'event CreditVaultDeployed(address proxy)',
+    fromBlock: FACTORY_START_BLOCK,
+    toBlock: currentBlock.number,
+  });
+
+  const vaults = [...LEGACY_VAULTS];
+  for (const ev of deployEvents) {
+    const proxy = ev.args.proxy;
+    if (!vaults.some((v) => v.toLowerCase() === proxy.toLowerCase())) {
+      vaults.push(proxy);
+    }
+  }
+
+  const vaultCalls = vaults.map((target) => ({ target }));
+  const [tokens, tranches, contractValues] = await Promise.all([
+    multiCall('address:token', vaultCalls),
+    multiCall('address:AATranche', vaultCalls),
+    multiCall('uint256:getContractValue', vaultCalls),
+  ]);
+
+  const [aprs, trancheNames, symbols, decimals] = await Promise.all([
+    multiCall(
+      'function getApr(address) view returns (uint256)',
+      vaults.map((target, i) => ({ target, params: [tranches[i]] }))
+    ),
+    multiCall('string:name', tranches.map((target) => ({ target }))),
+    multiCall('erc20:symbol', tokens.map((target) => ({ target }))),
+    multiCall('erc20:decimals', tokens.map((target) => ({ target }))),
+  ]);
+
+  const { pricesByAddress: prices } = await utils.getPrices(
+    [...new Set(tokens.filter(Boolean))],
+    CHAIN
+  );
+
+  const pools = vaults.map((vault, i) => {
+    const token = tokens[i];
+    const price = prices[token?.toLowerCase()];
+    if (!token || !price || !contractValues[i]) return null;
+
+    const tvlUsd = (contractValues[i] / 10 ** decimals[i]) * price;
+
+    return {
+      pool: `${vault}-${CHAIN}`.toLowerCase(),
+      chain: utils.formatChain(CHAIN),
+      project: 'pareto-credit',
+      symbol: utils.formatSymbol(symbols[i]),
+      poolMeta: vaultName(trancheNames[i], symbols[i]),
+      tvlUsd,
+      apyBase: aprs[i] / 1e18,
+      underlyingTokens: [token],
+    };
+  });
+
+  return pools.filter(Boolean).filter((p) => p.tvlUsd > 0 && utils.keepFinite(p));
+};
+
+module.exports = {
+  protocolId: '6429',
+  timetravel: false,
+  apy,
+  url: 'https://app.pareto.credit/vaults',
+};

--- a/src/adaptors/pareto-credit/index.js
+++ b/src/adaptors/pareto-credit/index.js
@@ -30,12 +30,11 @@ const multiCall = async (abi, calls) =>
 // "Pareto AA Tranche - FalconXUSDC" -> "FalconX", "IdleCDO AA Tranche - idle_Fasanara" -> "Fasanara"
 const vaultName = (trancheName, tokenSymbol) => {
   if (!trancheName) return undefined;
-  return trancheName
-    .split(' - ')
-    .pop()
-    .replace(new RegExp(`${tokenSymbol}$`), '')
-    .replace(/^idle_/, '')
-    .trim();
+  let name = trancheName.split(' - ').pop();
+  if (tokenSymbol && name.endsWith(tokenSymbol)) {
+    name = name.slice(0, -tokenSymbol.length);
+  }
+  return name.replace(/^idle_/, '').trim();
 };
 
 const apy = async () => {


### PR DESCRIPTION
Adds a yields adapter for Pareto Credit (pareto-credit, id 6429), closes #2796.

Pareto credit vaults are IdleCDO-style epoch contracts (the Idle team's successor product). Everything is read on-chain, same plumbing as the DefiLlama-Adapters TVL adapter:

- vault discovery: the 4 pre-factory vaults hardcoded + CreditVaultDeployed events from the factory (0x59aa...0626), so new vaults show up without PRs
- tvlUsd: getContractValue (underlying-denominated) x coins.llama.fi price of the underlying
- apyBase: getApr(AATranche) / 1e18, the per-epoch rate the vault manager sets, which is what their app advertises. No compounding applied since epochs pay simple interest
- BB tranches are ignored: totalSupply is 0 on every live vault, the product is AA-only in practice
- test/empty vaults (L1Test, Blackrock-test-0 etc, all deployed by the factory) come out with dust TVL and fall under the $10k display floor

Local run: 89/89 tests, 14 pools. The five real ones: FalconX $149.9M @ 8.31%, RockawayX $20.8M @ 7.13%, Bastion $15.2M @ 10.59%, Fasanara $11.2M @ 0% (no epoch running currently), Adaptive Frontier $2.1M @ 9.38%, sums to ~$199M vs the protocol's $201.7M on llama (difference is the USP stablecoin supply, which isn't a yield pool). APRs cross-check against app.pareto.credit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Pareto Credit vaults on Ethereum.
  * Reports each vault’s USD total value locked, base APY, and price per share.
  * Includes vault details such as the underlying asset and direct links to the Pareto Credit app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->