### PR TITLE
unexclude yieldfi, its apy feed is live again

### DIFF
--- a/src/adaptors/yieldfi/index.js
+++ b/src/adaptors/yieldfi/index.js
@@ -282,9 +282,10 @@ const poolsFunction = async () => {
   // duplicate call flaked
   const symbols = ['yUSD', 'vyUSD', 'yETH', 'vyETH', 'yBTC', 'vyBTC', 'yPrism', 'yHLP', 'yValos', 'yPYMN'];
   const apys = {};
-  for (const symbol of symbols) {
-    apys[symbol] = await fetchLatestAPY(symbol);
-  }
+  const apyValues = await Promise.all(symbols.map((symbol) => fetchLatestAPY(symbol)));
+  symbols.forEach((symbol, i) => {
+    apys[symbol] = apyValues[i];
+  });
 
   // Process all chains in parallel
   const chainPromises = SUPPORTED_CHAINS.map(async (chain) => {

--- a/src/adaptors/yieldfi/index.js
+++ b/src/adaptors/yieldfi/index.js
@@ -255,18 +255,14 @@ const createPool = (tokenAddress, symbol, chain, tvl, apy) => {
  * @param {string} chain - Blockchain name
  * @returns {Promise<Object|null>} Pool object or null if error
  */
-const processToken = async (tokenAddress, symbol, chain) => {
+const processToken = async (tokenAddress, symbol, chain, apy) => {
   try {
-    const [tvl, apy] = await Promise.all([
-      getTVL(tokenAddress, chain),
-      fetchLatestAPY(symbol)
-    ]);
-
     if (apy === 0) {
       console.log(`No APY data available for ${symbol} on ${chain}`);
       return null;
     }
 
+    const tvl = await getTVL(tokenAddress, chain);
     return createPool(tokenAddress, symbol, chain, tvl, apy);
   } catch (error) {
     console.error(`Error processing ${symbol} on ${chain}:`, error);
@@ -281,42 +277,51 @@ const processToken = async (tokenAddress, symbol, chain) => {
 const poolsFunction = async () => {
   const allPools = [];
 
+  // Fetch each symbol's APY once up front - the same endpoint used to be hit
+  // once per (symbol, chain) in parallel and randomly dropped pools when a
+  // duplicate call flaked
+  const symbols = ['yUSD', 'vyUSD', 'yETH', 'vyETH', 'yBTC', 'vyBTC', 'yPrism', 'yHLP', 'yValos', 'yPYMN'];
+  const apys = {};
+  for (const symbol of symbols) {
+    apys[symbol] = await fetchLatestAPY(symbol);
+  }
+
   // Process all chains in parallel
   const chainPromises = SUPPORTED_CHAINS.map(async (chain) => {
     const tokenPromises = [
-      processToken(YUSD_CONTRACTS[chain], 'yUSD', chain),
-      processToken(VYUSD_CONTRACTS[chain], 'vyUSD', chain),
+      processToken(YUSD_CONTRACTS[chain], 'yUSD', chain, apys['yUSD']),
+      processToken(VYUSD_CONTRACTS[chain], 'vyUSD', chain, apys['vyUSD']),
     ];
 
     // Only process yETH, vyETH, yBTC, vyBTC on Ethereum
     if (chain === 'ethereum') {
       tokenPromises.push(
-        processToken(YETH_CONTRACTS[chain], 'yETH', chain),
-        processToken(VYETH_CONTRACTS[chain], 'vyETH', chain),
-        processToken(YBTC_CONTRACTS[chain], 'yBTC', chain),
-        processToken(VYBTC_CONTRACTS[chain], 'vyBTC', chain),
-        processToken(YPRISM_CONTRACTS[chain], 'yPrism', chain),
-        processToken(YHLP_CONTRACTS[chain], 'yHLP', chain),
-        processToken(YVALOS_CONTRACTS[chain], 'yValos', chain),
-        processToken(YPYMN_CONTRACTS[chain], 'yPYMN', chain)
+        processToken(YETH_CONTRACTS[chain], 'yETH', chain, apys['yETH']),
+        processToken(VYETH_CONTRACTS[chain], 'vyETH', chain, apys['vyETH']),
+        processToken(YBTC_CONTRACTS[chain], 'yBTC', chain, apys['yBTC']),
+        processToken(VYBTC_CONTRACTS[chain], 'vyBTC', chain, apys['vyBTC']),
+        processToken(YPRISM_CONTRACTS[chain], 'yPrism', chain, apys['yPrism']),
+        processToken(YHLP_CONTRACTS[chain], 'yHLP', chain, apys['yHLP']),
+        processToken(YVALOS_CONTRACTS[chain], 'yValos', chain, apys['yValos']),
+        processToken(YPYMN_CONTRACTS[chain], 'yPYMN', chain, apys['yPYMN'])
       );
     }
     if (chain === 'arbitrum' || chain === 'base') {
       tokenPromises.push(
-        processToken(YETH_CONTRACTS[chain], 'yETH', chain),
-        processToken(VYETH_CONTRACTS[chain], 'vyETH', chain)
+        processToken(YETH_CONTRACTS[chain], 'yETH', chain, apys['yETH']),
+        processToken(VYETH_CONTRACTS[chain], 'vyETH', chain, apys['vyETH'])
       );
     }
 
     // Process yETH for saga chain (vyETH not available on saga)
     if (chain === 'saga') {
-      tokenPromises.push(processToken(YETH_CONTRACTS[chain], 'yETH', chain));
+      tokenPromises.push(processToken(YETH_CONTRACTS[chain], 'yETH', chain, apys['yETH']));
       // Note: vyETH is not supported on saga chain - VYETH_CONTRACTS has no saga entry
     }
 
     if (chain === 'bsc') {
       tokenPromises.push(
-        processToken(YPRISM_CONTRACTS[chain], 'yPrism', chain)
+        processToken(YPRISM_CONTRACTS[chain], 'yPrism', chain, apys['yPrism'])
       );
     }
 

--- a/src/utils/exclude.js
+++ b/src/utils/exclude.js
@@ -491,7 +491,6 @@ const excludedProtocols = [
   { id: '2417', slug: 'thena-v1' },
   { id: '2743', slug: 'yama-finance' },
   { id: '686', slug: 'yel-finance' },
-  { id: '5588', slug: 'yieldfi' },
   { id: '3941', slug: 'yldr' },
   { id: '2143', slug: 'zircon-gamma' },
   { id: '1229', slug: 'looksrare' },


### PR DESCRIPTION
yieldfi got excluded on jul 12 - fair call at the time, their ctrl.yield.fi apy feed had been serving 0 since jul 9 so the adapter (fixed in #2792 the same day) had nothing to report. the feed came back today with real numbers (yusd 9.03%, vyusd 9.13%, 383 days of history on the endpoint), so this removes the exclude entry, same as the amnis one in #2793.

also made the adapter fetch each symbol's apy once up front instead of once per (symbol, chain) - it was hitting the same endpoint ~30 times in parallel and random pools dropped whenever a duplicate call flaked (i was getting 18 pools on one run and 30 on the next). with the change the count is stable.

test: 215 passed, 35 pools, 9.9M total across ethereum/saga/base/arbitrum + smaller chains, ran it twice with matching results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YieldFi pool data processing for more consistent APY and TVL results.
  * YieldFi pool APY handling was updated to avoid missing or mismatched APY values in listings.
* **Behavior Changes**
  * YieldFi is no longer excluded by a static safety list and will only be filtered out when flagged by active safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->