### PR TITLE
feat(t3tris-finance): surface entry & exit fees in poolMeta

### DIFF
--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -404,14 +404,15 @@ const main = async () => {
         // Fee metadata: always show the performance fee, then append the
         // management, entry, and exit fees whenever they are non-zero (kept
         // conditional so vaults that don't charge them aren't cluttered with 0%).
-        const feeParts = [`perf ${vault.perfFeePct.toFixed(1)}%`];
-        if (vault.mgmtFeePct > 0)
-          feeParts.push(`mgmt ${vault.mgmtFeePct.toFixed(1)}%`);
-        if (vault.entryFeePct > 0)
-          feeParts.push(`entry ${vault.entryFeePct.toFixed(1)}%`);
-        if (vault.exitFeePct > 0)
-          feeParts.push(`exit ${vault.exitFeePct.toFixed(1)}%`);
-        const poolMeta = feeParts.join(', ');
+        // Compact labels (in/out) and a '/' separator keep the string short;
+        // rates keep up to 2 decimals with trailing zeros stripped, so fine fees
+        // like 0.05% aren't rounded away while whole numbers stay as e.g. 20%.
+        const fmtPct = (x) => `${Math.round(x * 100) / 100}%`;
+        const feeParts = [`perf ${fmtPct(vault.perfFeePct)}`];
+        if (vault.mgmtFeePct > 0) feeParts.push(`mgmt ${fmtPct(vault.mgmtFeePct)}`);
+        if (vault.entryFeePct > 0) feeParts.push(`in ${fmtPct(vault.entryFeePct)}`);
+        if (vault.exitFeePct > 0) feeParts.push(`out ${fmtPct(vault.exitFeePct)}`);
+        const poolMeta = feeParts.join('/');
 
         pools.push({
           pool: `${vault.address}-${chain}`.toLowerCase(),

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -401,13 +401,17 @@ const main = async () => {
           APY_WINDOW_DAYS,
         );
 
-        // Fee metadata: performance fee, plus management fee when non-zero.
-        const poolMeta =
-          vault.mgmtFeePct > 0
-            ? `perf ${vault.perfFeePct.toFixed(1)}%, mgmt ${vault.mgmtFeePct.toFixed(
-                1,
-              )}%`
-            : `perf ${vault.perfFeePct.toFixed(1)}%`;
+        // Fee metadata: always show the performance fee, then append the
+        // management, entry, and exit fees whenever they are non-zero (kept
+        // conditional so vaults that don't charge them aren't cluttered with 0%).
+        const feeParts = [`perf ${vault.perfFeePct.toFixed(1)}%`];
+        if (vault.mgmtFeePct > 0)
+          feeParts.push(`mgmt ${vault.mgmtFeePct.toFixed(1)}%`);
+        if (vault.entryFeePct > 0)
+          feeParts.push(`entry ${vault.entryFeePct.toFixed(1)}%`);
+        if (vault.exitFeePct > 0)
+          feeParts.push(`exit ${vault.exitFeePct.toFixed(1)}%`);
+        const poolMeta = feeParts.join(', ');
 
         pools.push({
           pool: `${vault.address}-${chain}`.toLowerCase(),


### PR DESCRIPTION
## What

The T3tris Finance adaptor already reads all four vault fees on-chain (performance, management, entry, exit) but only surfaced perf & mgmt in `poolMeta`. This PR adds the entry and exit fees so the full fee schedule is visible in the pool metadata.

## Details

- **No new on-chain calls** — `getEntryFee`/`getExitFee` were already fetched and stored per vault; only the display string changed.
- `poolMeta` is now assembled from a parts list: the performance fee is always shown, and management, entry, and exit are appended only when non-zero (so vaults that don't charge a given fee stay uncluttered).
- Example output: `perf 10.0%, mgmt 2.0%, entry 0.5%, exit 0.5%`

Follow-up to #2735.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated displayed pool fee information to consistently include vault performance fees.
  * Improved the fee summary formatting to show management, entry, and exit fee components only when their rates are non-zero.
  * Refined percentage display to use rounded values without trailing zeros.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->