### PR TITLE
yield-yak-aggregator: add yiUSD Milk vault on Base

### DIFF
--- a/src/adaptors/yield-yak-aggregator/index.js
+++ b/src/adaptors/yield-yak-aggregator/index.js
@@ -8,6 +8,7 @@ const CHAIN_CONFIG = {
   '43114': { chain: 'avax', chainName: 'Avalanche' },
   '42161': { chain: 'arbitrum', chainName: 'Arbitrum' },
   '5000': { chain: 'mantle', chainName: 'Mantle' },
+  '8453': { chain: 'base', chainName: 'Base', noFarms: true },
 }
 
 // Yield Yak vaults configuration
@@ -68,6 +69,14 @@ const VAULTS = [
     symbol: 'sSUZ',
     underlyingToken: '0x451532F1C9eb7E4Dc2d493dB52b682C0Acf6F5EF',
     rateDecimals: 18,
+  },
+  {
+    chainId: '8453',
+    address: '0xB5803023B8fa8BFe7d64E373297dFaA24e3B5962',
+    accountant: '0x0D7e98D765E19760499670ba674079442451eeb8',
+    symbol: 'yiUSD',
+    underlyingToken: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    rateDecimals: 6,
   }
 ];
 
@@ -309,7 +318,9 @@ const getFarms = async (chainId) => {
 }
 
 const getAllFarmData = async () => {
-  const farmPromises = Object.keys(CHAIN_CONFIG).map(chainId => getFarms(chainId));
+  const farmPromises = Object.keys(CHAIN_CONFIG)
+    .filter(chainId => !CHAIN_CONFIG[chainId].noFarms)
+    .map(chainId => getFarms(chainId));
   const farmResults = await Promise.all(farmPromises);
   return farmResults.flat();
 }


### PR DESCRIPTION
Adds the newly launched yiUSD Milk vault (BoringVault architecture) on Base.

- Added Base (8453) to CHAIN_CONFIG with a `noFarms` flag (no classic farms on Base)
- Added yiUSD to the VAULTS array; APY/TVL computed on-chain like the existing Milk vaults

Contracts (Base):
- Vault: https://basescan.org/address/0xB5803023B8fa8BFe7d64E373297dFaA24e3B5962
- Accountant: https://basescan.org/address/0x0D7e98D765E19760499670ba674079442451eeb8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Yield Yak vault data on the Base network.
* **Bug Fixes**
  * Improved farm data collection by skipping networks without supported farm information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->