### PR TITLE
rename townsquare -> townsquare-lending

### DIFF
--- a/migrations/1784277966895_rename-townsquare-to-townsquare-lending.js
+++ b/migrations/1784277966895_rename-townsquare-to-townsquare-lending.js
@@ -1,0 +1,7 @@
+exports.up = (pgm) => {
+  pgm.sql(`UPDATE config SET project = 'townsquare-lending' WHERE project = 'townsquare'`);
+};
+
+exports.down = (pgm) => {
+  pgm.sql(`UPDATE config SET project = 'townsquare' WHERE project = 'townsquare-lending'`);
+};

--- a/src/adaptors/townsquare-lending/index.js
+++ b/src/adaptors/townsquare-lending/index.js
@@ -119,7 +119,7 @@ const apy = async () => {
       return {
         pool: `${poolAddr}-${chain}`.toLowerCase(),
         chain: utils.formatChain(chain),
-        project: 'townsquare',
+        project: 'townsquare-lending',
         symbol: symbol,
         tvlUsd,
         apyBase,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated project identification from “townsquare” to “townsquare-lending” across relevant records and generated entries.
  - Existing functionality and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->