### PR TITLE
Add Atoma vault yield adapter

### DIFF
--- a/src/adaptors/atoma/index.js
+++ b/src/adaptors/atoma/index.js
@@ -1,0 +1,48 @@
+const utils = require('../utils');
+const ethers = require('ethers');
+
+const USDC_ARBITRUM = '0xaf88d065e77c8cc2239327c5edb3a432268e5831';
+
+const VAULTS = [
+  {
+    symbol: 'USDC',
+    address: '0xCC56410e1a136aF0eCEb7241c6aE394F4d8b581c',
+    network: 'arbitrum',
+    underlyingToken: USDC_ARBITRUM,
+    underlyingTokenDecimals: 6,
+    poolMeta: 'Extended x Nado',
+  },
+  {
+    symbol: 'USDC',
+    address: '0x1C788E14d8e5B446e3F71B5142e2edaBcAB36da1',
+    network: 'arbitrum',
+    underlyingToken: USDC_ARBITRUM,
+    underlyingTokenDecimals: 6,
+    poolMeta: 'Lighter x Trade[XYZ]',
+  },
+];
+
+const getVaultData = async (timestamp, vault) => {
+  const vaultERC4626Info = await utils.getERC4626Info(vault.address, vault.network, timestamp);
+  const { tvl, ...rest } = vaultERC4626Info;
+  return {
+    ...rest,
+    project: 'atoma',
+    symbol: vault.symbol,
+    underlyingTokens: [vault.underlyingToken],
+    tvlUsd: parseFloat(ethers.utils.formatUnits(tvl, vault.underlyingTokenDecimals)),
+    poolMeta: vault.poolMeta,
+    url: 'https://app.atoma.fi/',
+  };
+};
+
+const apy = async (timestamp) => {
+  return Promise.all(VAULTS.map((vault) => getVaultData(timestamp, vault)));
+};
+
+module.exports = {
+  protocolId: '8300',
+  timetravel: false,
+  apy,
+  url: 'https://app.atoma.fi/',
+};


### PR DESCRIPTION
Adds APY adapter for ATOMA — delta-neutral basis-trading ERC-4626 vaults on Arbitrum.
Two USDC pools (Extended x Nado, Lighter x XYZ). apyBase is computed on-chain from each
vault's convertToAssets() rate over a 24h window; TVL from totalAssets(). No new npm deps.

Update protocolId after PR https://github.com/DefiLlama/DefiLlama-Adapters/pull/20242 is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Atoma vault support on Arbitrum.
  * Added reporting for two USDC vaults, including annual percentage yield data, total value locked, underlying assets, and pool details.
  * Added links to the Atoma application for supported vaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->