### PR TITLE
apyBase: use relative rate ratio for five more LST adapters (follows #2833)

### DIFF
--- a/src/adaptors/crypto.com-liquid-staking/index.js
+++ b/src/adaptors/crypto.com-liquid-staking/index.js
@@ -46,10 +46,10 @@ const apy = async () => {
   ]);
 
   const apr1d =
-    ((exchangeRates[0].output - exchangeRates[1].output) / 1e18) * 365 * 100;
+    ((exchangeRates[0].output - exchangeRates[1].output) / exchangeRates[1].output) * 365 * 100;
 
   const apr7d =
-    ((exchangeRates[0].output - exchangeRates[2].output) / 1e18) * 52 * 100;
+    ((exchangeRates[0].output - exchangeRates[2].output) / exchangeRates[2].output) * 52 * 100;
 
   const priceKey = `ethereum:${weth}`;
   const price = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;

--- a/src/adaptors/ether.fi-stake/index.js
+++ b/src/adaptors/ether.fi-stake/index.js
@@ -55,10 +55,10 @@ const apy = async () => {
   ]);
 
   const apr1d =
-    ((weETHRates[0].output - weETHRates[1].output) / 1e18) * 365 * 100;
+    ((weETHRates[0].output - weETHRates[1].output) / weETHRates[1].output) * 365 * 100;
 
   const apr7d =
-    ((weETHRates[0].output - weETHRates[2].output) / 1e18 / 7) * 365 * 100;
+    ((weETHRates[0].output - weETHRates[2].output) / weETHRates[2].output / 7) * 365 * 100;
 
   const eBTCRateCurrent = Number(eBTCRates[0].output);
   const eBTCRate1dAgo = Number(eBTCRates[1].output);

--- a/src/adaptors/liquid-collective/index.js
+++ b/src/adaptors/liquid-collective/index.js
@@ -43,8 +43,8 @@ const apy = async () => {
   const exchangeRate7d =
     _underlyingAssetAmount / sharesFromUnderlyingBalances[2].output;
 
-  const apyBase1d = (exchangeRateNow - exchangeRate1d) * 365 * 100;
-  const apyBase7d = ((exchangeRateNow - exchangeRate7d) / 7) * 365 * 100;
+  const apyBase1d = ((exchangeRateNow - exchangeRate1d) / exchangeRate1d) * 365 * 100;
+  const apyBase7d = ((exchangeRateNow - exchangeRate7d) / exchangeRate7d / 7) * 365 * 100;
 
   const priceKey = 'ethereum:0x0000000000000000000000000000000000000000';
   const ethPrice = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;

--- a/src/adaptors/meth-protocol/index.js
+++ b/src/adaptors/meth-protocol/index.js
@@ -48,10 +48,10 @@ const apy = async () => {
   ]);
 
   const apyBase =
-    ((exchangeRates[0].output - exchangeRates[1].output) / 1e18) * 365 * 100;
+    ((exchangeRates[0].output - exchangeRates[1].output) / exchangeRates[1].output) * 365 * 100;
 
   const apyBase7d =
-    ((exchangeRates[0].output - exchangeRates[2].output) / 1e18 / 7) *
+    ((exchangeRates[0].output - exchangeRates[2].output) / exchangeRates[2].output / 7) *
     365 *
     100;
 

--- a/src/adaptors/stader/index.js
+++ b/src/adaptors/stader/index.js
@@ -44,7 +44,7 @@ const getApy = async () => {
   ]);
 
   const apyBase7d =
-    ((exchangeRates[0].output - exchangeRates[1].output) / 1e18 / 7) *
+    ((exchangeRates[0].output - exchangeRates[1].output) / exchangeRates[1].output / 7) *
     365 *
     100;
 
@@ -71,7 +71,7 @@ const getApy = async () => {
 
   const apyBase7dPolygon =
     ((exchangeRatesPolygon[0].output[0] - exchangeRatesPolygon[1].output[0]) /
-      1e18 /
+      exchangeRatesPolygon[1].output[0] /
       7) *
     365 *
     100;


### PR DESCRIPTION
Applies the same fix merged in #2833 (cbETH) to the five remaining LST adapters that annualize an exchange-rate delta with an absolute `/ 1e18` instead of the relative ratio the repo's `getERC4626Info` helper (`utils.js:707`) uses. Per the offer in #2832.

Each divides the rate delta by the prior rate instead of the constant `1e18`. The prior rate is already read in every case, so there is no new call.

- `ether.fi-stake` (weETH): `/ 1e18` -> `/ weETHRates[1].output` (1d), `/ weETHRates[2].output / 7` (7d)
- `meth-protocol` (mETH): `/ exchangeRates[1].output`, `/ exchangeRates[2].output / 7`
- `stader` (ETHx): ETH and polygon paths -> `/ exchangeRates[1].output / 7`, `/ exchangeRatesPolygon[1].output[0] / 7`
- `crypto.com-liquid-staking` (cdcETH): `/ exchangeRates[1].output`, `/ exchangeRates[2].output`
- `liquid-collective` (LSETH): float form, adds `/ exchangeRate1d` and `/ exchangeRate7d`

Computed on-chain (relative form vs current absolute), same rates:

| pool | current | relative | rate |
|---|---:|---:|---:|
| mETH | 2.35 | 2.14 | 1.096 |
| ETHx | 2.32 | 2.09 | 1.11 |
| cdcETH | 1.56 | 1.44 | 1.08 |
| LSETH | 3.23 | 3.05 | 1.06 |
| weETH (base) | 2.52 | 2.29 | 1.099 |

`weETH`'s reported apyBase also includes a separate restaking component added on a different line; this change only affects the `getRate`-derived base, leaving the restaking part untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected 1-day and 7-day APR/APY calculations across multiple liquid-staking protocols.
  * Improved exchange-rate normalization for more accurate yield estimates.
  * Fixed annualized yield calculations for Ethereum and Polygon staking pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->