### PR TITLE
Add GBLIN Yield Adapter (Base Network) — V6 vault

### DIFF
--- a/src/adaptors/gblin/index.js
+++ b/src/adaptors/gblin/index.js
@@ -1,0 +1,34 @@
+const utils = require('../utils');
+
+const GBLIN_V5 = '0x38DcDB3A381677239BBc652aed9811F2f8496345';
+
+const getApy = async () => {
+  // Recuperiamo i dati del TVL dalla tua dashboard o direttamente on-chain
+  // In questo caso usiamo l'API di DefiLlama che già legge il tuo TVL per semplicità
+  const protocolData = await utils.getData('https://api.llama.fi/protocol/gblin');
+  const tvl = protocolData.tvl[protocolData.tvl.length - 1].totalLiquidityUSD;
+
+  // DefiLlama richiede un valore APY. Poiché GBLIN cresce col volume, 
+  // qui definiamo la pool che gli utenti vedranno.
+  return [{
+    pool: `${GBLIN_V5}-base`.toLowerCase(),
+    chain: utils.formatChain('base'),
+    project: 'gblin',
+    symbol: 'GBLIN',
+    tvlUsd: tvl,
+    apyBase: 0.05, // Rappresenta la fee di apprezzamento fissa ad ogni acquisto
+    underlyingTokens: [
+      '0x4200000000000000000000000000000000000006', // WETH
+      '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf', // cbBTC
+      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'  // USDC
+    ],
+    poolMeta: 'Treasury-backed Appreciation Model',
+    url: 'https://gblin.digital/'
+  }];
+};
+
+module.exports = {
+  timetravel: false,
+  apy: getApy,
+  url: 'https://gblin.digital/',
+};

--- a/src/adaptors/gblin/index.js
+++ b/src/adaptors/gblin/index.js
@@ -17,9 +17,38 @@ const MINTED_TOPIC = ethers.utils.id('Minted(address,uint256,uint256)');
 const STABILITY_FEE_BPS = 5;
 const BPS_DENOMINATOR = 10000;
 
-// Lookback window for APY estimation
-const LOOKBACK_DAYS = 30;
-const BLOCKS_PER_DAY_BASE = 43200; // Base ~2s blocks
+// Lookback window for APY estimation. Kept short to (a) stay within RPC log
+// limits when chunking and (b) limit price-drift error from converting ETH
+// volumes at the end of the window using the current ETH price.
+const LOOKBACK_DAYS = 7;
+const BLOCKS_PER_DAY_BASE = 43200; // Base ~2s blocks (approx, used only for window sizing)
+const CHUNK_SIZE = 9000; // safe under typical eth_getLogs caps (10k)
+
+// Fetch logs in chunks to stay under provider limits
+const fetchLogsChunked = async (fromBlock, toBlock) => {
+  const all = [];
+  for (let start = fromBlock; start <= toBlock; start += CHUNK_SIZE) {
+    const end = Math.min(start + CHUNK_SIZE - 1, toBlock);
+    try {
+      const res = await sdk.api.util.getLogs({
+        target: GBLIN_V5,
+        topic: MINTED_TOPIC,
+        fromBlock: start,
+        toBlock: end,
+        chain: 'base',
+        keys: [],
+      });
+      if (Array.isArray(res?.output)) all.push(...res.output);
+    } catch (e) {
+      // Log and continue: a single failed chunk shouldn't tank the whole APY.
+      // We surface the failure but keep aggregating partial data.
+      console.warn(
+        `GBLIN: getLogs chunk ${start}-${end} failed: ${e.message}`
+      );
+    }
+  }
+  return all;
+};
 
 const getApy = async () => {
   try {
@@ -36,56 +65,58 @@ const getApy = async () => {
     const latest = protocolData.tvl[protocolData.tvl.length - 1];
     const tvlUsd = latest?.totalLiquidityUSD;
 
-    if (!tvlUsd || tvlUsd < 100) {
-      console.warn(`GBLIN: TVL below threshold (${tvlUsd})`);
+    // Allow tiny but valid pools through; only drop if TVL is missing or non-positive.
+    if (typeof tvlUsd !== 'number' || tvlUsd <= 0) {
+      console.warn(`GBLIN: invalid TVL (${tvlUsd})`);
       return [];
     }
+    if (tvlUsd < 100) {
+      console.warn(`GBLIN: tiny TVL (${tvlUsd}) — pool still reported`);
+    }
 
-    // 2) Sum Minted event ETH volumes over the last LOOKBACK_DAYS days
+    // 2) Sum Minted event ETH volumes over the lookback window (chunked)
     const currentBlock = await sdk.api.util.getLatestBlock('base');
     const fromBlock = Math.max(
       0,
       currentBlock.number - BLOCKS_PER_DAY_BASE * LOOKBACK_DAYS
     );
 
-    const logs = await sdk.api.util.getLogs({
-      target: GBLIN_V5,
-      topic: MINTED_TOPIC,
-      fromBlock,
-      toBlock: currentBlock.number,
-      chain: 'base',
-      keys: [],
-    });
+    const logs = await fetchLogsChunked(fromBlock, currentBlock.number);
 
     let totalVolumeWei = 0n;
-    for (const log of logs?.output || []) {
-      // log.data = abi.encode(ethIn, gblinOut) -> first 32 bytes = ethIn
+    for (const log of logs) {
+      // Defensive: malformed entries shouldn't crash the loop
+      if (typeof log?.data !== 'string') continue;
       const dataHex = log.data.startsWith('0x') ? log.data.slice(2) : log.data;
       if (dataHex.length < 64) continue;
+      // log.data = abi.encode(ethIn, gblinOut) -> first 32 bytes = ethIn
       const ethInHex = '0x' + dataHex.slice(0, 64);
-      totalVolumeWei += BigInt(ethInHex);
+      try {
+        totalVolumeWei += BigInt(ethInHex);
+      } catch (_) {
+        // Skip non-hex / corrupted entries silently
+        continue;
+      }
     }
 
     let apyBase = 0;
 
     if (totalVolumeWei > 0n) {
-      // Convert ETH volume to USD (current ETH price)
+      // Compute fees in ETH first to minimize price-drift bias, then convert
+      // the annualized total to USD ONCE using the current ETH price. This is
+      // internally consistent with `tvlUsd` (also a current snapshot).
+      const totalVolumeEth = Number(totalVolumeWei) / 1e18;
+      const periodFeesEth =
+        totalVolumeEth * (STABILITY_FEE_BPS / BPS_DENOMINATOR);
+      const annualizedFeesEth = periodFeesEth * (365 / LOOKBACK_DAYS);
+
       const priceResp = await utils.getData(
         'https://coins.llama.fi/prices/current/coingecko:ethereum'
       );
       const ethUsd = priceResp?.coins?.['coingecko:ethereum']?.price;
 
-      if (ethUsd && ethUsd > 0) {
-        const totalVolumeEth = Number(totalVolumeWei) / 1e18;
-        const totalVolumeUsd = totalVolumeEth * ethUsd;
-
-        // Stability fees accrued in window = volume * 0.05%
-        const periodFeesUsd =
-          totalVolumeUsd * (STABILITY_FEE_BPS / BPS_DENOMINATOR);
-
-        // Annualize (period -> 365d)
-        const annualizedFeesUsd = periodFeesUsd * (365 / LOOKBACK_DAYS);
-
+      if (typeof ethUsd === 'number' && ethUsd > 0) {
+        const annualizedFeesUsd = annualizedFeesEth * ethUsd;
         apyBase = (annualizedFeesUsd / tvlUsd) * 100;
       }
     }

--- a/src/adaptors/gblin/index.js
+++ b/src/adaptors/gblin/index.js
@@ -1,30 +1,113 @@
+const sdk = require('@defillama/sdk');
+const { ethers } = require('ethers');
 const utils = require('../utils');
 
+// === GBLIN V5 — Base mainnet ===
 const GBLIN_V5 = '0x38DcDB3A381677239BBc652aed9811F2f8496345';
 
-const getApy = async () => {
-  // Recuperiamo i dati del TVL dalla tua dashboard o direttamente on-chain
-  // In questo caso usiamo l'API di DefiLlama che già legge il tuo TVL per semplicità
-  const protocolData = await utils.getData('https://api.llama.fi/protocol/gblin');
-  const tvl = protocolData.tvl[protocolData.tvl.length - 1].totalLiquidityUSD;
+// Underlying basket
+const WETH = '0x4200000000000000000000000000000000000006';
+const CBTC = '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf';
+const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 
-  // DefiLlama richiede un valore APY. Poiché GBLIN cresce col volume, 
-  // qui definiamo la pool che gli utenti vedranno.
-  return [{
-    pool: `${GBLIN_V5}-base`.toLowerCase(),
-    chain: utils.formatChain('base'),
-    project: 'gblin',
-    symbol: 'GBLIN',
-    tvlUsd: tvl,
-    apyBase: 0.05, // Rappresenta la fee di apprezzamento fissa ad ogni acquisto
-    underlyingTokens: [
-      '0x4200000000000000000000000000000000000006', // WETH
-      '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf', // cbBTC
-      '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'  // USDC
-    ],
-    poolMeta: 'Treasury-backed Appreciation Model',
-    url: 'https://gblin.digital/'
-  }];
+// Event: Minted(address indexed user, uint256 ethIn, uint256 gblinOut)
+const MINTED_TOPIC = ethers.utils.id('Minted(address,uint256,uint256)');
+
+// Stability Fee = 5 BPS (0.05%) — funds NAV appreciation via distributeYield()
+const STABILITY_FEE_BPS = 5;
+const BPS_DENOMINATOR = 10000;
+
+// Lookback window for APY estimation
+const LOOKBACK_DAYS = 30;
+const BLOCKS_PER_DAY_BASE = 43200; // Base ~2s blocks
+
+const getApy = async () => {
+  try {
+    // 1) Fetch TVL from DefiLlama protocol API (already computed by tvl adapter)
+    const protocolData = await utils.getData(
+      'https://api.llama.fi/protocol/global-balanced-liquidity-index'
+    );
+
+    if (!protocolData?.tvl?.length) {
+      console.warn('GBLIN: TVL array empty or missing');
+      return [];
+    }
+
+    const latest = protocolData.tvl[protocolData.tvl.length - 1];
+    const tvlUsd = latest?.totalLiquidityUSD;
+
+    if (!tvlUsd || tvlUsd < 100) {
+      console.warn(`GBLIN: TVL below threshold (${tvlUsd})`);
+      return [];
+    }
+
+    // 2) Sum Minted event ETH volumes over the last LOOKBACK_DAYS days
+    const currentBlock = await sdk.api.util.getLatestBlock('base');
+    const fromBlock = Math.max(
+      0,
+      currentBlock.number - BLOCKS_PER_DAY_BASE * LOOKBACK_DAYS
+    );
+
+    const logs = await sdk.api.util.getLogs({
+      target: GBLIN_V5,
+      topic: MINTED_TOPIC,
+      fromBlock,
+      toBlock: currentBlock.number,
+      chain: 'base',
+      keys: [],
+    });
+
+    let totalVolumeWei = 0n;
+    for (const log of logs?.output || []) {
+      // log.data = abi.encode(ethIn, gblinOut) -> first 32 bytes = ethIn
+      const dataHex = log.data.startsWith('0x') ? log.data.slice(2) : log.data;
+      if (dataHex.length < 64) continue;
+      const ethInHex = '0x' + dataHex.slice(0, 64);
+      totalVolumeWei += BigInt(ethInHex);
+    }
+
+    let apyBase = 0;
+
+    if (totalVolumeWei > 0n) {
+      // Convert ETH volume to USD (current ETH price)
+      const priceResp = await utils.getData(
+        'https://coins.llama.fi/prices/current/coingecko:ethereum'
+      );
+      const ethUsd = priceResp?.coins?.['coingecko:ethereum']?.price;
+
+      if (ethUsd && ethUsd > 0) {
+        const totalVolumeEth = Number(totalVolumeWei) / 1e18;
+        const totalVolumeUsd = totalVolumeEth * ethUsd;
+
+        // Stability fees accrued in window = volume * 0.05%
+        const periodFeesUsd =
+          totalVolumeUsd * (STABILITY_FEE_BPS / BPS_DENOMINATOR);
+
+        // Annualize (period -> 365d)
+        const annualizedFeesUsd = periodFeesUsd * (365 / LOOKBACK_DAYS);
+
+        apyBase = (annualizedFeesUsd / tvlUsd) * 100;
+      }
+    }
+
+    return [
+      {
+        pool: `${GBLIN_V5}-base`.toLowerCase(),
+        chain: utils.formatChain('base'),
+        project: 'gblin',
+        symbol: 'GBLIN',
+        tvlUsd,
+        apyBase,
+        underlyingTokens: [WETH, CBTC, USDC],
+        poolMeta:
+          'NAV appreciation from protocol fees (0.05% stability fee per mint)',
+        url: 'https://gblin.digital/',
+      },
+    ];
+  } catch (err) {
+    console.error('GBLIN adapter error:', err.message);
+    return [];
+  }
 };
 
 module.exports = {

--- a/src/adaptors/gblin/index.js
+++ b/src/adaptors/gblin/index.js
@@ -2,24 +2,6 @@ const sdk = require('@defillama/sdk');
 const { ethers } = require('ethers');
 const utils = require('../utils');
 
-// === GBLIN V5 — Base mainnet ===
-const GBLIN_V5 = '0x38DcDB3A381677239BBc652aed9811F2f8496345';
-
-// Underlying basket
-const WETH = '0x4200000000000000000000000000000000000006';
-const CBTC = '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf';
-const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
-
-// Event: Minted(address indexed user, uint256 ethIn, uint256 gblinOut)
-const MINTED_TOPIC = ethers.utils.id('Minted(address,uint256,uint256)');
-
-// Stability Fee = 5 BPS (0.05%) — funds NAV appreciation via distributeYield()
-const STABILITY_FEE_BPS = 5;
-const BPS_DENOMINATOR = 10000;
-const sdk = require('@defillama/sdk');
-const { ethers } = require('ethers');
-const utils = require('../utils');
-
 // GBLIN V6 — Base mainnet
 const GBLIN_V6 = '0x36C81d7E1966310F305eA637e761Cf77F90852f0';
 
@@ -41,125 +23,12 @@ const BLOCKS_PER_DAY_BASE = 43200; // Base ~2s blocks
 const CHUNK_SIZE = 9000;
 
 const fetchLogsChunked = async (fromBlock, toBlock) => {
-    const all = [];
-    for (let start = fromBlock; start <= toBlock; start += CHUNK_SIZE) {
-          const end = Math.min(start + CHUNK_SIZE - 1, toBlock);
-          try {
-                  const res = await sdk.api.util.getLogs({
-                            target: GBLIN_V6,
-                            topic: MINTED_TOPIC,
-                            fromBlock: start,
-                            toBlock: end,
-                            chain: 'base',
-                            keys: [],
-                  });
-                  if (Array.isArray(res?.output)) all.push(...res.output);
-          } catch (e) {
-                  console.warn(`GBLIN: getLogs chunk ${start}-${end} failed: ${e.message}`);
-          }
-    }
-    return all;
-};
-
-const getApy = async () => {
-    try {
-          const protocolData = await utils.getData(
-                  'https://api.llama.fi/protocol/global-balanced-liquidity-index'
-                );
-
-          if (!protocolData?.tvl?.length) {
-                  console.warn('GBLIN: TVL array empty or missing');
-                  return [];
-          }
-
-          const latest = protocolData.tvl[protocolData.tvl.length - 1];
-          const tvlUsd = latest?.totalLiquidityUSD;
-
-          if (typeof tvlUsd !== 'number' || tvlUsd <= 0) {
-                  console.warn(`GBLIN: invalid TVL (${tvlUsd})`);
-                  return [];
-          }
-
-          const currentBlock = await sdk.api.util.getLatestBlock('base');
-          const fromBlock = Math.max(
-                  0,
-                  currentBlock.number - BLOCKS_PER_DAY_BASE * LOOKBACK_DAYS
-                );
-
-          const logs = await fetchLogsChunked(fromBlock, currentBlock.number);
-
-          let totalVolumeWei = 0n;
-          for (const log of logs) {
-                  if (typeof log?.data !== 'string') continue;
-                  const dataHex = log.data.startsWith('0x') ? log.data.slice(2) : log.data;
-                  if (dataHex.length < 64) continue;
-                  const ethInHex = '0x' + dataHex.slice(0, 64);
-                  try {
-                            totalVolumeWei += BigInt(ethInHex);
-                  } catch (_) {
-                            continue;
-                  }
-          }
-
-          let apyBase = 0;
-
-          if (totalVolumeWei > 0n) {
-                  const totalVolumeEth = Number(totalVolumeWei) / 1e18;
-                  const periodFeesEth =
-                            totalVolumeEth * (STABILITY_FEE_BPS / BPS_DENOMINATOR);
-                  const annualizedFeesEth = periodFeesEth * (365 / LOOKBACK_DAYS);
-
-                  const priceResp = await utils.getData(
-                            'https://coins.llama.fi/prices/current/coingecko:ethereum'
-                          );
-                  const ethUsd = priceResp?.coins?.['coingecko:ethereum']?.price;
-
-                  if (typeof ethUsd === 'number' && ethUsd > 0) {
-                            const annualizedFeesUsd = annualizedFeesEth * ethUsd;
-                            apyBase = (annualizedFeesUsd / tvlUsd) * 100;
-                  }
-          }
-
-          return [
-            {
-                      pool: `${GBLIN_V6}-base`.toLowerCase(),
-                      chain: utils.formatChain('base'),
-                      project: 'gblin',
-                      symbol: 'GBLIN',
-                      tvlUsd,
-                      apyBase,
-                      underlyingTokens: [WETH, CBTC, USDC],
-                      poolMeta:
-                                  'NAV appreciation from protocol fees (0.05% stability fee per mint)',
-                      url: 'https://gblin.digital/',
-            },
-                ];
-    } catch (err) {
-          console.error('GBLIN adapter error:', err.message);
-          return [];
-    }
-};
-
-module.exports = {
-    timetravel: false,
-    apy: getApy,
-    url: 'https://gblin.digital/',
-};
-// Lookback window for APY estimation. Kept short to (a) stay within RPC log
-// limits when chunking and (b) limit price-drift error from converting ETH
-// volumes at the end of the window using the current ETH price.
-const LOOKBACK_DAYS = 7;
-const BLOCKS_PER_DAY_BASE = 43200; // Base ~2s blocks (approx, used only for window sizing)
-const CHUNK_SIZE = 9000; // safe under typical eth_getLogs caps (10k)
-
-// Fetch logs in chunks to stay under provider limits
-const fetchLogsChunked = async (fromBlock, toBlock) => {
   const all = [];
   for (let start = fromBlock; start <= toBlock; start += CHUNK_SIZE) {
     const end = Math.min(start + CHUNK_SIZE - 1, toBlock);
     try {
       const res = await sdk.api.util.getLogs({
-        target: GBLIN_V5,
+        target: GBLIN_V6,
         topic: MINTED_TOPIC,
         fromBlock: start,
         toBlock: end,
@@ -168,11 +37,7 @@ const fetchLogsChunked = async (fromBlock, toBlock) => {
       });
       if (Array.isArray(res?.output)) all.push(...res.output);
     } catch (e) {
-      // Log and continue: a single failed chunk shouldn't tank the whole APY.
-      // We surface the failure but keep aggregating partial data.
-      console.warn(
-        `GBLIN: getLogs chunk ${start}-${end} failed: ${e.message}`
-      );
+      console.warn(`GBLIN: getLogs chunk ${start}-${end} failed: ${e.message}`);
     }
   }
   return all;
@@ -180,7 +45,6 @@ const fetchLogsChunked = async (fromBlock, toBlock) => {
 
 const getApy = async () => {
   try {
-    // 1) Fetch TVL from DefiLlama protocol API (already computed by tvl adapter)
     const protocolData = await utils.getData(
       'https://api.llama.fi/protocol/global-balanced-liquidity-index'
     );
@@ -193,16 +57,11 @@ const getApy = async () => {
     const latest = protocolData.tvl[protocolData.tvl.length - 1];
     const tvlUsd = latest?.totalLiquidityUSD;
 
-    // Allow tiny but valid pools through; only drop if TVL is missing or non-positive.
     if (typeof tvlUsd !== 'number' || tvlUsd <= 0) {
       console.warn(`GBLIN: invalid TVL (${tvlUsd})`);
       return [];
     }
-    if (tvlUsd < 100) {
-      console.warn(`GBLIN: tiny TVL (${tvlUsd}) — pool still reported`);
-    }
 
-    // 2) Sum Minted event ETH volumes over the lookback window (chunked)
     const currentBlock = await sdk.api.util.getLatestBlock('base');
     const fromBlock = Math.max(
       0,
@@ -213,16 +72,13 @@ const getApy = async () => {
 
     let totalVolumeWei = 0n;
     for (const log of logs) {
-      // Defensive: malformed entries shouldn't crash the loop
       if (typeof log?.data !== 'string') continue;
       const dataHex = log.data.startsWith('0x') ? log.data.slice(2) : log.data;
       if (dataHex.length < 64) continue;
-      // log.data = abi.encode(ethIn, gblinOut) -> first 32 bytes = ethIn
       const ethInHex = '0x' + dataHex.slice(0, 64);
       try {
         totalVolumeWei += BigInt(ethInHex);
       } catch (_) {
-        // Skip non-hex / corrupted entries silently
         continue;
       }
     }
@@ -230,9 +86,6 @@ const getApy = async () => {
     let apyBase = 0;
 
     if (totalVolumeWei > 0n) {
-      // Compute fees in ETH first to minimize price-drift bias, then convert
-      // the annualized total to USD ONCE using the current ETH price. This is
-      // internally consistent with `tvlUsd` (also a current snapshot).
       const totalVolumeEth = Number(totalVolumeWei) / 1e18;
       const periodFeesEth =
         totalVolumeEth * (STABILITY_FEE_BPS / BPS_DENOMINATOR);
@@ -251,7 +104,7 @@ const getApy = async () => {
 
     return [
       {
-        pool: `${GBLIN_V5}-base`.toLowerCase(),
+        pool: `${GBLIN_V6}-base`.toLowerCase(),
         chain: utils.formatChain('base'),
         project: 'gblin',
         symbol: 'GBLIN',

--- a/src/adaptors/gblin/index.js
+++ b/src/adaptors/gblin/index.js
@@ -16,7 +16,135 @@ const MINTED_TOPIC = ethers.utils.id('Minted(address,uint256,uint256)');
 // Stability Fee = 5 BPS (0.05%) — funds NAV appreciation via distributeYield()
 const STABILITY_FEE_BPS = 5;
 const BPS_DENOMINATOR = 10000;
+const sdk = require('@defillama/sdk');
+const { ethers } = require('ethers');
+const utils = require('../utils');
 
+// GBLIN V6 — Base mainnet
+const GBLIN_V6 = '0x36C81d7E1966310F305eA637e761Cf77F90852f0';
+
+// Underlying basket
+const WETH = '0x4200000000000000000000000000000000000006';
+const CBTC = '0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf';
+const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+// Event: Minted(address indexed user, uint256 ethIn, uint256 gblinOut)
+const MINTED_TOPIC = ethers.utils.id('Minted(address,uint256,uint256)');
+
+// Stability Fee = 5 BPS (0.05%) — funds NAV appreciation via distributeYield()
+const STABILITY_FEE_BPS = 5;
+const BPS_DENOMINATOR = 10000;
+
+// 7-day window: stays within RPC log limits when chunking
+const LOOKBACK_DAYS = 7;
+const BLOCKS_PER_DAY_BASE = 43200; // Base ~2s blocks
+const CHUNK_SIZE = 9000;
+
+const fetchLogsChunked = async (fromBlock, toBlock) => {
+    const all = [];
+    for (let start = fromBlock; start <= toBlock; start += CHUNK_SIZE) {
+          const end = Math.min(start + CHUNK_SIZE - 1, toBlock);
+          try {
+                  const res = await sdk.api.util.getLogs({
+                            target: GBLIN_V6,
+                            topic: MINTED_TOPIC,
+                            fromBlock: start,
+                            toBlock: end,
+                            chain: 'base',
+                            keys: [],
+                  });
+                  if (Array.isArray(res?.output)) all.push(...res.output);
+          } catch (e) {
+                  console.warn(`GBLIN: getLogs chunk ${start}-${end} failed: ${e.message}`);
+          }
+    }
+    return all;
+};
+
+const getApy = async () => {
+    try {
+          const protocolData = await utils.getData(
+                  'https://api.llama.fi/protocol/global-balanced-liquidity-index'
+                );
+
+          if (!protocolData?.tvl?.length) {
+                  console.warn('GBLIN: TVL array empty or missing');
+                  return [];
+          }
+
+          const latest = protocolData.tvl[protocolData.tvl.length - 1];
+          const tvlUsd = latest?.totalLiquidityUSD;
+
+          if (typeof tvlUsd !== 'number' || tvlUsd <= 0) {
+                  console.warn(`GBLIN: invalid TVL (${tvlUsd})`);
+                  return [];
+          }
+
+          const currentBlock = await sdk.api.util.getLatestBlock('base');
+          const fromBlock = Math.max(
+                  0,
+                  currentBlock.number - BLOCKS_PER_DAY_BASE * LOOKBACK_DAYS
+                );
+
+          const logs = await fetchLogsChunked(fromBlock, currentBlock.number);
+
+          let totalVolumeWei = 0n;
+          for (const log of logs) {
+                  if (typeof log?.data !== 'string') continue;
+                  const dataHex = log.data.startsWith('0x') ? log.data.slice(2) : log.data;
+                  if (dataHex.length < 64) continue;
+                  const ethInHex = '0x' + dataHex.slice(0, 64);
+                  try {
+                            totalVolumeWei += BigInt(ethInHex);
+                  } catch (_) {
+                            continue;
+                  }
+          }
+
+          let apyBase = 0;
+
+          if (totalVolumeWei > 0n) {
+                  const totalVolumeEth = Number(totalVolumeWei) / 1e18;
+                  const periodFeesEth =
+                            totalVolumeEth * (STABILITY_FEE_BPS / BPS_DENOMINATOR);
+                  const annualizedFeesEth = periodFeesEth * (365 / LOOKBACK_DAYS);
+
+                  const priceResp = await utils.getData(
+                            'https://coins.llama.fi/prices/current/coingecko:ethereum'
+                          );
+                  const ethUsd = priceResp?.coins?.['coingecko:ethereum']?.price;
+
+                  if (typeof ethUsd === 'number' && ethUsd > 0) {
+                            const annualizedFeesUsd = annualizedFeesEth * ethUsd;
+                            apyBase = (annualizedFeesUsd / tvlUsd) * 100;
+                  }
+          }
+
+          return [
+            {
+                      pool: `${GBLIN_V6}-base`.toLowerCase(),
+                      chain: utils.formatChain('base'),
+                      project: 'gblin',
+                      symbol: 'GBLIN',
+                      tvlUsd,
+                      apyBase,
+                      underlyingTokens: [WETH, CBTC, USDC],
+                      poolMeta:
+                                  'NAV appreciation from protocol fees (0.05% stability fee per mint)',
+                      url: 'https://gblin.digital/',
+            },
+                ];
+    } catch (err) {
+          console.error('GBLIN adapter error:', err.message);
+          return [];
+    }
+};
+
+module.exports = {
+    timetravel: false,
+    apy: getApy,
+    url: 'https://gblin.digital/',
+};
 // Lookback window for APY estimation. Kept short to (a) stay within RPC log
 // limits when chunking and (b) limit price-drift error from converting ETH
 // volumes at the end of the window using the current ETH price.

--- a/src/adaptors/global-balanced-liquidity-index/index.js
+++ b/src/adaptors/global-balanced-liquidity-index/index.js
@@ -106,7 +106,7 @@ const getApy = async () => {
       {
         pool: `${GBLIN_V6}-base`.toLowerCase(),
         chain: utils.formatChain('base'),
-        project: 'gblin',
+        project: 'global-balanced-liquidity-index',
         symbol: 'GBLIN',
         tvlUsd,
         apyBase,
@@ -123,6 +123,7 @@ const getApy = async () => {
 };
 
 module.exports = {
+  protocolId: '7577',
   timetravel: false,
   apy: getApy,
   url: 'https://gblin.digital/',


### PR DESCRIPTION
**Project Description:**
GBLIN is a wealth preservation protocol on Base. APY is generated via an "Appreciation Model" where 0.05% of every buy transaction is routed to the treasury (WETH, cbBTC, USDC) without minting new tokens, mathematically increasing the NAV for all holders.

**Methodology:**
APY is calculated based on the 0.05% stability fee collected per mint (buy), annualized over a 7-day lookback window using on-chain `Minted` event logs from the V6 vault contract. TVL is fetched from the DefiLlama protocol API (`global-balanced-liquidity-index`).

**TVL adapter:** Already live in DefiLlama-Adapters via `registries/sumTokens/data3.js` (V6 vault `0x36C81d7E1966310F305eA637e761Cf77F90852f0`, merged in PR #19746).

**Changes vs previous PR #2641:**
- Updated vault address from V5 (`0x38Dc...`) to V6 (`0x36C8...`)
- - Removed $10k TVL hard gate (adapter returns pool regardless, APY is 0 if no recent mints)
- - Cleaner code with no duplicate declarations
**Chain:** Base
**Contract:** `0x36C81d7E1966310F305eA637e761Cf77F90852f0`
**Basket:** WETH + cbBTC + USDC
**Project slug:** `gblin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added APY tracking for GBLIN V6 on Base.
  * Displays current TVL and estimated annual percentage yield based on recent minting activity and protocol fees.
  * Includes pool token details and a link to the protocol website.
  * Supports reliable historical event retrieval across RPC block ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->