### PR TITLE
feat(metrom-adapter): integrate hold fungible asset campaign types

### DIFF
--- a/src/adaptors/metrom/index.ts
+++ b/src/adaptors/metrom/index.ts
@@ -42,6 +42,24 @@ interface Token {
   symbol: string;
 }
 
+interface LpTokenDetails {
+  type: 'lp';
+  dex: string;
+  baseTokenAddress: string;
+  baseTokenSymbol: string;
+  quoteTokenAddress: string;
+  quoteTokenSymbol: string;
+}
+
+interface ProtocolTokenDetails {
+  type: 'protocol';
+  slug: string;
+}
+
+interface TokenWithDetails extends Token {
+  details?: LpTokenDetails | ProtocolTokenDetails;
+}
+
 interface BaseTarget {
   chainType: string;
   chainId: number;
@@ -110,6 +128,11 @@ interface YieldSeekerTarget extends BaseTarget {
   type: 'yield-seeker';
 }
 
+interface HoldFungibleAssetTarget extends BaseTarget {
+  type: 'hold-fungible-asset';
+  asset: TokenWithDetails;
+}
+
 interface Erc4626Target extends BaseTarget {
   type: 'erc4626-vault';
   brand: string;
@@ -143,6 +166,7 @@ interface Campaign {
     | AaveV3NetSupplyTarget
     | TurtleTarget
     | YieldSeekerTarget
+    | HoldFungibleAssetTarget
     | Erc4626Target;
   rewards?: Rewards;
   usdTvl?: number;
@@ -312,6 +336,28 @@ async function processCampaign(
         symbol: 'USDC',
         underlyingTokens: [BASE_USDC],
         poolMeta: 'Deposit',
+      };
+    }
+    case 'hold-fungible-asset': {
+      const asset = campaign.target.asset;
+
+      if (asset.details?.type === 'lp')
+        return {
+          symbol: `${asset.details.baseTokenSymbol} - ${asset.details.quoteTokenSymbol}`,
+          underlyingTokens: [
+            asset.details.baseTokenAddress,
+            asset.details.quoteTokenAddress,
+          ],
+          poolMeta: humanizeTargetProtocol('Pool on', asset.details.dex),
+        };
+
+      return {
+        symbol: asset.symbol,
+        underlyingTokens: [asset.address],
+        poolMeta: humanizeTargetProtocol(
+          'Hold',
+          asset.details?.type === 'protocol' ? asset.details.slug : undefined
+        ),
       };
     }
     case 'erc4626-vault': {

--- a/src/adaptors/metrom/index.ts
+++ b/src/adaptors/metrom/index.ts
@@ -351,14 +351,7 @@ async function processCampaign(
           poolMeta: humanizeTargetProtocol('Pool on', asset.details.dex),
         };
 
-      return {
-        symbol: asset.symbol,
-        underlyingTokens: [asset.address],
-        poolMeta: humanizeTargetProtocol(
-          'Hold',
-          asset.details?.type === 'protocol' ? asset.details.slug : undefined
-        ),
-      };
+      return null;
     }
     case 'erc4626-vault': {
       return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Metrom campaigns targeting held fungible assets (`hold-fungible-asset`).
  * For LP-based assets, the UI now includes underlying token symbols and addresses, along with the associated exchange information.
  * Non-LP asset detail types are not processed for this campaign target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->