### PR TITLE
Add supply caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ interface Pool {
   apyBaseBorrow?: number;
   apyRewardBorrow?: number;
   totalSupplyUsd?: number;
+  supplyCapUsd?: number; // protocol supply cap in USD at sample-time price; omit when uncapped (e.g. aave supplyCap of 0), never emit 0
   totalBorrowUsd?: number;
   availableBorrowUsd?: number; // current available borrow liquidity in USD, accounting for caps and constraints; do not zero solely because borrowable is false
   borrowToken?: string; // underlying token address/string the borrower receives; not a debt receipt token

--- a/src/adaptors/aave-v3/index.js
+++ b/src/adaptors/aave-v3/index.js
@@ -181,6 +181,7 @@ const getApy = async (market) => {
         price;
       const borrowCapUsd = Number(poolsReserveCaps[i].borrowCap) * price;
       const hasBorrowCap = Number(poolsReserveCaps[i].borrowCap) > 0;
+      const supplyCap = Number(poolsReserveCaps[i].supplyCap);
       // Core Ethereum GHO is minted by the Aave facilitator, so available
       // liquidity is constrained by remaining borrow cap, not reserve cash.
       let availableBorrowUsd = null;
@@ -222,6 +223,7 @@ const getApy = async (market) => {
         apyBase: (p.liquidityRate / 10 ** 27) * 100,
         underlyingTokens: [pool.tokenAddress],
         totalSupplyUsd,
+        ...(supplyCap > 0 && { supplyCapUsd: supplyCap * price }),
         totalBorrowUsd,
         availableBorrowUsd,
         apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
@@ -272,6 +274,7 @@ const getApyAptos = async () => {
       const tvlUsd = totalSupplyUsd - totalBorrowUsd;
       const borrowCapUsd = Number(r.borrowCap) * priceUsd;
       const hasBorrowCap = Number(r.borrowCap) > 0;
+      const supplyCap = Number(r.supplyCap);
       const availableBorrowUsd = hasBorrowCap
         ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
         : tvlUsd;
@@ -285,6 +288,7 @@ const getApyAptos = async () => {
         apyBase: (Number(r.liquidityRate) / 10 ** 27) * 100,
         underlyingTokens: [r.underlyingAsset],
         totalSupplyUsd,
+        ...(supplyCap > 0 && { supplyCapUsd: supplyCap * priceUsd }),
         totalBorrowUsd,
         availableBorrowUsd,
         apyBaseBorrow: Number(r.variableBorrowRate) / 1e25,

--- a/src/adaptors/aave-v3/index.js
+++ b/src/adaptors/aave-v3/index.js
@@ -166,6 +166,10 @@ const getApy = async (market) => {
         (isGho ? ghoPrice : undefined);
       const decimals = Number(underlyingDecimals[i]);
 
+      // totalSupplyUsd is the claims side (aToken supply). On reserves carrying
+      // a v3.3 bad-debt deficit (pool.getReserveDeficit) it exceeds cash+debt,
+      // which is what the Aave UI shows as "total supplied". Kept as claims on
+      // purpose: it is the quantity the on-chain supply cap validates against.
       const supply = isGho ? p.totalAToken : totalSupply[i];
       const totalSupplyUsd = (supply / 10 ** decimals) * price;
 

--- a/src/adaptors/test.js
+++ b/src/adaptors/test.js
@@ -40,6 +40,7 @@ describe(`Running ${process.env.npm_config_adapter} Test`, () => {
       'apyBaseBorrow',
       'apyRewardBorrow',
       'totalSupplyUsd',
+      'supplyCapUsd',
       'totalBorrowUsd',
       'ltv',
       'borrowable',
@@ -209,6 +210,11 @@ describe(`Running ${process.env.npm_config_adapter} Test`, () => {
     let additionalFieldRules = {
       totalSupplyUsd: {
         type: 'number',
+      },
+      // supply cap in USD; omitted when uncapped (never 0)
+      supplyCapUsd: {
+        type: 'number',
+        min: 0,
       },
       totalBorrowUsd: {
         type: 'number',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional USD-denominated supply cap data to Aave v3 pools when a positive protocol cap is available.
  * Documented the `supplyCapUsd` field, including guidance for uncapped markets.

* **Bug Fixes**
  * Improved pool data validation to accept and verify optional supply cap values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->