### PR TITLE
coinbase-wrapped-staked-eth: use relative rate ratio for apyBase

### DIFF
--- a/src/adaptors/coinbase-wrapped-staked-eth/index.js
+++ b/src/adaptors/coinbase-wrapped-staked-eth/index.js
@@ -29,7 +29,7 @@ const getApy = async () => {
   ]);
 
   const apr =
-    ((exchangeRates[0].output - exchangeRates[1].output) / 1e18 / duration) *
+    ((exchangeRates[0].output - exchangeRates[1].output) / exchangeRates[1].output / duration) *
     365 *
     100;
 


### PR DESCRIPTION
Divides the cbETH `apyBase` exchange-rate delta by the prior rate (the relative ratio) instead of by the constant `1e18`.

`coinbase-wrapped-staked-eth/index.js:31` divided the `exchangeRate()` delta by `1e18`, which scales the annualized figure by the cbETH exchange rate (currently 1.135). The repo's own `getERC4626Info` helper (`utils.js:707`) and the rest of the site use the relative ratio. With the same on-chain rates, reported `apyBase` goes from 2.84 to 2.50; the ratio 1.135 is the exchange rate.

One line: `/ 1e18` to `/ exchangeRates[1].output`. The full class (six adapters) is described in #2832; this PR is the cbETH fix only. Precedent for an outside correctness fix landing here: #2762.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APY/APR calculations for Coinbase Wrapped Staked ETH by using the correct relative rate change.
  * Provides more accurate yield figures when exchange rates fluctuate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->