### PR TITLE
remove isprivate condition from yield server

### DIFF
--- a/src/adaptors/ember-protocol/index.js
+++ b/src/adaptors/ember-protocol/index.js
@@ -5,7 +5,7 @@ const utils = require('../utils');
 const PROJECT = 'ember-protocol';
 const BASE_URL = 'https://ember.so/';
 const EARN_URL = 'https://ember.so/earn';
-const VAULTS_URL = 'https://vaults.api.sui-prod.bluefin.io/api/v2/vaults';
+const VAULTS_URL = 'https://vaults.api.prod.ember.so/api/v2/vaults';
 
 const poolUrl = (receiptSymbol) =>
   receiptSymbol ? `${EARN_URL}/${receiptSymbol}` : BASE_URL;

--- a/src/adaptors/ember-protocol/index.js
+++ b/src/adaptors/ember-protocol/index.js
@@ -66,7 +66,6 @@ const rewardTokenAddresses = (vault, apyReward) => {
 const collectVaultEntries = (vaults, chainKey) => {
   const out = [];
   for (const vault of vaults) {
-    if (vault.isPrivate) continue;
     const details = vault.detailsByChain?.[chainKey];
     if (!details?.address) continue;
     if (BLACKLISTED_VAULTS.has(details.address.toLowerCase())) continue;


### PR DESCRIPTION
Removed isPrivate condition because it is used by our FE to enable/disable deposits on our UI based on a whitelist we set onchain for certain vaults, this doesn't constitute an internal vault but rather it is a mechanism that some managers use to have a better control of inflows from LPs that want to deposit. It also doesn't hinder the operations of the vault, the strategies are still deployed across multiple chains/protocols and accrue yield in the same way as other vaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated vault metadata retrieval to use the current API endpoint.
  * Private vaults can now be included in supported pool listings and related APY and TVL calculations when they meet eligibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->