### PR TITLE
Add Tristero AUSD yield adapter

### DIFF
--- a/src/adaptors/tristero-margin/index.js
+++ b/src/adaptors/tristero-margin/index.js
@@ -1,0 +1,89 @@
+// DeFiLlama yield adapter for the Tristero AUSD margin-lending vault.
+//
+// The vault is not an ERC-4626 share vault. Its on-chain accounting exposes
+// getTVOL(asset) for TVL and assets(tokenId).ratePerSecond for the configured
+// lender rate. APY is derived from that explicit contract rate; TVOL is never
+// used as a yield proxy.
+//
+// This deliberately lists only the Ethereum AUSD deployment. The Arbitrum and
+// Base deployments use USDC and should be added separately once their lender
+// yield treatment is confirmed.
+
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+const CHAIN = 'ethereum';
+const VAULT = '0xB49781E8c39c75f413C1178f395bF68b0BEE8d00';
+const AUSD = '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a';
+const SECONDS_PER_YEAR = 365 * 24 * 60 * 60;
+const AUSD_ID = BigInt(AUSD).toString();
+
+const getTVOL = async (block) => {
+  const result = await sdk.api.abi.call({
+    target: VAULT,
+    abi: 'function getTVOL(address _token) view returns (uint256)',
+    params: [AUSD],
+    chain: CHAIN,
+    ...(block ? { block } : {}),
+  });
+
+  return BigInt(result.output);
+};
+
+const getAssetInfo = async () => {
+  const result = await sdk.api.abi.call({
+    target: VAULT,
+    abi: 'function assets(uint256) view returns (uint256 ratePerSecond, uint256 index, uint256 lastUpdate)',
+    params: [AUSD_ID],
+    chain: CHAIN,
+  });
+
+  return result.output;
+};
+
+const poolsFunction = async () => {
+  const [tvolNow, assetInfo, assetPrice, assetDecimals] = await Promise.all([
+    getTVOL(),
+    getAssetInfo(),
+    utils.getPrices([AUSD], CHAIN),
+    sdk.api.abi.call({
+      target: AUSD,
+      abi: 'erc20:decimals',
+      chain: CHAIN,
+    }),
+  ]);
+
+  const decimals = Number(assetDecimals.output);
+  const price = assetPrice.pricesByAddress[AUSD.toLowerCase()] ?? 0;
+  const assetsNow = Number(tvolNow) / 10 ** decimals;
+  const tvlUsd = assetsNow * price;
+
+  // The contract applies ratePerSecond linearly between index updates. Treat
+  // the configured per-second rate as APR, then use DeFiLlama's standard daily
+  // compounding conversion to APY.
+  const ratePerSecond = Number(assetInfo.ratePerSecond ?? assetInfo[0]);
+  const apr = ratePerSecond * SECONDS_PER_YEAR / 1e18 * 100;
+  const apyBase = Number.isFinite(apr) && apr >= 0
+    ? utils.aprToApy(apr)
+    : 0;
+
+  return [{
+    pool: `${VAULT}-${CHAIN}`.toLowerCase(),
+    chain: utils.formatChain(CHAIN),
+    project: 'tristero-margin',
+    symbol: 'AUSD',
+    tvlUsd,
+    apyBase,
+    underlyingTokens: [AUSD],
+    poolMeta: 'AUSD margin lending vault',
+    url: 'https://app.tristero.com',
+    token: null,
+  }];
+};
+
+module.exports = {
+  protocolId: '7639',
+  timetravel: false,
+  apy: poolsFunction,
+  url: 'https://app.tristero.com',
+};

--- a/src/adaptors/tristero-margin/index.js
+++ b/src/adaptors/tristero-margin/index.js
@@ -42,13 +42,19 @@ const getAssetInfo = async () => {
 };
 
 const poolsFunction = async () => {
-  const [tvolNow, assetInfo, assetPrice, assetDecimals] = await Promise.all([
+  const [tvolNow, assetInfo, assetPrice, assetDecimals, pricePerShareInfo] = await Promise.all([
     getTVOL(),
     getAssetInfo(),
     utils.getPrices([AUSD], CHAIN),
     sdk.api.abi.call({
       target: AUSD,
       abi: 'erc20:decimals',
+      chain: CHAIN,
+    }),
+    sdk.api.abi.call({
+      target: VAULT,
+      abi: 'function readValue(address _token, uint256 shares) view returns (uint256)',
+      params: [AUSD, '1000000000000000000'],
       chain: CHAIN,
     }),
   ]);
@@ -66,6 +72,7 @@ const poolsFunction = async () => {
   const apyBase = Number.isFinite(apr) && apr >= 0
     ? utils.aprToApy(apr)
     : 0;
+  const pricePerShare = Number(pricePerShareInfo.output) / 1e18;
 
   return [{
     pool: `${VAULT}-${CHAIN}`.toLowerCase(),
@@ -74,9 +81,11 @@ const poolsFunction = async () => {
     symbol: 'AUSD',
     tvlUsd,
     apyBase,
+    pricePerShare,
     underlyingTokens: [AUSD],
-    poolMeta: 'AUSD margin lending vault',
     url: 'https://app.tristero.com',
+    // Deposits mint ERC6909 shares on the vault, keyed by the AUSD-derived
+    // asset ID. There is no standalone ERC20 receipt-token address to expose.
     token: null,
   }];
 };


### PR DESCRIPTION
## Summary

- Add the Ethereum AUSD Tristero margin-lending vault to the yields adapter set.
- Derive APY from the vault’s on-chain `ratePerSecond` asset parameter using standard daily compounding.
- Derive TVL from the vault’s `getTVOL(AUSD)` balance and AUSD price.

## Validation

- `git diff --check` passes.
- The adapter was manually exercised against live Ethereum contract data and returned TVL and APY values.

Arbitrum and Base deployments are intentionally excluded because they use USDC and need separate confirmation of their lender-yield treatment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tristero’s AUSD margin-lending vault to yield tracking.
  * Added reporting for vault total value and estimated APY, including a share price metric.
  * Added a direct link to the Tristero app for more information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->