### PR TITLE
pareto-credit: set token to AATranche address (was falling back to vault address)

### DIFF
--- a/src/adaptors/pareto-credit/index.js
+++ b/src/adaptors/pareto-credit/index.js
@@ -78,7 +78,7 @@ const apy = async () => {
   const pools = vaults.map((vault, i) => {
     const token = tokens[i];
     const price = prices[token?.toLowerCase()];
-    if (!token || !price || !contractValues[i]) return null;
+    if (!token || !price || !contractValues[i] || !tranches[i]) return null;
 
     const tvlUsd = (contractValues[i] / 10 ** decimals[i]) * price;
 

--- a/src/adaptors/pareto-credit/index.js
+++ b/src/adaptors/pareto-credit/index.js
@@ -90,6 +90,7 @@ const apy = async () => {
       poolMeta: vaultName(trancheNames[i], symbols[i]),
       tvlUsd,
       apyBase: aprs[i] / 1e18,
+      token: tranches[i].toLowerCase(),
       underlyingTokens: [token],
       pricePerShare: sharePrices[i] / 10 ** decimals[i],
       url: `https://app.pareto.credit/vault#${tranches[i]}`,


### PR DESCRIPTION
`token` was never set on the returned pool object in #2797, so the
yield-server fallback regex grabbed the first 0x... address in the
`pool` id string  the CDO vault contract itself  instead of the
actual depositor receipt token. `tranches[i]` (the AATranche address)
is already fetched and used for `getApr`/`virtualPrice`/`name` in the
same function, just never wired into the returned pool object.

Fix: add `token: tranches[i].toLowerCase()`, pointing at the correct
transferable ERC20 (the AA tranche), not the vault.

Verified locally:
- `npm run test --adapter=pareto-credit`  131/131 passing, same 14
  pools, same TVL/APY/pricePerShare values as before — only the new
  `token` field is added, nothing else changes.
- Each pool's `token` now matches the tranche address already used in
  its own `url` fragment (e.g. Fasanara: `token` and `url#` both
  resolve to `0x45054c6753b4Bce40C5d54418DabC20b070F85bE`).

Separately checked whether `pricePerShare`'s decimal scaling
(`sharePrices[i] / 10 ** decimals[i]`, using the underlying's
decimals) was correct  confirmed on-chain the underlying is USDC (6
decimals) and `virtualPrice` scales against that correctly, so no
issue there, unrelated to this PR.

cc @0xkr3p since you reviewed and merged #2797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Pool data now includes the associated tranche token address (lowercased) for clearer identification.
* **Bug Fixes**
  * Pools are no longer created when a required tranche entry is missing; such incomplete pools are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->