### PR TITLE
fusion-by-ipor: fetch vault list once instead of per chain (fixes OOM, pools stale since Jul 11)

### DIFF
--- a/src/adaptors/fusion-by-ipor/index.js
+++ b/src/adaptors/fusion-by-ipor/index.js
@@ -116,13 +116,9 @@ const CHAIN_CONFIG = {
     }
 };
 
-async function getChainData(chain) {
+async function getAllVaults() {
     const allVaultsRes = await axios.get(FUSION_API_URL);
-    const chainVaults = allVaultsRes.data.vaults.filter(
-        vault => vault.chainId === CHAIN_CONFIG[chain].chainId
-    );
-
-    return chainVaults;
+    return allVaultsRes.data.vaults;
 }
 
 async function getPublicVaults() {
@@ -168,13 +164,14 @@ async function buildPool(vault) {
 
 const apy = async() => {
     const publicVaults = await getPublicVaults();
-    const chainsData = await Promise.all(
-        Object.entries(CHAIN_CONFIG).map(async([chain, config]) => ({
-            chain,
-            config,
-            data: await getChainData(chain)
-        }))
-    );
+    // fetch the full vault list once and filter per chain; fetching it per chain
+    // (11 parallel copies of a multi-MB payload) OOMs the 1GB lambda
+    const allVaults = await getAllVaults();
+    const chainsData = Object.entries(CHAIN_CONFIG).map(([chain, config]) => ({
+        chain,
+        config,
+        data: allVaults.filter(vault => vault.chainId === config.chainId)
+    }));
 
     const pools = await Promise.all(
         chainsData.flatMap(({ chain, data }) =>


### PR DESCRIPTION
## Problem

All 56 `fusion-by-ipor` pools stopped updating on **Jul 11 ~03:17 UTC** (every pool has `apyPct1D: null`, charts end there, e.g. pool `69c4caa5-0dc7-4608-8385-b87753fd126b`). TVL side (DefiLlama-Adapters) is unaffected.

## Root cause

`getChainData()` downloaded and parsed the full `https://api.ipor.io/fusion/vaults` payload (currently ~3.7 MB) **once per chain, all chains in parallel**. #2800 raised the chain count from 9 to 11, and the payload keeps growing as vaults are added. Measured peak RSS of `apy()` is **~1850 MB**, while the `triggerAdaptor` lambda has `memorySize: 1024` — so every run dies with:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
    ... v8::internal::JsonParser<unsigned short>::ParseJson ...
```

Reproducible locally with `node --max-old-space-size=800`.

## Fix

Fetch the vault list once and filter per chain in memory.

| | before | after |
|---|---|---|
| peak RSS | 1850 MB | 326 MB |
| runtime | 8.3 s | 3.7 s |
| pools returned | 317 | 317 |
| requests to api.ipor.io/fusion/vaults | 11 | 1 |

- `node --max-old-space-size=800` run: OOM before, passes after
- `npm run test --adapter=fusion-by-ipor`: 1915 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Fusion vault data retrieval by using a complete vault list and filtering results by chain.
  * Enhanced consistency of APY and pool information across supported chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->