### PR TITLE
Add Barker adaptor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -629,7 +629,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -3074,7 +3073,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3963,7 +3961,6 @@
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -4212,6 +4209,7 @@
       "resolved": "https://registry.npmjs.org/@ton/crypto-primitives/-/crypto-primitives-2.1.0.tgz",
       "integrity": "sha512-PQesoyPgqyI6vzYtCXw4/ZzevePc4VGcJtFwf08v10OevVJHVfW238KBdpj1kEDQkxWLeuNHEpTECNFKnP6tow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jssha": "3.2.0"
       }
@@ -4440,7 +4438,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -4532,6 +4529,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4548,6 +4546,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4564,6 +4563,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4580,6 +4580,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4596,6 +4597,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4612,6 +4614,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4628,6 +4631,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4644,6 +4648,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4660,6 +4665,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4676,6 +4682,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4692,6 +4699,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4708,6 +4716,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4724,6 +4733,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4740,6 +4750,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4756,6 +4767,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4772,6 +4784,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4788,6 +4801,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4804,6 +4818,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4820,6 +4835,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -4836,6 +4852,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -5079,7 +5096,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5169,7 +5185,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6061,7 +6076,6 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -6162,7 +6176,6 @@
       "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -6472,7 +6485,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -6617,7 +6629,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -8306,7 +8317,6 @@
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -8703,7 +8713,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -8910,7 +8919,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8968,7 +8976,6 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -9052,7 +9059,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -10647,7 +10653,6 @@
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -10689,7 +10694,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.2.tgz",
       "integrity": "sha512-1PRqdDPAmViWr4h1GVBT8RoPZfWSGZa7kDzleTilOfVIslsgf+cia3Nl95v1KDmR4iERPaT7WzQ+tN4MJmbg3w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -13244,6 +13248,7 @@
       "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.2.0.tgz",
       "integrity": "sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -13610,7 +13615,6 @@
       "integrity": "sha512-ek8NRg/OPvS9ISOJNWNAz5vZcpYacWNFDWNJjj5OXsc6YuKacfey6wF04cXz/tOJIVrZ2nGSkHpAY5qKtF6ISg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d": "^1.0.2",
         "duration": "^0.2.2",
@@ -14042,7 +14046,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15233,7 +15236,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -15512,7 +15514,6 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -16524,7 +16525,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/client-api-gateway": "^3.588.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.588.0",
@@ -18263,7 +18263,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18436,7 +18435,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -18928,7 +18926,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -19755,7 +19752,6 @@
       "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -19812,7 +19808,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19839,7 +19834,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20096,7 +20090,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -20302,7 +20295,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/adaptors/barker/index.js
+++ b/src/adaptors/barker/index.js
@@ -1,0 +1,93 @@
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+// Barker (https://barker.money) runs boost campaigns on top of third-party
+// vaults (non-custodial): user principal is deposited directly into the
+// underlying protocol's own vault, and Barker distributes boosted rewards on
+// top. This adapter lists vaults with an active Barker boost — same pattern
+// as the merkl adaptor (pool suffix `-barker`, apyReward = boost on top of
+// the vault's native APY).
+const API_BASE = 'https://api.barker.money/api';
+
+// Barker chain_uid → defillama chain slug (unsupported chains are skipped)
+const CHAIN_SLUG = {
+  ethereum: 'ethereum',
+  hyperevm: 'hyperliquid',
+};
+
+const apy = async () => {
+  const campaignsRes = await utils.getData(`${API_BASE}/protocols/campaigns`);
+  const campaigns = (campaignsRes?.data?.campaigns ?? []).filter(
+    (c) => !c.is_cex && c.is_active
+  );
+  const protocolUids = [...new Set(campaigns.map((c) => c.protocol_uid))];
+
+  const pools = [];
+  for (const uid of protocolUids) {
+    let vaults = [];
+    try {
+      const res = await utils.getData(
+        `${API_BASE}/campaigns/protocol/${encodeURIComponent(uid)}/boost-vaults`
+      );
+      vaults = res?.data?.vaults ?? [];
+    } catch (e) {
+      continue; // protocol without boost vaults
+    }
+
+    for (const v of vaults) {
+      if (!v.barker_boost_enabled || v.boost_status !== 'active') continue;
+      const chain = CHAIN_SLUG[v.chain_uid];
+      if (!chain || !v.vault_address || !v.asset_address) continue;
+
+      // ERC-4626 vault TVL = totalAssets × underlying price
+      const totalAssets = (
+        await sdk.api.abi.call({
+          target: v.vault_address,
+          abi: 'uint256:totalAssets',
+          chain,
+        })
+      ).output;
+      const priceKey = `${chain}:${v.asset_address}`;
+      const priceRes = await utils.getData(
+        `https://coins.llama.fi/prices/current/${priceKey}`
+      );
+      const price = priceRes?.coins?.[priceKey]?.price;
+      if (price == null) continue;
+      const tvlUsd =
+        (Number(totalAssets) / 10 ** Number(v.asset_decimals ?? 18)) * price;
+
+      const apyBase = Number(v.base_apy ?? 0) * 100;
+      const apyReward = Math.max(
+        0,
+        (Number(v.total_pool_apy ?? 0) - Number(v.base_apy ?? 0)) * 100
+      );
+      if (!apyReward) continue; // only list pools with a live Barker boost
+
+      pools.push({
+        pool: `${v.vault_address}-barker`.toLowerCase(),
+        chain: utils.formatChain(chain),
+        project: 'barker',
+        symbol: utils.formatSymbol(
+          String(v.asset || v.share_symbol || '').toUpperCase()
+        ),
+        tvlUsd,
+        apyBase,
+        apyReward,
+        rewardTokens: [v.reward_token_address].filter(Boolean),
+        underlyingTokens: [v.asset_address].filter(Boolean),
+        poolMeta: v.campaign_name
+          ? `Barker boost — ${v.campaign_name}`
+          : 'Barker boost',
+        url: 'https://app.barker.money/campaigns',
+      });
+    }
+  }
+
+  return pools;
+};
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: 'https://app.barker.money/campaigns',
+};

--- a/src/adaptors/barker/index.js
+++ b/src/adaptors/barker/index.js
@@ -1,3 +1,5 @@
+const __axios = require('axios');
+__axios.interceptors.response.use((r) => r, (e) => { console.error('AXIOS-FAIL:', e?.config?.url, 'status:', e?.response?.status, 'body:', String(e?.response?.data ?? '').slice(0, 120)); return Promise.reject(e); });
 const sdk = require('@defillama/sdk');
 const utils = require('../utils');
 

--- a/src/adaptors/barker/index.js
+++ b/src/adaptors/barker/index.js
@@ -1,5 +1,3 @@
-const __axios = require('axios');
-__axios.interceptors.response.use((r) => r, (e) => { console.error('AXIOS-FAIL:', e?.config?.url, 'status:', e?.response?.status, 'body:', String(e?.response?.data ?? '').slice(0, 120)); return Promise.reject(e); });
 const sdk = require('@defillama/sdk');
 const utils = require('../utils');
 


### PR DESCRIPTION
Adds [Barker](https://barker.money) — a non-custodial stablecoin yield distribution layer that runs boost campaigns on top of third-party vaults (user principal sits in the underlying protocol's own vault; Barker distributes boosted rewards on top). Same listing pattern as the merkl adaptor: pool suffix `-barker`, `apyReward` = the Barker boost on top of the vault's native APY. Pools are served from the public API at api.barker.money and update automatically as campaigns start/end.

Protocol listing PR (zero-TVL, Merkl-style): DefiLlama/DefiLlama-Adapters#20033

**Note on `npm run test`**: the jest global setup fails externally on `https://yields.llama.fi/distinctID` (404 from outside your infra — reproducible with a bare curl), so posting the standalone adaptor output instead:

```json
[
 {
  "pool": "0x32401b9fb79065bc15949de0bd43927492f02f0c-barker",
  "chain": "Ethereum",
  "project": "barker",
  "symbol": "AUSD",
  "tvlUsd": 10973137.33,
  "apyBase": 5.93,
  "apyReward": 7.22,
  "rewardTokens": ["0xdac17f958d2ee523a2206206994597c13d831ec7"],
  "underlyingTokens": ["0x00000000efe302beaa2b3e6e1b18d08d69a9012a"],
  "poolMeta": "Barker boost — Saturn — Flowdesk AUSD RWA Strategy",
  "url": "https://app.barker.money/campaigns"
 }
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking active Barker boost campaigns.
  * Reports eligible boost vaults with TVL, base APY, and additional reward APY.
  * Includes campaign, chain, token, and vault details with links to Barker campaigns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->