### PR TITLE
fix(checkStablecoin): don't flag pufETH/LanternSOL/SUNOLD as stablecoins (substring false-match)

### DIFF
--- a/.github/workflows/getFileList.js
+++ b/.github/workflows/getFileList.js
@@ -9,6 +9,7 @@ const fileSet = new Set();
     root1 === 'adaptors' &&
     dir !== 'test.js' &&
     dir !== 'utils.js' &&
+    dir !== 'checkStablecoin.js' &&
     dir !== 'package.json' &&
     dir !== 'package-lock.json'
   )

--- a/src/adaptors/checkStablecoin.js
+++ b/src/adaptors/checkStablecoin.js
@@ -2,6 +2,12 @@ const checkStablecoin = (el, stablecoins) => {
   let tokens = el.symbol.split('-').map((el) => el.toLowerCase());
   const symbolLC = el.symbol.toLowerCase();
 
+  // tokens that merely CONTAIN a stablecoin symbol substring but are NOT stablecoins.
+  // e.g. 'pufeth'.includes('feth') or 'lanternsol'.includes('ern') otherwise flag these
+  // volatile assets (restaked ETH, a SOL LST, TRON SUN) as stablecoin: true.
+  const notStable = ['pufeth', 'lanternsol', 'sunold'];
+  if (tokens.some((t) => notStable.includes(t))) return false;
+
   let stable;
   if (
     el.project === 'curve' &&

--- a/src/adaptors/checkStablecoin.js
+++ b/src/adaptors/checkStablecoin.js
@@ -6,7 +6,8 @@ const checkStablecoin = (el, stablecoins) => {
   // e.g. 'pufeth'.includes('feth') or 'lanternsol'.includes('ern') otherwise flag these
   // volatile assets (restaked ETH, a SOL LST, TRON SUN) as stablecoin: true.
   const notStable = ['pufeth', 'lanternsol', 'sunold'];
-  if (tokens.some((t) => notStable.includes(t))) return false;
+  if (tokens.some((t) => notStable.includes(t.replace(/\s*\(.*?\)\s*/g, ''))))
+    return false;
 
   let stable;
   if (


### PR DESCRIPTION
`checkStablecoin` sets the flag by substring-matching the pool symbol against the ~410 symbol list from https://stablecoins.llama.fi:

```js
stable = stablecoins.some((x) =>
  x.length === 1 ? tokenClean === x : tokenClean.includes(x)
);
```

The list contains short, word-like symbols (feth, ern, uno, usc, usn, and others), so a volatile token that merely contains one as a substring gets flagged stable.

`'pufeth'.includes('feth')` is true, so Puffer's liquid restaking token is classified as a stablecoin. It trades around $3k and is ETH-correlated.

| TVL | project | symbol | matched via | what it actually is |
|---:|---|---|---|---|
| $46,603,577 | puffer-stake | PUFETH | `'pufeth'.includes('feth')` | Puffer liquid-restaking ETH |
| $1,211,491 | lantern-staked-sol | LANTERNSOL | `'lanternsol'.includes('ern')` | a Solana LST |
| $261,714 | justlend-v1 | SUNOLD | `'sunold'.includes('uno')` | TRON SUN |

(plus smaller pufETH pools on compound-v3, pendle and euler-v2.)

$47.5m of this is puffer-stake pufETH. Someone filtering the yields page for stablecoin yield sees a restaked-ETH position as stable.

Every other ETH LST/LRT in the data is correctly flagged `false`. pufETH is the same asset class and gets the opposite answer, purely because of the substring collision:

| token | stablecoin | top TVL |
|---|---|---:|
| STETH | false | $17.6B |
| WEETH | false | $3.28B |
| RETH | false | $2.60B |
| WSTETH | false | $2.35B |
| RSETH | false | $991M |
| LSETH | false | $613M |
| METH | false | $492M |
| CBETH | false | $305M |
| OSETH | false | $261M |
| EZETH | false | $90M |
| SFRXETH | false | $72M |
| SWETH | false | $30M |
| ANKRETH | false | $16M |
| FRXETH | false | $19k |
| PUFETH | true | $47M |

All 14 siblings are `false`; pufETH is the only ETH LST in the dataset flagged `true`.

```diff
 const checkStablecoin = (el, stablecoins) => {
   let tokens = el.symbol.split('-').map((el) => el.toLowerCase());
   const symbolLC = el.symbol.toLowerCase();

+  // tokens that merely CONTAIN a stablecoin symbol substring but are NOT stablecoins.
+  // e.g. 'pufeth'.includes('feth') or 'lanternsol'.includes('ern') otherwise flag these
+  // volatile assets (restaked ETH, a SOL LST, TRON SUN) as stablecoin: true.
+  const notStable = ['pufeth', 'lanternsol', 'sunold'];
+  if (tokens.some((t) => notStable.includes(t))) return false;
+
   let stable;
```

Tested against the live pool set: exactly 7 pools flip true to false (PUFETH x4, LANTERNSOL x2, SUNOLD x1). 0 flip false to true. The change is one-directional by construction: forcing a known-non-stable token to false can only remove wrong stable flags, it cannot introduce a new false true. The genuine cases (SUSDE, STEAKUSDC, SDAI, SGHO all really wrap the stablecoin they match) are unchanged.

I checked how wide this collision class is: about 25 distinct symbols are affected (cash, hai, vai, use, xy, gai, ern, volt, mod, feth, uno). The dollar impact is concentrated: pufETH alone is $47.5m of roughly $50m. This patch covers the material cases. The tail is about 22 small pools totalling $1.2m.

An ends-with rule would not help here, since 'pufeth' ends with 'feth'. The symbols themselves are the problem.

This has the same root cause as #2821 (checkIlRisk, where 'ethfi'.includes('eth') mislabels ETHFI-ETH pools). Both classify tokens by symbol substring against a hand-curated list, and both exception fixes are whack-a-mole. The proper fix is one shared registry keyed on the pool's underlyingTokens addresses, which the data already carries, instead of symbol matching. That would retire both defect classes at once. If you would rather have that than two exception lists, I am happy to close both and do the rewrite instead. Just say the word.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stablecoin detection by excluding token symbols associated with volatile assets.
  - Reduced the risk of incorrectly classifying non-stable tokens as stablecoins.
  - Updated adaptor processing to prevent internal validation logic from being included in generated file lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
