### PR TITLE
Add Genesis Vault staking pool to StakeWise yields adaptor

### DIFF
--- a/src/adaptors/stakewise-v2/index.js
+++ b/src/adaptors/stakewise-v2/index.js
@@ -90,7 +90,8 @@ const getGenesisPool = async (ethPrice) => {
       totalAssets
     }
   }`;
-  const { data } = await axios.post(subgraphUrl, { query });
+  // bound the request — a hang would otherwise block the osETH pool too
+  const { data } = await axios.post(subgraphUrl, { query }, { timeout: 10000 });
   if (data?.errors) {
     console.error(
       'stakewise-v2: subgraph errors —',
@@ -99,8 +100,9 @@ const getGenesisPool = async (ethPrice) => {
     return null;
   }
   const vault = data?.data?.vault;
-  if (!vault) {
-    console.error('stakewise-v2: Genesis vault missing from subgraph response');
+  // null metrics would coerce to 0 and publish a false APY/TVL — skip instead
+  if (vault?.apy == null || vault?.totalAssets == null) {
+    console.error('stakewise-v2: Genesis vault missing or has null metrics');
     return null;
   }
 

--- a/src/adaptors/stakewise-v2/index.js
+++ b/src/adaptors/stakewise-v2/index.js
@@ -132,6 +132,11 @@ const getApy = async () => {
     `/prices/current/${ethKey},${osTokenKey}`
   );
   const ethPrice = coins[ethKey]?.price;
+  // without the base ETH price both pools would compute NaN TVL and get
+  // silently dropped — fail loudly and let the next run retry instead
+  if (!ethPrice) {
+    throw new Error('missing ETH price');
+  }
   const osTokenPrice = coins[osTokenKey]?.price || ethPrice;
 
   // osETH pool is the intrinsic source consumed by other adaptors — it must

--- a/src/adaptors/stakewise-v2/index.js
+++ b/src/adaptors/stakewise-v2/index.js
@@ -1,3 +1,8 @@
+// StakeWise — Ethereum liquid staking (V3). Returns two pools:
+//   1. osETH        — the liquid staking token; yield osETH holders accrue.
+//   2. Genesis Vault — direct ETH staking in the protocol's main vault.
+// Same protocol; the `stakewise-v2` slug is legacy — V3 has been the live
+// mainnet protocol since 2023-11-28 (a rename to stakewise-v3 is requested).
 const sdk = require('@defillama/sdk');
 const BigNumber = require('bignumber.js');
 const axios = require('axios');
@@ -40,6 +45,7 @@ const getOsTokenPool = async (osTokenPrice) => {
 
   // get last 14 events (1-week average)
   const lastWeekLogs = logs.slice(-14);
+  // no rate events in the window → APY would be NaN; fail instead of emitting it
   if (!lastWeekLogs.length) {
     throw new Error('no AvgRewardPerSecondUpdated events in the last week');
   }
@@ -63,8 +69,10 @@ const getOsTokenPool = async (osTokenPrice) => {
     chain,
     project: 'stakewise-v2',
     symbol: 'osETH',
-    // osETH is an appreciating token — price it directly, not with the ETH price
+    // osETH accrues value vs ETH (trades at a premium), so pricing its supply
+    // with the ETH price understated TVL — use the osETH feed (ETH fallback).
     tvlUsd: tvl * osTokenPrice,
+    // 1-week average of the on-chain osETH reward rate holders realize
     apyBase: Number(apyBN) / 100,
     underlyingTokens: ['0x0000000000000000000000000000000000000000'],
     searchTokenOverride: osTokenAddress,
@@ -72,7 +80,9 @@ const getOsTokenPool = async (osTokenPrice) => {
   };
 };
 
-// Direct staking in the Genesis Vault — net, unboosted (lower bound) APY
+// Direct ETH staking in the Genesis Vault. Distinct product from the osETH pool
+// above — osETH is the token optionally minted against a vault deposit — so
+// listing both is intentional, not a double-count.
 const getGenesisPool = async (ethPrice) => {
   const query = `{
     vault(id: "${genesisVaultAddress}") {
@@ -82,7 +92,10 @@ const getGenesisPool = async (ethPrice) => {
   }`;
   const { data } = await axios.post(subgraphUrl, { query });
   if (data?.errors) {
-    console.error('stakewise-v2: subgraph errors —', JSON.stringify(data.errors));
+    console.error(
+      'stakewise-v2: subgraph errors —',
+      JSON.stringify(data.errors)
+    );
     return null;
   }
   const vault = data?.data?.vault;
@@ -97,8 +110,11 @@ const getGenesisPool = async (ethPrice) => {
     pool: `${genesisVaultAddress}-${chain}`,
     chain,
     project: 'stakewise-v2',
+    // stakers deposit native ETH; the vault position is ETH-denominated
     symbol: 'ETH',
-    tvlUsd: tvl * ethPrice,
+    tvlUsd: tvl * ethPrice, // vault assets are native ETH
+    // subgraph `apy`: percent units, net of the vault fee, unboosted —
+    // the minimum-attainable yield (per DefiLlama methodology)
     apyBase: Number(vault.apy),
     underlyingTokens: ['0x0000000000000000000000000000000000000000'],
     poolMeta: 'Genesis Vault',

--- a/src/adaptors/stakewise-v2/index.js
+++ b/src/adaptors/stakewise-v2/index.js
@@ -12,12 +12,19 @@ const osTokenAddress = '0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38';
 const osTokenCtrlAddress = '0x2A261e60FB14586B474C208b1B7AC6D0f5000306';
 const chain = 'ethereum';
 
+// StakeWise V3 subgraph (public) — source for vault-level staking APY
+const subgraphUrl =
+  'https://graphs.stakewise.io/mainnet/subgraphs/name/stakewise/prod';
+// Genesis Vault: the protocol's primary public vault (~40% of TVL)
+const genesisVaultAddress = '0xac0f906e433d58fa868f936e8a43230473652885';
+
 const EVENTS = {
   AvgRewardPerSecondUpdated:
     'event AvgRewardPerSecondUpdated(uint256 avgRewardPerSecond)',
 };
 
-const getApy = async () => {
+// osETH holder yield — the liquid staking token (unchanged, intrinsic source)
+const getOsTokenPool = async (ethPrice) => {
   const currentBlock = await sdk.api.util.getLatestBlock(chain);
   const toBlock = currentBlock.number;
   const timestampWeekAgo = currentBlock.timestamp - secondsInWeek;
@@ -48,23 +55,64 @@ const getApy = async () => {
   const tvl =
     (await sdk.api.erc20.totalSupply({ target: osTokenAddress })).output / 1e18;
 
+  return {
+    pool: osTokenAddress,
+    chain,
+    project: 'stakewise-v2',
+    symbol: 'osETH',
+    tvlUsd: tvl * ethPrice,
+    apyBase: Number(apyBN) / 100,
+    underlyingTokens: ['0x0000000000000000000000000000000000000000'],
+    searchTokenOverride: osTokenAddress,
+    isIntrinsicSource: true,
+  };
+};
+
+// Direct staking in the Genesis Vault — net, unboosted (lower bound) APY
+const getGenesisPool = async (ethPrice) => {
+  const query = `{
+    vault(id: "${genesisVaultAddress}") {
+      apy
+      totalAssets
+    }
+  }`;
+  const { data } = await axios.post(subgraphUrl, { query });
+  const vault = data?.data?.vault;
+  if (!vault) return null;
+
+  const tvl = Number(vault.totalAssets) / wad;
+
+  return {
+    pool: `${genesisVaultAddress}-${chain}`,
+    chain,
+    project: 'stakewise-v2',
+    symbol: 'ETH',
+    tvlUsd: tvl * ethPrice,
+    apyBase: Number(vault.apy),
+    underlyingTokens: ['0x0000000000000000000000000000000000000000'],
+    poolMeta: 'Genesis Vault',
+    url: `https://app.stakewise.io/vaults/ethereum/${genesisVaultAddress}`,
+  };
+};
+
+const getApy = async () => {
   // fetch ETH price
   const priceKey = 'ethereum:0x0000000000000000000000000000000000000000';
-  const ethPrice = (await utils.getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;
+  const ethPrice = (await utils.getPriceApiData(`/prices/current/${priceKey}`))
+    .coins[priceKey]?.price;
 
-  return [
-    {
-      pool: osTokenAddress,
-      chain,
-      project: 'stakewise-v2',
-      symbol: 'osETH',
-      tvlUsd: tvl * ethPrice,
-      apyBase: Number(apyBN) / 100,
-      underlyingTokens: ['0x0000000000000000000000000000000000000000'],
-      searchTokenOverride: osTokenAddress,
-      isIntrinsicSource: true,
-    },
-  ];
+  // osETH pool is the intrinsic source consumed by other adaptors — it must
+  // not be dropped if the vault subgraph hiccups, so isolate the Genesis pool.
+  const osTokenPool = await getOsTokenPool(ethPrice);
+
+  let genesisPool = null;
+  try {
+    genesisPool = await getGenesisPool(ethPrice);
+  } catch (err) {
+    console.error('stakewise-v2: Genesis vault pool skipped —', err.message);
+  }
+
+  return [osTokenPool, genesisPool].filter(Boolean);
 };
 
 module.exports = {

--- a/src/adaptors/stakewise-v2/index.js
+++ b/src/adaptors/stakewise-v2/index.js
@@ -23,8 +23,8 @@ const EVENTS = {
     'event AvgRewardPerSecondUpdated(uint256 avgRewardPerSecond)',
 };
 
-// osETH holder yield — the liquid staking token (unchanged, intrinsic source)
-const getOsTokenPool = async (ethPrice) => {
+// osETH holder yield — the liquid staking token (intrinsic source)
+const getOsTokenPool = async (osTokenPrice) => {
   const currentBlock = await sdk.api.util.getLatestBlock(chain);
   const toBlock = currentBlock.number;
   const timestampWeekAgo = currentBlock.timestamp - secondsInWeek;
@@ -40,6 +40,9 @@ const getOsTokenPool = async (ethPrice) => {
 
   // get last 14 events (1-week average)
   const lastWeekLogs = logs.slice(-14);
+  if (!lastWeekLogs.length) {
+    throw new Error('no AvgRewardPerSecondUpdated events in the last week');
+  }
   const osEthRewardPerSecondSum = lastWeekLogs
     .map((log) => {
       return new BigNumber(log.args.avgRewardPerSecond.toString());
@@ -60,7 +63,8 @@ const getOsTokenPool = async (ethPrice) => {
     chain,
     project: 'stakewise-v2',
     symbol: 'osETH',
-    tvlUsd: tvl * ethPrice,
+    // osETH is an appreciating token — price it directly, not with the ETH price
+    tvlUsd: tvl * osTokenPrice,
     apyBase: Number(apyBN) / 100,
     underlyingTokens: ['0x0000000000000000000000000000000000000000'],
     searchTokenOverride: osTokenAddress,
@@ -77,8 +81,15 @@ const getGenesisPool = async (ethPrice) => {
     }
   }`;
   const { data } = await axios.post(subgraphUrl, { query });
+  if (data?.errors) {
+    console.error('stakewise-v2: subgraph errors —', JSON.stringify(data.errors));
+    return null;
+  }
   const vault = data?.data?.vault;
-  if (!vault) return null;
+  if (!vault) {
+    console.error('stakewise-v2: Genesis vault missing from subgraph response');
+    return null;
+  }
 
   const tvl = Number(vault.totalAssets) / wad;
 
@@ -96,14 +107,18 @@ const getGenesisPool = async (ethPrice) => {
 };
 
 const getApy = async () => {
-  // fetch ETH price
-  const priceKey = 'ethereum:0x0000000000000000000000000000000000000000';
-  const ethPrice = (await utils.getPriceApiData(`/prices/current/${priceKey}`))
-    .coins[priceKey]?.price;
+  // fetch ETH price (Genesis vault assets) and osETH price (appreciating token)
+  const ethKey = 'ethereum:0x0000000000000000000000000000000000000000';
+  const osTokenKey = `ethereum:${osTokenAddress.toLowerCase()}`;
+  const { coins } = await utils.getPriceApiData(
+    `/prices/current/${ethKey},${osTokenKey}`
+  );
+  const ethPrice = coins[ethKey]?.price;
+  const osTokenPrice = coins[osTokenKey]?.price || ethPrice;
 
   // osETH pool is the intrinsic source consumed by other adaptors — it must
   // not be dropped if the vault subgraph hiccups, so isolate the Genesis pool.
-  const osTokenPool = await getOsTokenPool(ethPrice);
+  const osTokenPool = await getOsTokenPool(osTokenPrice);
 
   let genesisPool = null;
   try {

--- a/src/adaptors/stakewise-v2/index.js
+++ b/src/adaptors/stakewise-v2/index.js
@@ -1,3 +1,8 @@
+// StakeWise — Ethereum liquid staking (V3). Returns two pools:
+//   1. osETH        — the liquid staking token; yield osETH holders accrue.
+//   2. Genesis Vault — direct ETH staking in the protocol's main vault.
+// Same protocol; the `stakewise-v2` slug is legacy — V3 has been the live
+// mainnet protocol since 2023-11-28 (a rename to stakewise-v3 is requested).
 const sdk = require('@defillama/sdk');
 const BigNumber = require('bignumber.js');
 const axios = require('axios');
@@ -12,12 +17,39 @@ const osTokenAddress = '0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38';
 const osTokenCtrlAddress = '0x2A261e60FB14586B474C208b1B7AC6D0f5000306';
 const chain = 'ethereum';
 
+// StakeWise V3 subgraph (public) — source for vault-level staking APY
+const subgraphUrl =
+  'https://graphs.stakewise.io/mainnet/subgraphs/name/stakewise/prod';
+const subgraphTimeout = 10000;
+// Genesis Vault: the protocol's primary public vault (~40% of TVL)
+const genesisVaultAddress = '0xac0f906e433d58fa868f936e8a43230473652885';
+
+// osETH minted against the Genesis Vault is only exposed per-allocator, so it
+// has to be paged over (~1.5k allocators today). Bound the paging so a broken
+// cursor can never spin forever.
+const allocatorsPageSize = 1000;
+const maxAllocatorPages = 20;
+
 const EVENTS = {
   AvgRewardPerSecondUpdated:
     'event AvgRewardPerSecondUpdated(uint256 avgRewardPerSecond)',
 };
 
-const getApy = async () => {
+const querySubgraph = async (query) => {
+  const { data } = await axios.post(
+    subgraphUrl,
+    { query },
+    { timeout: subgraphTimeout }
+  );
+  if (data?.errors) {
+    throw new Error(`subgraph errors — ${JSON.stringify(data.errors)}`);
+  }
+
+  return data?.data;
+};
+
+// osETH holder yield — the liquid staking token (intrinsic source)
+const getOsTokenPool = async (osTokenPrice) => {
   const currentBlock = await sdk.api.util.getLatestBlock(chain);
   const toBlock = currentBlock.number;
   const timestampWeekAgo = currentBlock.timestamp - secondsInWeek;
@@ -33,6 +65,10 @@ const getApy = async () => {
 
   // get last 14 events (1-week average)
   const lastWeekLogs = logs.slice(-14);
+  // no rate events in the window → APY would be NaN; fail instead of emitting it
+  if (!lastWeekLogs.length) {
+    throw new Error('no AvgRewardPerSecondUpdated events in the last week');
+  }
   const osEthRewardPerSecondSum = lastWeekLogs
     .map((log) => {
       return new BigNumber(log.args.avgRewardPerSecond.toString());
@@ -48,22 +84,132 @@ const getApy = async () => {
   const tvl =
     (await sdk.api.erc20.totalSupply({ target: osTokenAddress })).output / 1e18;
 
-  // fetch ETH price
-  const priceKey = 'ethereum:0x0000000000000000000000000000000000000000';
-  const ethPrice = (await utils.getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;
+  return {
+    pool: osTokenAddress,
+    chain,
+    project: 'stakewise-v2',
+    symbol: 'osETH',
+    // osETH accrues value vs ETH (trades at a premium), so pricing its supply
+    // with the ETH price understated TVL — use the osETH feed (ETH fallback).
+    tvlUsd: tvl * osTokenPrice,
+    // 1-week average of the on-chain osETH reward rate holders realize
+    apyBase: Number(apyBN) / 100,
+    underlyingTokens: ['0x0000000000000000000000000000000000000000'],
+    isIntrinsicSource: true,
+  };
+};
 
-  return [
-    {
-      pool: osTokenAddress,
-      chain,
-      project: 'stakewise-v2',
-      symbol: 'osETH',
-      tvlUsd: tvl * ethPrice,
-      apyBase: Number(apyBN) / 100,
-      underlyingTokens: ['0x0000000000000000000000000000000000000000'],
-      isIntrinsicSource: true,
-    },
-  ];
+// Total osETH shares minted against Genesis Vault deposits. Those shares are
+// already counted in the osETH pool above, so they have to come off the vault's
+// TVL to leave only the non-osETH-backed stake.
+const getGenesisMintedOsTokenShares = async () => {
+  let mintedShares = new BigNumber(0);
+  let lastId = '';
+
+  for (let page = 0; page < maxAllocatorPages; page += 1) {
+    const query = `{
+      allocators(
+        first: ${allocatorsPageSize}
+        orderBy: id
+        orderDirection: asc
+        where: {
+          vault: "${genesisVaultAddress}"
+          mintedOsTokenShares_gt: "0"
+          id_gt: "${lastId}"
+        }
+      ) {
+        id
+        mintedOsTokenShares
+      }
+    }`;
+    const { allocators } = await querySubgraph(query);
+    if (!allocators?.length) {
+      return mintedShares;
+    }
+
+    mintedShares = allocators.reduce(
+      (acc, { mintedOsTokenShares }) =>
+        acc.plus(new BigNumber(mintedOsTokenShares)),
+      mintedShares
+    );
+    if (allocators.length < allocatorsPageSize) {
+      return mintedShares;
+    }
+    lastId = allocators[allocators.length - 1].id;
+  }
+
+  // paged out without reaching the end — the deduction would be understated and
+  // the TVL overstated, so drop the pool rather than publish a wrong number
+  throw new Error('too many Genesis allocators to page through');
+};
+
+// Direct ETH staking in the Genesis Vault. Distinct product from the osETH pool
+// above — osETH is the token optionally minted against a vault deposit — so
+// listing both is intentional; the minted portion is netted out below.
+const getGenesisPool = async (ethPrice, osTokenPrice) => {
+  const query = `{
+    vault(id: "${genesisVaultAddress}") {
+      apy
+      totalAssets
+    }
+  }`;
+  const { vault } = await querySubgraph(query);
+  // null metrics would coerce to 0 and publish a false APY/TVL — skip instead
+  if (vault?.apy == null || vault?.totalAssets == null) {
+    console.error('stakewise-v2: Genesis vault missing or has null metrics');
+    return null;
+  }
+
+  const mintedShares = await getGenesisMintedOsTokenShares();
+  // vault assets are native ETH
+  const vaultUsd = (Number(vault.totalAssets) / wad) * ethPrice;
+  // priced with the same osETH feed the osETH pool uses, so this cancels
+  // exactly what that pool already reports for Genesis-minted osETH
+  const mintedUsd = mintedShares.dividedBy(wad).toNumber() * osTokenPrice;
+
+  return {
+    pool: `${genesisVaultAddress}-${chain}`,
+    chain,
+    project: 'stakewise-v2',
+    // stakers deposit native ETH; the vault position is ETH-denominated
+    symbol: 'ETH',
+    tvlUsd: Math.max(vaultUsd - mintedUsd, 0),
+    // subgraph `apy`: percent units, net of the vault fee, unboosted —
+    // the minimum-attainable yield (per DefiLlama methodology)
+    apyBase: Number(vault.apy),
+    underlyingTokens: ['0x0000000000000000000000000000000000000000'],
+    poolMeta: 'Genesis Vault',
+    url: `https://app.stakewise.io/vaults/ethereum/${genesisVaultAddress}`,
+  };
+};
+
+const getApy = async () => {
+  // fetch ETH price (Genesis vault assets) and osETH price (appreciating token)
+  const ethKey = 'ethereum:0x0000000000000000000000000000000000000000';
+  const osTokenKey = `ethereum:${osTokenAddress.toLowerCase()}`;
+  const { coins } = await utils.getPriceApiData(
+    `/prices/current/${ethKey},${osTokenKey}`
+  );
+  const ethPrice = coins[ethKey]?.price;
+  // without the base ETH price both pools would compute NaN TVL and get
+  // silently dropped — fail loudly and let the next run retry instead
+  if (!ethPrice) {
+    throw new Error('missing ETH price');
+  }
+  const osTokenPrice = coins[osTokenKey]?.price || ethPrice;
+
+  // osETH pool is the intrinsic source consumed by other adaptors — it must
+  // not be dropped if the vault subgraph hiccups, so isolate the Genesis pool.
+  const osTokenPool = await getOsTokenPool(osTokenPrice);
+
+  let genesisPool = null;
+  try {
+    genesisPool = await getGenesisPool(ethPrice, osTokenPrice);
+  } catch (err) {
+    console.error('stakewise-v2: Genesis vault pool skipped —', err.message);
+  }
+
+  return [osTokenPool, genesisPool].filter(Boolean);
 };
 
 module.exports = {

--- a/src/adaptors/stakewise-v2/index.js
+++ b/src/adaptors/stakewise-v2/index.js
@@ -20,7 +20,8 @@ const chain = 'ethereum';
 // StakeWise V3 subgraph (public) — source for vault-level staking APY
 const subgraphUrl =
   'https://graphs.stakewise.io/mainnet/subgraphs/name/stakewise/prod';
-const subgraphTimeout = 10000;
+// generous enough to survive a cold subgraph cache, still bounded
+const subgraphTimeout = 20000;
 // Genesis Vault: the protocol's primary public vault (~40% of TVL)
 const genesisVaultAddress = '0xac0f906e433d58fa868f936e8a43230473652885';
 
@@ -166,6 +167,13 @@ const getGenesisPool = async (ethPrice, osTokenPrice) => {
   // priced with the same osETH feed the osETH pool uses, so this cancels
   // exactly what that pool already reports for Genesis-minted osETH
   const mintedUsd = mintedShares.dividedBy(wad).toNumber() * osTokenPrice;
+  const tvlUsd = vaultUsd - mintedUsd;
+  // more osETH minted than the vault holds means the two sources disagree —
+  // that is a wrong number either way, so drop the pool instead of flooring it to 0
+  if (tvlUsd <= 0) {
+    console.error('stakewise-v2: Genesis minted osETH exceeds vault assets');
+    return null;
+  }
 
   return {
     pool: `${genesisVaultAddress}-${chain}`,
@@ -173,7 +181,7 @@ const getGenesisPool = async (ethPrice, osTokenPrice) => {
     project: 'stakewise-v2',
     // stakers deposit native ETH; the vault position is ETH-denominated
     symbol: 'ETH',
-    tvlUsd: Math.max(vaultUsd - mintedUsd, 0),
+    tvlUsd,
     // subgraph `apy`: percent units, net of the vault fee, unboosted —
     // the minimum-attainable yield (per DefiLlama methodology)
     apyBase: Number(vault.apy),


### PR DESCRIPTION
## What this adds

A second pool to the StakeWise (`stakewise-v2`) yields adaptor: the **Genesis Vault**, the protocol's primary public vault (~40% of TVL). Today the adaptor lists only the `osETH` liquid-staking token; this surfaces the direct-staking APY of the flagship vault, which stakers actually earn.

- **Source:** the public StakeWise V3 subgraph (`vault(id:).apy`, `.totalAssets`).
- **`apy` semantics:** the subgraph `apy` is in **percent units, net of the vault fee, and unboosted** (no osETH-boost / restaking layered in) — i.e. the minimum attainable staking yield, per the methodology. No boosted/leveraged figures are included.
- **osETH pool kept intact** as the `isIntrinsicSource` primitive consumed by downstream osETH markets; the Genesis fetch is isolated in try/catch so a subgraph hiccup can never drop it.

## Also fixes (same lines touched)

- **osETH `tvlUsd` was mispriced.** It multiplied osETH `totalSupply` by the **ETH** price, but osETH is an appreciating token priced above ETH — now uses the osETH price feed (falls back to ETH price if unavailable).
- Guard against an empty `AvgRewardPerSecondUpdated` window (would produce `NaN` apy) and against subgraph `errors`/missing-vault responses (now logged, not silently dropped).

## Test

`npm run test --adapter=stakewise-v2` → 19/19 pass, returns both pools (osETH + Genesis Vault) with valid schema.

## Please rename the protocol `stakewise-v2` → `stakewise-v3`

The slug is stale. **StakeWise V3 has been the live protocol on Ethereum mainnet since its launch on 28 November 2023** ([announcement](https://stakewise.medium.com/announcing-the-launch-of-stakewise-v3-55effc24dbe4)); the V3 Genesis Vault was deployed on-chain on 31 October 2023. V2 has been fully deprecated for ~20 months, and the entire ~$712M currently listed under `stakewise-v2` is V3 TVL (V3 vaults + osETH). The `v2` label is purely historical.

Could a maintainer please **rename protocol id `277` "StakeWise V2" → "StakeWise V3"** (slug `stakewise-v3`), **keeping id `277`** so the TVL history is preserved, and migrate this project's yields pool ownership from `stakewise-v2` to `stakewise-v3` so the APY history isn't orphaned? Once the `stakewise-v3` slug exists, I'll open a follow-up here to rename this adaptor's folder + `project` field accordingly (the `protocolId` stays `277`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate StakeWise V3 reporting for the intrinsic osETH pool and Genesis Vault.
  * osETH TVL valuation now uses the osETH price, with an ETH fallback.
  * Added Genesis Vault APY, asset, and adjusted TVL reporting.

* **Bug Fixes**
  * Prevents invalid osETH APY values when reward data is unavailable.
  * Skips Genesis Vault reporting when required metrics or data requests fail, while preserving osETH reporting.
  * Filters incomplete pool results and safely handles oversized data responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->