### PR TITLE
feat(liminal-basis): add remaining Liminal products

### DIFF
--- a/src/adaptors/liminal-basis/abi.js
+++ b/src/adaptors/liminal-basis/abi.js
@@ -1,4 +1,5 @@
 module.exports = {
+  navUpdated: 'event NAVUpdated(uint256 newNAV, uint256 timestamp)',
   getNAV: {
     inputs: [],
     name: 'getNAV',

--- a/src/adaptors/liminal-basis/apy.js
+++ b/src/adaptors/liminal-basis/apy.js
@@ -3,141 +3,233 @@ const { default: BigNumber } = require('bignumber.js');
 const utils = require('../utils');
 const abi = require('./abi');
 
+const SECONDS_PER_DAY = 24 * 60 * 60;
+const TRAILING_WINDOW_DAYS = 7;
+const NAV_UPDATE_LOOKBACK_DAYS = 30;
+const NAV_UPDATE_CONFIRMATION_BLOCKS = 120;
+
+const blockRangePromises = new Map();
+
 async function getBlockByEpoch(epochSecs, chain) {
   const data = await utils.getPriceApiData(`/block/${chain}/${epochSecs}`);
   return data.height;
 }
 
-async function getPPSAtBlock(
-  navOracleAddress,
+function getNavUpdateBlockRange(chain) {
+  if (!blockRangePromises.has(chain)) {
+    const rangePromise = (async () => {
+      const toTimestamp = Math.floor(Date.now() / 1000);
+      const fromTimestamp =
+        toTimestamp - NAV_UPDATE_LOOKBACK_DAYS * SECONDS_PER_DAY;
+      const [fromBlock, toBlock] = await Promise.all([
+        getBlockByEpoch(fromTimestamp, chain),
+        getBlockByEpoch(toTimestamp, chain),
+      ]);
+
+      return {
+        fromBlock,
+        toBlock: Math.max(fromBlock, toBlock - NAV_UPDATE_CONFIRMATION_BLOCKS),
+      };
+    })();
+    blockRangePromises.set(chain, rangePromise);
+  }
+
+  return blockRangePromises.get(chain);
+}
+
+function parseNavUpdates(logs) {
+  return logs
+    .map((log) => {
+      const timestamp = Number(log.args?.timestamp ?? log.args?.[1]);
+      const newNav = new BigNumber(
+        (log.args?.newNAV ?? log.args?.[0] ?? 0).toString(),
+      );
+
+      return {
+        blockNumber: Number(log.blockNumber),
+        logIndex: Number(log.logIndex ?? log.index ?? 0),
+        timestamp,
+        newNav,
+      };
+    })
+    .filter(
+      (record) =>
+        Number.isFinite(record.blockNumber) &&
+        record.blockNumber > 0 &&
+        Number.isFinite(record.timestamp) &&
+        record.timestamp > 0 &&
+        record.newNav.isFinite() &&
+        record.newNav.gte(0),
+    )
+    .sort(
+      (a, b) =>
+        a.timestamp - b.timestamp ||
+        a.blockNumber - b.blockNumber ||
+        a.logIndex - b.logIndex,
+    );
+}
+
+async function getNavUpdates(navOracleAddress, chain) {
+  const { fromBlock, toBlock } = await getNavUpdateBlockRange(chain);
+  const logs = await sdk.getEventLogs({
+    target: navOracleAddress,
+    chain,
+    fromBlock,
+    toBlock,
+    eventAbi: abi.navUpdated,
+    entireLog: true,
+  });
+
+  return parseNavUpdates(logs);
+}
+
+function findClosestNavApyBaseline(records, asOfIndex, windowDays) {
+  if (asOfIndex <= 0) return null;
+
+  const targetTimestamp =
+    records[asOfIndex].timestamp - windowDays * SECONDS_PER_DAY;
+  let bestRecord = null;
+  let bestDiff = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < asOfIndex; i++) {
+    const record = records[i];
+    const diff = Math.abs(record.timestamp - targetTimestamp);
+    if (
+      diff < bestDiff ||
+      (diff === bestDiff &&
+        bestRecord &&
+        record.timestamp < bestRecord.timestamp)
+    ) {
+      bestRecord = record;
+      bestDiff = diff;
+    }
+  }
+
+  return bestRecord;
+}
+
+function calculateShareValue(newNav, totalSupply, decimals) {
+  const supply = new BigNumber(totalSupply);
+  if (supply.lte(0)) return 0;
+
+  const scale = new BigNumber(10).pow(decimals);
+  return newNav
+    .times(scale)
+    .div(supply)
+    .integerValue(BigNumber.ROUND_FLOOR)
+    .div(scale)
+    .toNumber();
+}
+
+function computeCompoundedApy(
+  startShareValue,
+  endShareValue,
+  startTimestamp,
+  endTimestamp,
+) {
+  const periodDays = (endTimestamp - startTimestamp) / SECONDS_PER_DAY;
+  if (
+    !Number.isFinite(startShareValue) ||
+    !Number.isFinite(endShareValue) ||
+    startShareValue <= 0 ||
+    endShareValue <= 0 ||
+    periodDays <= 0
+  ) {
+    return 0;
+  }
+
+  const apy =
+    ((endShareValue / startShareValue) ** (365 / periodDays) - 1) * 100;
+  return Number.isFinite(apy) ? apy : 0;
+}
+
+async function getShareValues(
+  startRecord,
+  endRecord,
   shareManagerAddress,
-  block,
   chain,
 ) {
-  const [navResult, supplyResult] = await Promise.all([
+  const [
+    startSupplyResult,
+    endSupplyResult,
+    startDecimalsResult,
+    endDecimalsResult,
+  ] = await Promise.all([
     sdk.api.abi.call({
-      target: navOracleAddress,
-      abi: abi.getNAV,
+      target: shareManagerAddress,
+      abi: abi.totalSupply,
       chain,
-      block,
+      block: startRecord.blockNumber,
     }),
     sdk.api.abi.call({
       target: shareManagerAddress,
       abi: abi.totalSupply,
       chain,
-      block,
+      block: endRecord.blockNumber,
+    }),
+    sdk.api.abi.call({
+      target: shareManagerAddress,
+      abi: abi.decimals,
+      chain,
+      block: startRecord.blockNumber,
+    }),
+    sdk.api.abi.call({
+      target: shareManagerAddress,
+      abi: abi.decimals,
+      chain,
+      block: endRecord.blockNumber,
     }),
   ]);
 
-  const nav = new BigNumber(navResult.output);
-  const supply = new BigNumber(supplyResult.output);
-
-  if (supply.isZero()) {
-    return new BigNumber(0);
-  }
-
-  return nav.times(1e18).div(supply);
-}
-
-async function calcApy(
-  navOracleAddress,
-  shareManagerAddress,
-  startEpochSecs,
-  endEpochSecs,
-  intervalDays,
-  chain,
-) {
-  const startBlock = await getBlockByEpoch(startEpochSecs, chain);
-  const endBlock = await getBlockByEpoch(endEpochSecs, chain);
-
-  let startPPS;
-  try {
-    startPPS = await getPPSAtBlock(
-      navOracleAddress,
-      shareManagerAddress,
-      startBlock,
-      chain,
-    );
-  } catch (e) {
-    console.error(
-      `Liminal: Unable to get start PPS for ${shareManagerAddress} at block ${startBlock}:`,
-      e.message,
-    );
-    return 0;
-  }
-
-  if (startPPS.isZero()) {
-    return 0;
-  }
-
-  const endPPS = await getPPSAtBlock(
-    navOracleAddress,
-    shareManagerAddress,
-    endBlock,
-    chain,
-  );
-
-  if (endPPS.isZero()) {
-    return 0;
-  }
-
-  const yieldRatio = endPPS.minus(startPPS).div(startPPS);
-  const apy = yieldRatio.times(365).div(intervalDays).times(100).toNumber();
-
-  return Number.isNaN(apy) || apy < 0 ? 0 : apy;
-}
-
-function utcToday() {
-  const dateString = new Date().toISOString().split('T')[0];
-  return new Date(`${dateString}T00:00:00.000Z`);
-}
-
-function utcEndOfYesterday() {
-  const today = utcToday();
-  return new Date(today.getTime() - 1000);
-}
-
-async function getApy(navOracleAddress, shareManagerAddress, chain) {
-  const yesterday = utcEndOfYesterday();
-  const start = new Date(yesterday.getTime() - 24 * 60 * 60 * 1000);
-
-  const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
-  const startEpoch = Math.floor(start.getTime() / 1000);
-
-  return calcApy(
-    navOracleAddress,
-    shareManagerAddress,
-    startEpoch,
-    yesterdayEpoch,
-    1,
-    chain,
-  );
+  const startDecimals = Number(startDecimalsResult.output);
+  const endDecimals = Number(endDecimalsResult.output);
+  return {
+    startShareValue: calculateShareValue(
+      startRecord.newNav,
+      startSupplyResult.output,
+      startDecimals,
+    ),
+    endShareValue: calculateShareValue(
+      endRecord.newNav,
+      endSupplyResult.output,
+      endDecimals,
+    ),
+  };
 }
 
 async function getApy7d(navOracleAddress, shareManagerAddress, chain) {
-  const interval = 7;
-  const yesterday = utcEndOfYesterday();
-  const start = new Date(
-    yesterday.getTime() - (interval - 1) * 24 * 60 * 60 * 1000,
+  const records = await getNavUpdates(navOracleAddress, chain);
+  if (records.length < 2) return 0;
+
+  const asOfIndex = records.length - 1;
+  const endRecord = records[asOfIndex];
+  const startRecord = findClosestNavApyBaseline(
+    records,
+    asOfIndex,
+    TRAILING_WINDOW_DAYS,
+  );
+  if (!startRecord) return 0;
+
+  const { startShareValue, endShareValue } = await getShareValues(
+    startRecord,
+    endRecord,
+    shareManagerAddress,
+    chain,
   );
 
-  const yesterdayEpoch = Math.floor(yesterday.getTime() / 1000);
-  const startEpoch = Math.floor(start.getTime() / 1000);
-
-  return calcApy(
-    navOracleAddress,
-    shareManagerAddress,
-    startEpoch,
-    yesterdayEpoch,
-    interval,
-    chain,
+  return computeCompoundedApy(
+    startShareValue,
+    endShareValue,
+    startRecord.timestamp,
+    endRecord.timestamp,
   );
 }
 
 module.exports = {
+  calculateShareValue,
+  computeCompoundedApy,
+  findClosestNavApyBaseline,
   getBlockByEpoch,
-  getPPSAtBlock,
-  calcApy,
-  getApy,
   getApy7d,
+  parseNavUpdates,
 };

--- a/src/adaptors/liminal-basis/index.js
+++ b/src/adaptors/liminal-basis/index.js
@@ -35,7 +35,7 @@ const PRODUCTS = [
   },
   {
     symbol: 'xBTC',
-    poolMeta: 'Delta-neutral BTC yield',
+    poolMeta: 'Delta-neutral yield',
     deployments: {
       hyperliquidL1: {
         address: '0x97df58CE4489896F4eC7D16B59B64aD0a56243a8',

--- a/src/adaptors/liminal-basis/index.js
+++ b/src/adaptors/liminal-basis/index.js
@@ -10,28 +10,100 @@ const USDC_HYPEREVM = '0xb88339CB7199b77E23DB6E890353E22632Ba630f';
 const USDC_ARBITRUM = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
 const USDC_ETHEREUM = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 
-const XHYPE = {
-  hyperliquidL1: {
-    address: '0xac962fa04bf91b7fd0dc0c5c32414e0ce3c51e03',
-    navOracle: '0xbF97a22B1229B3FfbA65003C01df8bA9e7bfF042',
-    chain: 'hyperliquid',
-    underlyingTokens: [USDC_HYPEREVM],
+const PRODUCTS = [
+  {
+    symbol: 'xHYPE',
+    poolMeta: 'Delta-neutral yield',
+    deployments: {
+      hyperliquidL1: {
+        address: '0xac962fa04bf91b7fd0dc0c5c32414e0ce3c51e03',
+        navOracle: '0xbF97a22B1229B3FfbA65003C01df8bA9e7bfF042',
+        chain: 'hyperliquid',
+        underlyingTokens: [USDC_HYPEREVM],
+      },
+      arbitrum: {
+        address: '0xcffE430E9492966727Ddc60eb183fe93E5a218E4',
+        chain: 'arbitrum',
+        underlyingTokens: [USDC_ARBITRUM],
+      },
+      ethereum: {
+        address: '0xAc962FA04BF91B7fd0DC0c5C32414E0Ce3C51E03',
+        chain: 'ethereum',
+        underlyingTokens: [USDC_ETHEREUM],
+      },
+    },
   },
-  arbitrum: {
-    address: '0xcffE430E9492966727Ddc60eb183fe93E5a218E4',
-    chain: 'arbitrum',
-    underlyingTokens: [USDC_ARBITRUM],
+  {
+    symbol: 'xBTC',
+    poolMeta: 'Delta-neutral BTC yield',
+    deployments: {
+      hyperliquidL1: {
+        address: '0x97df58CE4489896F4eC7D16B59B64aD0a56243a8',
+        navOracle: '0x2A6448fc3A0FAde5811bb0087836a090EaA34715',
+        chain: 'hyperliquid',
+        underlyingTokens: [USDC_HYPEREVM],
+      },
+      arbitrum: {
+        address: '0xA06A65032b78106EA47d122387E40E1fbCBA942d',
+        chain: 'arbitrum',
+        underlyingTokens: [USDC_ARBITRUM],
+      },
+      ethereum: {
+        address: '0x0c0104e35A101de9af2e0cb307A15e1175580Bd5',
+        chain: 'ethereum',
+        underlyingTokens: [USDC_ETHEREUM],
+      },
+    },
   },
-  ethereum: {
-    address: '0xAc962FA04BF91B7fd0DC0c5C32414E0Ce3C51E03',
-    chain: 'ethereum',
-    underlyingTokens: [USDC_ETHEREUM],
+  {
+    symbol: 'xLEND',
+    poolMeta: 'Money market yield',
+    deployments: {
+      hyperliquidL1: {
+        address: '0x95f6d66c09A22e6F2bB693306b3ed69663066cbB',
+        navOracle: '0xdbB4da0f1548F6237DF6960532563804A901C2AE',
+        chain: 'hyperliquid',
+        underlyingTokens: [USDC_HYPEREVM],
+      },
+      arbitrum: {
+        address: '0xD68700e70F1bC9BFc589082b27083f27ac85936C',
+        chain: 'arbitrum',
+        underlyingTokens: [USDC_ARBITRUM],
+      },
+      ethereum: {
+        address: '0xD68700e70F1bC9BFc589082b27083f27ac85936C',
+        chain: 'ethereum',
+        underlyingTokens: [USDC_ETHEREUM],
+      },
+    },
   },
-};
+  {
+    symbol: 'limUSD',
+    poolMeta: 'Diversified Hyperliquid yield',
+    deployments: {
+      hyperliquidL1: {
+        address: '0x1822bd335489d84abdd0779a7dCAeDa0625e83c8',
+        navOracle: '0x47f8d4847f528C18Ea5A6dcb9E0940F6b2977CA7',
+        chain: 'hyperliquid',
+        underlyingTokens: [USDC_HYPEREVM],
+      },
+      arbitrum: {
+        address: '0x9B74D3BD96f54dE689CfFDeb27EE34f68dFf086d',
+        chain: 'arbitrum',
+        underlyingTokens: [USDC_ARBITRUM],
+      },
+      ethereum: {
+        address: '0x9B74D3BD96f54dE689CfFDeb27EE34f68dFf086d',
+        chain: 'ethereum',
+        underlyingTokens: [USDC_ETHEREUM],
+      },
+    },
+  },
+];
 
-async function getTvlUsd() {
+async function getTvlUsd(navOracleAddress) {
   const navResult = await sdk.api.abi.call({
-    target: XHYPE.hyperliquidL1.navOracle,
+    target: navOracleAddress,
     abi: abi.getNAV,
     chain: HYPERLIQUID_L1_CHAIN,
   });
@@ -40,28 +112,33 @@ async function getTvlUsd() {
   return navIn18Decimals.div(1e18).toNumber();
 }
 
-async function main() {
-  const tvlUsd = await getTvlUsd();
+async function getPools(product) {
+  const hubDeployment = product.deployments.hyperliquidL1;
+  const tvlUsd = await getTvlUsd(hubDeployment.navOracle);
   const apyBase7d = await getApy7d(
-    XHYPE.hyperliquidL1.navOracle,
-    XHYPE.hyperliquidL1.address,
-    HYPERLIQUID_L1_CHAIN,
+    hubDeployment.navOracle,
+    hubDeployment.address,
+    HYPERLIQUID_L1_CHAIN
   );
 
-  const pools = Object.entries(XHYPE).map(([key, config]) => ({
+  return Object.entries(product.deployments).map(([key, config]) => ({
     pool: `${config.address}-${config.chain}-${key}`.toLowerCase(),
     chain: utils.formatChain(config.chain),
     project: 'liminal-basis',
-    symbol: 'xHYPE',
+    symbol: product.symbol,
     tvlUsd,
     apyBase: apyBase7d,
     apyBase7d,
     underlyingTokens: config.underlyingTokens,
-    poolMeta: 'Delta-neutral yield',
+    poolMeta: product.poolMeta,
     url: 'https://liminal.money/app/tokenized',
   }));
+}
 
-  return pools.filter((p) => p.tvlUsd > 0);
+async function main() {
+  const pools = await Promise.all(PRODUCTS.map(getPools));
+
+  return pools.flat().filter((p) => p.tvlUsd > 0);
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- add xBTC, xLEND, and limUSD to the existing Liminal Basis adapter
- list every product on Hyperliquid, Arbitrum, and Ethereum
- calculate each product's TVL and 7-day APY from its own HyperEVM NAV Oracle and ShareManager
- preserve the existing xHYPE integration and pool identifiers

## Why

The adapter currently lists only xHYPE. This change adds the other active Liminal products using the same on-chain methodology.

## Validation

- ran the official adapter test suite: 77 tests passed
- adapter returns 12 pools across 4 products and 3 networks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking NAV update events.
  * APY calculations now use NAV updates and share values for improved annualized performance reporting.
  * Added support for multiple Liminal Basis products, including xHYPE, xBTC, xLEND, and limUSD, across supported networks.
  * Pool listings now include product-specific symbols, metadata, TVL, and seven-day APY.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->