### PR TITLE
Add Robinhood Chain to T3tris Finance APY adapter

### DIFF
--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -278,7 +278,7 @@ const getAnchoredHistoricalPps = async (vaults, chain) => {
   const blockByTs = {};
   await Promise.all(
     uniqueTs.map(async (ts) => {
-      blockByTs[ts] = await getBlockNumber(ts, chain);
+      blockByTs[ts] = await getBlockNumber(ts, sdkChain(chain));
     }),
   );
 
@@ -366,7 +366,7 @@ const main = async () => {
 
       // Get prices for underlying assets
       const assetAddresses = [...new Set(vaults.map((v) => v.asset))];
-      const prices = await utils.getPrices(assetAddresses, chain);
+      const prices = await utils.getPrices(assetAddresses, sdkChain(chain));
 
       // Current PPS (= value saved at the last NAV) + historical PPS anchored at
       // each vault's last NAV, so the APY is held (extrapolated) afterwards.

--- a/src/adaptors/t3tris-finance/index.js
+++ b/src/adaptors/t3tris-finance/index.js
@@ -33,11 +33,17 @@ const ABI = {
     'function lastValuationTimestamp() external view returns (uint64)',
 };
 
-// Supported chains: DefiLlama chain name -> ecosystem-API chainId. Arbitrum only
-// for now (same CREATE3 addresses on every EVM chain); add a chain here once it
-// goes live and the API returns verified vaults for it.
-const CHAIN_IDS = { arbitrum: 42161 };
+// Supported chains: DefiLlama chain name -> ecosystem-API chainId. Vaults share
+// the same CREATE3 addresses on every EVM chain, so adding a chain here surfaces
+// its vaults as soon as the ecosystem API returns verified entries for it.
+const CHAIN_IDS = { arbitrum: 42161, robinhood: 4663 };
 const CHAINS = Object.keys(CHAIN_IDS);
+
+// A few chains' @defillama/sdk provider key differs from the DefiLlama slug we
+// use for the DB/URL: map slug -> sdk chain for on-chain calls (Robinhood's
+// provider is registered as "robinhoodchain", chainId 4663).
+const SDK_CHAIN = { robinhood: 'robinhoodchain' };
+const sdkChain = (chain) => SDK_CHAIN[chain] || chain;
 
 const DAY_SECONDS = 24 * 3600;
 
@@ -50,7 +56,7 @@ const multiCall = (targets, abi, chain, block = undefined) =>
   sdk.api.abi.multiCall({
     calls: targets.map((target) => ({ target })),
     abi,
-    chain,
+    chain: sdkChain(chain),
     block,
     permitFailure: true,
   });
@@ -293,7 +299,7 @@ const getAnchoredHistoricalPps = async (vaults, chain) => {
         const ppsRes = await sdk.api.abi.multiCall({
           calls: items.map((it) => ({ target: it.oracle })),
           abi: ABI.getLastSavedPricePerShare,
-          chain,
+          chain: sdkChain(chain),
           block: Number(block),
           permitFailure: true,
         });
@@ -325,7 +331,7 @@ const getCurrentOraclePps = async (vaults, chain) => {
     const ppsRes = await sdk.api.abi.multiCall({
       calls: oracleAddresses.map((oracle) => ({ target: oracle })),
       abi: ABI.getLastSavedPricePerShare,
-      chain,
+      chain: sdkChain(chain),
       permitFailure: true,
     });
 

--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -197,6 +197,7 @@ exports.formatChain = (chain) => {
   if (chain && chain.toLowerCase() === 'optimism') return 'OP Mainnet';
   if (chain && chain.toLowerCase() === 'ton') return 'TON';
   if (chain && chain.toLowerCase() === 'zklink') return 'zkLink Nova';
+  if (chain && chain.toLowerCase() === 'robinhood') return 'Robinhood Chain';
 
   return chain.charAt(0).toUpperCase() + chain.slice(1);
 };

--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -47,13 +47,11 @@ const getStarknetRpc = () => {
   return process.env.STARKNET_RPC;
 };
 
-const rateLimitedStarknetCall =
-  (fn) =>
-  (...args) => {
-    const promise = pendingStarknetCall.then(() => fn(...args));
-    pendingStarknetCall = promise.catch(() => {});
-    return promise;
-  };
+const rateLimitedStarknetCall = (fn) => (...args) => {
+  const promise = pendingStarknetCall.then(() => fn(...args));
+  pendingStarknetCall = promise.catch(() => {});
+  return promise;
+};
 
 const chunkArray = (arr, chunkSize = 100) => {
   const chunks = [];
@@ -65,23 +63,16 @@ const chunkArray = (arr, chunkSize = 100) => {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const getStarknetCallBody = (
-  { abi, target, params = [], allAbi = [] },
-  id = 0
-) => {
+const getStarknetCallBody = ({ abi, target, params = [], allAbi = [] }, id = 0) => {
   if ((params || params === 0) && !Array.isArray(params)) params = [params];
 
   const contract = new Contract([abi, ...allAbi], target, null);
   const requestData = contract.populate(abi.name, params);
-  requestData.entry_point_selector = starknetHash.getSelectorFromName(
-    requestData.entrypoint
-  );
+  requestData.entry_point_selector = starknetHash.getSelectorFromName(requestData.entrypoint);
   requestData.contract_address = requestData.contractAddress;
   delete requestData.contractAddress;
   delete requestData.entrypoint;
-  requestData.calldata = requestData.calldata.map((i) =>
-    starknetNumber.toHex(starknetNumber.toBN(i))
-  );
+  requestData.calldata = requestData.calldata.map((i) => starknetNumber.toHex(starknetNumber.toBN(i)));
 
   return {
     jsonrpc: '2.0',
@@ -113,20 +104,12 @@ const parseStarknetOutput = (result, abi, allAbi) => {
 const starknetCall = async ({ abi, target, params = [], allAbi = [] } = {}) => {
   const {
     data: { result },
-  } = await axios.post(
-    getStarknetRpc(),
-    getStarknetCallBody({ abi, target, params, allAbi })
-  );
+  } = await axios.post(getStarknetRpc(), getStarknetCallBody({ abi, target, params, allAbi }));
 
   return parseStarknetOutput(result, abi, allAbi);
 };
 
-const starknetMultiCall = async ({
-  abi: rootAbi,
-  target: rootTarget,
-  calls = [],
-  allAbi = [],
-}) => {
+const starknetMultiCall = async ({ abi: rootAbi, target: rootTarget, calls = [], allAbi = [] }) => {
   if (!calls.length) return [];
 
   calls = calls.map((callArgs) => {
@@ -275,7 +258,7 @@ const getBlocksByTime = async (timestamps, chainString) => {
   return Promise.all(
     timestamps.map(async (timestamp) => {
       const response = await axios.get(
-        getPriceApiUrl(`/block/${chain}/${timestamp}`)
+      getPriceApiUrl(`/block/${chain}/${timestamp}`)
       );
       return response.data.height;
     })
@@ -683,43 +666,42 @@ exports.getERC4626Info = async (
         .then((r) => r.data.height)
     )
   );
-  const [tvl, priceNow, priceYesterday, asset, shareDecimalsRes] =
-    await Promise.all([
-      sdk.api.abi.call({
+  const [tvl, priceNow, priceYesterday, asset, shareDecimalsRes] = await Promise.all([
+    sdk.api.abi.call({
+      target: address,
+      block: blockNow,
+      abi: totalAssetsAbi,
+      chain: chain,
+    }),
+    sdk.api.abi.call({
+      target: address,
+      block: blockNow,
+      abi: convertToAssetsAbi,
+      params: [assetUnit],
+      chain: chain,
+    }),
+    sdk.api.abi.call({
+      target: address,
+      block: blockYesterday,
+      abi: convertToAssetsAbi,
+      params: [assetUnit],
+      chain: chain,
+    }),
+    sdk.api.abi
+      .call({
         target: address,
-        block: blockNow,
-        abi: totalAssetsAbi,
+        abi: 'address:asset',
         chain: chain,
-      }),
-      sdk.api.abi.call({
+      })
+      .catch(() => null),
+    sdk.api.abi
+      .call({
         target: address,
-        block: blockNow,
-        abi: convertToAssetsAbi,
-        params: [assetUnit],
+        abi: 'erc20:decimals',
         chain: chain,
-      }),
-      sdk.api.abi.call({
-        target: address,
-        block: blockYesterday,
-        abi: convertToAssetsAbi,
-        params: [assetUnit],
-        chain: chain,
-      }),
-      sdk.api.abi
-        .call({
-          target: address,
-          abi: 'address:asset',
-          chain: chain,
-        })
-        .catch(() => null),
-      sdk.api.abi
-        .call({
-          target: address,
-          abi: 'erc20:decimals',
-          chain: chain,
-        })
-        .catch(() => null),
-    ]);
+      })
+      .catch(() => null),
+  ]);
   const apy = (priceNow.output / priceYesterday.output) ** 365 * 100 - 100;
   let assetDecimals = 18;
   if (asset && asset.output) {
@@ -784,22 +766,15 @@ exports.getTotalSupply = async (tokenMintAddress) => {
 };
 
 // Solana RPC helper for getAccountInfo
-const getSolanaAccountInfo = async (
-  address,
-  rpcUrl = 'https://api.mainnet-beta.solana.com'
-) => {
-  const response = await axios.post(
-    rpcUrl,
-    {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'getAccountInfo',
-      params: [address, { encoding: 'base64' }],
-    },
-    {
-      headers: { 'Content-Type': 'application/json' },
-    }
-  );
+const getSolanaAccountInfo = async (address, rpcUrl = 'https://api.mainnet-beta.solana.com') => {
+  const response = await axios.post(rpcUrl, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'getAccountInfo',
+    params: [address, { encoding: 'base64' }],
+  }, {
+    headers: { 'Content-Type': 'application/json' },
+  });
 
   const data = response.data;
   if (data.error) {
@@ -816,64 +791,41 @@ const getSolanaAccountInfo = async (
 // SPL Stake Pool data decoder using official library
 const { StakePoolLayout } = require('@solana/spl-stake-pool');
 
-exports.getStakePoolInfo = async (
-  stakePoolAddress,
-  rpcUrl = 'https://api.mainnet-beta.solana.com'
-) => {
-  const stakePoolAccountData = await getSolanaAccountInfo(
-    stakePoolAddress,
-    rpcUrl
-  );
+exports.getStakePoolInfo = async (stakePoolAddress, rpcUrl = 'https://api.mainnet-beta.solana.com') => {
+  const stakePoolAccountData = await getSolanaAccountInfo(stakePoolAddress, rpcUrl);
 
   // Decode using official SPL stake pool layout
   const stakePool = StakePoolLayout.decode(stakePoolAccountData);
 
   const totalLamports = BigInt(stakePool.totalLamports.toString());
   const poolTokenSupply = BigInt(stakePool.poolTokenSupply.toString());
-  const lastEpochTotalLamports = BigInt(
-    stakePool.lastEpochTotalLamports.toString()
-  );
-  const lastEpochPoolTokenSupply = BigInt(
-    stakePool.lastEpochPoolTokenSupply.toString()
-  );
+  const lastEpochTotalLamports = BigInt(stakePool.lastEpochTotalLamports.toString());
+  const lastEpochPoolTokenSupply = BigInt(stakePool.lastEpochPoolTokenSupply.toString());
   const lastUpdateEpoch = BigInt(stakePool.lastUpdateEpoch.toString());
 
   // Exchange rate = SOL per pool token (guard against division by zero)
-  const exchangeRate =
-    poolTokenSupply === 0n
-      ? 0
-      : Number(totalLamports) / Number(poolTokenSupply);
+  const exchangeRate = poolTokenSupply === 0n ? 0 : Number(totalLamports) / Number(poolTokenSupply);
 
   // Epoch fee as a fraction (numerator/denominator)
-  const epochFee =
-    stakePool.epochFee && Number(stakePool.epochFee.denominator) > 0
-      ? {
-          numerator: Number(stakePool.epochFee.numerator),
-          denominator: Number(stakePool.epochFee.denominator),
-        }
-      : null;
+  const epochFee = stakePool.epochFee && Number(stakePool.epochFee.denominator) > 0
+    ? { numerator: Number(stakePool.epochFee.numerator), denominator: Number(stakePool.epochFee.denominator) }
+    : null;
 
   // Fetch current epoch info for epochs-per-year calculation
-  const epochResponse = await axios.post(
-    rpcUrl,
-    {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'getEpochInfo',
-      params: [{ commitment: 'confirmed' }],
-    },
-    {
-      headers: { 'Content-Type': 'application/json' },
-    }
-  );
+  const epochResponse = await axios.post(rpcUrl, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'getEpochInfo',
+    params: [{ commitment: 'confirmed' }],
+  }, {
+    headers: { 'Content-Type': 'application/json' },
+  });
   const currentEpoch = epochResponse.data.result?.epoch || 0;
 
   // Solana genesis: March 16, 2020 (UTC)
   const SOLANA_GENESIS_MS = Date.UTC(2020, 2, 16);
-  const yearsSinceGenesis =
-    (Date.now() - SOLANA_GENESIS_MS) / (365.25 * 24 * 60 * 60 * 1000);
-  const epochsPerYear =
-    yearsSinceGenesis > 0 ? currentEpoch / yearsSinceGenesis : 0;
+  const yearsSinceGenesis = (Date.now() - SOLANA_GENESIS_MS) / (365.25 * 24 * 60 * 60 * 1000);
+  const epochsPerYear = yearsSinceGenesis > 0 ? currentEpoch / yearsSinceGenesis : 0;
 
   return {
     totalLamports: Number(totalLamports),
@@ -900,10 +852,8 @@ exports.solanaLstPricePerShare = (stakePoolInfo) => {
 // Uses previous-epoch snapshots stored in the stake pool account
 exports.calcSolanaLstApy = (stakePoolInfo) => {
   const {
-    totalLamports,
-    poolTokenSupply,
-    lastEpochTotalLamports,
-    lastEpochPoolTokenSupply,
+    totalLamports, poolTokenSupply,
+    lastEpochTotalLamports, lastEpochPoolTokenSupply,
     epochsPerYear,
   } = stakePoolInfo;
 
@@ -927,11 +877,7 @@ exports.calcSolanaLstApy = (stakePoolInfo) => {
 };
 
 // 7-day smoothed APY from DefiLlama price ratio for Solana LSTs
-exports.calcSolanaLstApyFromPriceRatio = async (
-  currentExchangeRate,
-  lstMint,
-  days = 7
-) => {
+exports.calcSolanaLstApyFromPriceRatio = async (currentExchangeRate, lstMint, days = 7) => {
   const SOL = 'So11111111111111111111111111111111111111112';
   const lstKey = `solana:${lstMint}`;
   const solKey = `solana:${SOL}`;

--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -47,11 +47,13 @@ const getStarknetRpc = () => {
   return process.env.STARKNET_RPC;
 };
 
-const rateLimitedStarknetCall = (fn) => (...args) => {
-  const promise = pendingStarknetCall.then(() => fn(...args));
-  pendingStarknetCall = promise.catch(() => {});
-  return promise;
-};
+const rateLimitedStarknetCall =
+  (fn) =>
+  (...args) => {
+    const promise = pendingStarknetCall.then(() => fn(...args));
+    pendingStarknetCall = promise.catch(() => {});
+    return promise;
+  };
 
 const chunkArray = (arr, chunkSize = 100) => {
   const chunks = [];
@@ -63,16 +65,23 @@ const chunkArray = (arr, chunkSize = 100) => {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const getStarknetCallBody = ({ abi, target, params = [], allAbi = [] }, id = 0) => {
+const getStarknetCallBody = (
+  { abi, target, params = [], allAbi = [] },
+  id = 0
+) => {
   if ((params || params === 0) && !Array.isArray(params)) params = [params];
 
   const contract = new Contract([abi, ...allAbi], target, null);
   const requestData = contract.populate(abi.name, params);
-  requestData.entry_point_selector = starknetHash.getSelectorFromName(requestData.entrypoint);
+  requestData.entry_point_selector = starknetHash.getSelectorFromName(
+    requestData.entrypoint
+  );
   requestData.contract_address = requestData.contractAddress;
   delete requestData.contractAddress;
   delete requestData.entrypoint;
-  requestData.calldata = requestData.calldata.map((i) => starknetNumber.toHex(starknetNumber.toBN(i)));
+  requestData.calldata = requestData.calldata.map((i) =>
+    starknetNumber.toHex(starknetNumber.toBN(i))
+  );
 
   return {
     jsonrpc: '2.0',
@@ -104,12 +113,20 @@ const parseStarknetOutput = (result, abi, allAbi) => {
 const starknetCall = async ({ abi, target, params = [], allAbi = [] } = {}) => {
   const {
     data: { result },
-  } = await axios.post(getStarknetRpc(), getStarknetCallBody({ abi, target, params, allAbi }));
+  } = await axios.post(
+    getStarknetRpc(),
+    getStarknetCallBody({ abi, target, params, allAbi })
+  );
 
   return parseStarknetOutput(result, abi, allAbi);
 };
 
-const starknetMultiCall = async ({ abi: rootAbi, target: rootTarget, calls = [], allAbi = [] }) => {
+const starknetMultiCall = async ({
+  abi: rootAbi,
+  target: rootTarget,
+  calls = [],
+  allAbi = [],
+}) => {
   if (!calls.length) return [];
 
   calls = calls.map((callArgs) => {
@@ -197,7 +214,6 @@ exports.formatChain = (chain) => {
   if (chain && chain.toLowerCase() === 'optimism') return 'OP Mainnet';
   if (chain && chain.toLowerCase() === 'ton') return 'TON';
   if (chain && chain.toLowerCase() === 'zklink') return 'zkLink Nova';
-  if (chain && chain.toLowerCase() === 'robinhood') return 'Robinhood Chain';
 
   return chain.charAt(0).toUpperCase() + chain.slice(1);
 };
@@ -259,7 +275,7 @@ const getBlocksByTime = async (timestamps, chainString) => {
   return Promise.all(
     timestamps.map(async (timestamp) => {
       const response = await axios.get(
-      getPriceApiUrl(`/block/${chain}/${timestamp}`)
+        getPriceApiUrl(`/block/${chain}/${timestamp}`)
       );
       return response.data.height;
     })
@@ -667,42 +683,43 @@ exports.getERC4626Info = async (
         .then((r) => r.data.height)
     )
   );
-  const [tvl, priceNow, priceYesterday, asset, shareDecimalsRes] = await Promise.all([
-    sdk.api.abi.call({
-      target: address,
-      block: blockNow,
-      abi: totalAssetsAbi,
-      chain: chain,
-    }),
-    sdk.api.abi.call({
-      target: address,
-      block: blockNow,
-      abi: convertToAssetsAbi,
-      params: [assetUnit],
-      chain: chain,
-    }),
-    sdk.api.abi.call({
-      target: address,
-      block: blockYesterday,
-      abi: convertToAssetsAbi,
-      params: [assetUnit],
-      chain: chain,
-    }),
-    sdk.api.abi
-      .call({
+  const [tvl, priceNow, priceYesterday, asset, shareDecimalsRes] =
+    await Promise.all([
+      sdk.api.abi.call({
         target: address,
-        abi: 'address:asset',
+        block: blockNow,
+        abi: totalAssetsAbi,
         chain: chain,
-      })
-      .catch(() => null),
-    sdk.api.abi
-      .call({
+      }),
+      sdk.api.abi.call({
         target: address,
-        abi: 'erc20:decimals',
+        block: blockNow,
+        abi: convertToAssetsAbi,
+        params: [assetUnit],
         chain: chain,
-      })
-      .catch(() => null),
-  ]);
+      }),
+      sdk.api.abi.call({
+        target: address,
+        block: blockYesterday,
+        abi: convertToAssetsAbi,
+        params: [assetUnit],
+        chain: chain,
+      }),
+      sdk.api.abi
+        .call({
+          target: address,
+          abi: 'address:asset',
+          chain: chain,
+        })
+        .catch(() => null),
+      sdk.api.abi
+        .call({
+          target: address,
+          abi: 'erc20:decimals',
+          chain: chain,
+        })
+        .catch(() => null),
+    ]);
   const apy = (priceNow.output / priceYesterday.output) ** 365 * 100 - 100;
   let assetDecimals = 18;
   if (asset && asset.output) {
@@ -767,15 +784,22 @@ exports.getTotalSupply = async (tokenMintAddress) => {
 };
 
 // Solana RPC helper for getAccountInfo
-const getSolanaAccountInfo = async (address, rpcUrl = 'https://api.mainnet-beta.solana.com') => {
-  const response = await axios.post(rpcUrl, {
-    jsonrpc: '2.0',
-    id: 1,
-    method: 'getAccountInfo',
-    params: [address, { encoding: 'base64' }],
-  }, {
-    headers: { 'Content-Type': 'application/json' },
-  });
+const getSolanaAccountInfo = async (
+  address,
+  rpcUrl = 'https://api.mainnet-beta.solana.com'
+) => {
+  const response = await axios.post(
+    rpcUrl,
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getAccountInfo',
+      params: [address, { encoding: 'base64' }],
+    },
+    {
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
 
   const data = response.data;
   if (data.error) {
@@ -792,41 +816,64 @@ const getSolanaAccountInfo = async (address, rpcUrl = 'https://api.mainnet-beta.
 // SPL Stake Pool data decoder using official library
 const { StakePoolLayout } = require('@solana/spl-stake-pool');
 
-exports.getStakePoolInfo = async (stakePoolAddress, rpcUrl = 'https://api.mainnet-beta.solana.com') => {
-  const stakePoolAccountData = await getSolanaAccountInfo(stakePoolAddress, rpcUrl);
+exports.getStakePoolInfo = async (
+  stakePoolAddress,
+  rpcUrl = 'https://api.mainnet-beta.solana.com'
+) => {
+  const stakePoolAccountData = await getSolanaAccountInfo(
+    stakePoolAddress,
+    rpcUrl
+  );
 
   // Decode using official SPL stake pool layout
   const stakePool = StakePoolLayout.decode(stakePoolAccountData);
 
   const totalLamports = BigInt(stakePool.totalLamports.toString());
   const poolTokenSupply = BigInt(stakePool.poolTokenSupply.toString());
-  const lastEpochTotalLamports = BigInt(stakePool.lastEpochTotalLamports.toString());
-  const lastEpochPoolTokenSupply = BigInt(stakePool.lastEpochPoolTokenSupply.toString());
+  const lastEpochTotalLamports = BigInt(
+    stakePool.lastEpochTotalLamports.toString()
+  );
+  const lastEpochPoolTokenSupply = BigInt(
+    stakePool.lastEpochPoolTokenSupply.toString()
+  );
   const lastUpdateEpoch = BigInt(stakePool.lastUpdateEpoch.toString());
 
   // Exchange rate = SOL per pool token (guard against division by zero)
-  const exchangeRate = poolTokenSupply === 0n ? 0 : Number(totalLamports) / Number(poolTokenSupply);
+  const exchangeRate =
+    poolTokenSupply === 0n
+      ? 0
+      : Number(totalLamports) / Number(poolTokenSupply);
 
   // Epoch fee as a fraction (numerator/denominator)
-  const epochFee = stakePool.epochFee && Number(stakePool.epochFee.denominator) > 0
-    ? { numerator: Number(stakePool.epochFee.numerator), denominator: Number(stakePool.epochFee.denominator) }
-    : null;
+  const epochFee =
+    stakePool.epochFee && Number(stakePool.epochFee.denominator) > 0
+      ? {
+          numerator: Number(stakePool.epochFee.numerator),
+          denominator: Number(stakePool.epochFee.denominator),
+        }
+      : null;
 
   // Fetch current epoch info for epochs-per-year calculation
-  const epochResponse = await axios.post(rpcUrl, {
-    jsonrpc: '2.0',
-    id: 1,
-    method: 'getEpochInfo',
-    params: [{ commitment: 'confirmed' }],
-  }, {
-    headers: { 'Content-Type': 'application/json' },
-  });
+  const epochResponse = await axios.post(
+    rpcUrl,
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getEpochInfo',
+      params: [{ commitment: 'confirmed' }],
+    },
+    {
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
   const currentEpoch = epochResponse.data.result?.epoch || 0;
 
   // Solana genesis: March 16, 2020 (UTC)
   const SOLANA_GENESIS_MS = Date.UTC(2020, 2, 16);
-  const yearsSinceGenesis = (Date.now() - SOLANA_GENESIS_MS) / (365.25 * 24 * 60 * 60 * 1000);
-  const epochsPerYear = yearsSinceGenesis > 0 ? currentEpoch / yearsSinceGenesis : 0;
+  const yearsSinceGenesis =
+    (Date.now() - SOLANA_GENESIS_MS) / (365.25 * 24 * 60 * 60 * 1000);
+  const epochsPerYear =
+    yearsSinceGenesis > 0 ? currentEpoch / yearsSinceGenesis : 0;
 
   return {
     totalLamports: Number(totalLamports),
@@ -853,8 +900,10 @@ exports.solanaLstPricePerShare = (stakePoolInfo) => {
 // Uses previous-epoch snapshots stored in the stake pool account
 exports.calcSolanaLstApy = (stakePoolInfo) => {
   const {
-    totalLamports, poolTokenSupply,
-    lastEpochTotalLamports, lastEpochPoolTokenSupply,
+    totalLamports,
+    poolTokenSupply,
+    lastEpochTotalLamports,
+    lastEpochPoolTokenSupply,
     epochsPerYear,
   } = stakePoolInfo;
 
@@ -878,7 +927,11 @@ exports.calcSolanaLstApy = (stakePoolInfo) => {
 };
 
 // 7-day smoothed APY from DefiLlama price ratio for Solana LSTs
-exports.calcSolanaLstApyFromPriceRatio = async (currentExchangeRate, lstMint, days = 7) => {
+exports.calcSolanaLstApyFromPriceRatio = async (
+  currentExchangeRate,
+  lstMint,
+  days = 7
+) => {
   const SOL = 'So11111111111111111111111111111111111111112';
   const lstKey = `solana:${lstMint}`;
   const solKey = `solana:${SOL}`;


### PR DESCRIPTION
T3tris Finance is now deployed on Robinhood Chain (4663). Adds `robinhood` to the APY adapter's chain list — vaults are auto-discovered from the T3tris ecosystem API per chainId (same curation gate: verified & non-blacklisted). The chain's @defillama/sdk provider is registered as `robinhoodchain`, so on-chain calls map the slug accordingly while the pool chain/URL keep the canonical `robinhood` slug (formatChain -> 'Robinhood Chain'). Kept separate from #2806 (poolMeta) to isolate concerns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Robinhood chain data in the T3tris Finance integration.
  * Enabled historical and current oracle price retrieval, block resolution, and asset pricing for the new chain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->