### PR TITLE
add royco-v2 yields adapter

### DIFF
--- a/src/adaptors/royco-v2/index.js
+++ b/src/adaptors/royco-v2/index.js
@@ -1,0 +1,101 @@
+const utils = require('../utils');
+
+// Royco serves pools pre-shaped in the DefiLlama schema,
+// so this adapter validates/normalises rather than derives.
+// Docs: https://vault.api.royco.org/docs#tag/defillama/GET/api/v1/defillama/pools
+const API_URL = 'https://vault.api.royco.org/api/v1/defillama/pools';
+
+const PROJECT = 'royco-v2';
+
+// Concrete provides the vault infrastructure behind these two Royco vaults and
+// its API lists them, so the `concrete` adapter already emits (and owns) these
+// pool ids. A pool id may only belong to one project, so they are skipped here
+// to avoid clashing. Drop the entry once `concrete` stops listing the vault.
+const POOL_IDS_OWNED_BY_CONCRETE = new Set([
+  '0xcd9f5907f92818bc06c9ad70217f089e190d2a32-ethereum', // srRoyUSDC
+  '0x41ce72e04d349eb957bdc373baa9c69207032c56-ethereum', // roywstETH
+]);
+
+const toNumber = (v) => (Number.isFinite(v) ? v : undefined);
+
+const toAddresses = (v) => {
+  if (!Array.isArray(v)) return undefined;
+  const out = [
+    ...new Set(
+      v
+        .filter((a) => typeof a === 'string' && a.trim())
+        .map((a) => a.toLowerCase())
+    ),
+  ];
+  return out.length ? out : undefined;
+};
+
+const toText = (v) =>
+  typeof v === 'string' && v.trim() ? v.trim() : undefined;
+
+// The upstream payload is third-party controlled, so fields are picked
+// explicitly: an unexpected key added upstream would otherwise fail the
+// adapter's "allowed field names" test on the next run.
+const normalize = (p) => {
+  const poolId = toText(p.pool)?.toLowerCase();
+  const chain = toText(p.chain);
+  const symbol = toText(p.symbol);
+  if (!poolId || !chain || !symbol) return null;
+  if (POOL_IDS_OWNED_BY_CONCRETE.has(poolId)) return null;
+
+  const rewardTokens = toAddresses(p.rewardTokens);
+  const apyReward = toNumber(p.apyReward);
+
+  const token = poolId.split('-')[0];
+
+  const pricePerShare = toNumber(p.sharePrice);
+
+  return {
+    pool: poolId,
+    chain: utils.formatChain(chain),
+    project: PROJECT,
+    symbol,
+    tvlUsd: toNumber(p.tvlUsd),
+    apyBase: toNumber(p.apyBase),
+    ...(token && { token }),
+    ...(pricePerShare > 0 && { pricePerShare }),
+    // apyReward is only valid alongside the tokens paying it
+    ...(apyReward !== undefined && rewardTokens && { apyReward, rewardTokens }),
+    ...(toAddresses(p.underlyingTokens) && {
+      underlyingTokens: toAddresses(p.underlyingTokens),
+    }),
+    ...(toText(p.poolMeta) && { poolMeta: toText(p.poolMeta) }),
+    ...(toText(p.url) && { url: toText(p.url) }),
+  };
+};
+
+const apy = async () => {
+  const data = await utils.withRetry(() => utils.getData(API_URL));
+
+  if (!Array.isArray(data) || !data.length) {
+    throw new Error(
+      `royco-v2: expected a non-empty array from ${API_URL}, got ${
+        Array.isArray(data) ? 'an empty array' : typeof data
+      }`
+    );
+  }
+
+  const pools = utils
+    .removeDuplicates(data.map(normalize).filter(Boolean))
+    .filter(utils.keepFinite);
+
+  if (!pools.length) {
+    throw new Error(
+      `royco-v2: no valid pools left after filtering ${data.length} entries`
+    );
+  }
+
+  return pools;
+};
+
+module.exports = {
+  protocolId: '7425',
+  timetravel: false,
+  apy,
+  url: 'https://royco.org',
+};


### PR DESCRIPTION
Adds a yields adapter for Royco V2 — tranched credit markets that split a yield-bearing deposit into senior and junior claims, plus a small number of standalone vaults.

Protocol slug `royco-v2` (id `7425`) confirmed via `https://api.llama.fi/protocols`. Already listed on the TVL page.

### Pools (32)

| Chain | Pools | TVL |
|---|---|---|
| Ethereum | 26 | $15,209,691 |
| Avalanche | 2 | $6,235,011 |
| Base | 2 | $1,851,675 |
| Arbitrum | 2 | $1,272,918 |

$24,569,294 total; 22 pools clear the $10k display floor.

Largest positions:

| Chain | Symbol | Market | TVL | apyBase | pricePerShare |
|---|---|---|---|---|---|
| Avalanche | srRoySAVUSD | Staked Avant USD · Senior | $4,825,153 | 8.49% | 0.8631 |
| Ethereum | srRoyAA_FALCONXUSDC | Pareto AA FalconXUSDC · Senior | $2,613,975 | 7.09% | 0.9187 |
| Ethereum | srRoyAPYUSD | Apyx apyUSD · Senior | $2,521,216 | 92.07% | 0.8283 |
| Ethereum | srRoySYRUPUSDC | Maple Finance syrupUSDC · Senior | $2,456,514 | 5.14% | 0.8640 |
| Ethereum | srRoySTCUSD | Staked Cap USD · Senior | $2,415,556 | 4.43% | 0.9438 |
| Base | srRoySUSN | Staked USN · Senior | $1,605,471 | 8.26% | 0.8308 |

### Data source

Sourced from `https://vault.api.royco.org/api/v1/defillama/pools` — a public, unauthenticated endpoint Royco maintains specifically for this integration (documented in their OpenAPI spec under the `defillama` tag).

Royco's `convertToAssets` is non-standard, so APY cannot be calculated directly from the contracts.

### APY methodology

`apyBase` and `sharePrice` (→ `pricePerShare`, underlying-assets-per-share) come from the endpoint. No reward APY is emitted — Royco has no incentive campaigns running. The adapter still gates `apyReward` on a non-empty `rewardTokens`, so if campaigns launch later, points-based or pre-TGE incentives can't leak in.

The adapter picks fields explicitly rather than spreading the upstream response, so a new key added by Royco can't break the allowed-field-names test.

### Two pools deliberately excluded

`srRoyUSDC` (`0xcd9f5907…-ethereum`, $13.0M) and `roywstETH` (`0x41ce72e0…-ethereum`, $220k) are omitted. Concrete provides the vault infrastructure behind them and the `concrete` adapter already owns both pool ids — confirmed live, not stale: both appear in `yields.llama.fi/pools` under `project: concrete` with 79 datapoints and hourly updates. Including them fails the "pool id already used by other project" test.

If maintainers would rather these sit under `royco-v2`, the ids need retiring from `concrete` first; the exclusion is a single labelled constant that can then be dropped.

### Test

```
npm run test --adapter=royco-v2
PASS ./test.js
Test Suites: 1 passed, 1 total
Tests:       293 passed, 293 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying Royco v2 pool data.
  * Added normalized pool information, including chains, symbols, rates, rewards, underlying assets, metadata, and links.
  * Added validation and filtering to exclude incomplete, duplicate, or unsupported pool entries.
  * Added resilient data retrieval with retry handling and clear error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->