### PR TITLE
add zensats adapter

### DIFF
--- a/src/adaptors/zensats/index.js
+++ b/src/adaptors/zensats/index.js
@@ -77,8 +77,15 @@ const apy = async (timestamp) => {
 
   return VAULTS.map((v, i) => {
     const price = pricesByAddress[v.underlyingToken.toLowerCase()];
-    const total = Number(totalAssets.output[i]?.output);
-    if (!price || !Number.isFinite(total)) return null;
+    const totalRes = totalAssets.output[i];
+    const total = Number(totalRes?.output);
+    if (
+      !price ||
+      totalRes?.success === false ||
+      !Number.isFinite(total) ||
+      total <= 0
+    )
+      return null;
 
     const unit = 10 ** v.decimals;
     const current = Number(ppsNow.output[i]?.output);

--- a/src/adaptors/zensats/index.js
+++ b/src/adaptors/zensats/index.js
@@ -93,12 +93,17 @@ const apy = async (timestamp) => {
 
     const unit = 10 ** v.decimals;
     const current = Number(ppsNow.output[i]?.output);
+    // Without a current share price there is no APY to report. Drop the pool
+    // rather than publishing apyBase: 0, which would overwrite the last good
+    // value with a rate the vault never paid.
+    if (!(current > 0)) return null;
 
-    // Annualized share-price growth over `days`, or null when either endpoint
-    // is missing — a vault deployed inside the window, or a failed archive call.
+    // Annualized share-price growth over `days`, or null when the historical
+    // endpoint is missing — a vault deployed inside the window, or a failed
+    // archive call. Then apyBase: 0 is correct: no growth has been observed.
     const growth = (pastRes, days) => {
       const past = Number(pastRes.output[i]?.output);
-      if (!(current > 0) || !(past > 0)) return null;
+      if (!(past > 0)) return null;
       const value = ((current / past) ** (365 / days) - 1) * 100;
       return Number.isFinite(value) ? value : null;
     };
@@ -114,7 +119,7 @@ const apy = async (timestamp) => {
       tvlUsd: (total / unit) * price,
       apyBase: apyBase7d ?? apyBase1d ?? 0,
       ...(apyBase7d !== null && { apyBase7d }),
-      ...(current > 0 && { pricePerShare: current / unit }),
+      pricePerShare: current / unit,
       underlyingTokens: [v.underlyingToken],
       token: v.address,
       poolMeta: v.poolMeta,

--- a/src/adaptors/zensats/index.js
+++ b/src/adaptors/zensats/index.js
@@ -6,18 +6,12 @@ const CHAIN = 'ethereum';
 const URL = 'https://zensats.app';
 
 const DAY = 86400;
+const LOOKBACK_DAYS = 7;
 
-// ZenSats "Zenji" vaults are ERC-4626 leverage loops: the collateral asset is
-// deposited, USDT is borrowed against it on LlamaLend and the proceeds are
-// looped back in. Yield accrues into the share price, so apyBase is the growth
-// of convertToAssets(1 share).
-//
-// The share price is denominated in the collateral asset while the debt is
-// stablecoin-denominated, so it is NOT monotonic — it marks to market with the
-// collateral/debt price ratio. A 24h window annualises that noise (both vaults
-// read negative over 24h while their 7d/14d/30d growth was positive), so the
-// 7 day growth is reported as apyBase and the 24h figure is only a fallback
-// for when the 7d reading is unusable (same approach as the geth adapter).
+// ZenSats Zenji vaults are ERC-4626 leverage loops on LlamaLend. Yield accrues
+// into share price (convertToAssets). Share price marks to market with the
+// collateral/debt ratio, so a 24h window is noisy — apyBase uses 7d growth
+// instead of the 1d window in utils.getERC4626Info.
 const VAULTS = [
   {
     address: '0x18E2F4F2E6565187fce73ECC707579E5F7933f74',
@@ -42,27 +36,24 @@ const CONVERT_TO_ASSETS_ABI =
 
 const apy = async (timestamp) => {
   const now = timestamp || Math.floor(Date.now() / 1e3);
-  const [block7d, block1d] = await Promise.all(
-    [7, 1].map((days) =>
-      utils
-        .getPriceApiData(`/block/${CHAIN}/${now - days * DAY}`)
-        .then((r) => r.height)
+  const block7d = (
+    await utils.getPriceApiData(
+      `/block/${CHAIN}/${now - LOOKBACK_DAYS * DAY}`
     )
-  );
+  ).height;
 
   const { pricesByAddress } = await utils.getPrices(
-    [...new Set(VAULTS.map((v) => v.underlyingToken))],
+    VAULTS.map((v) => v.underlyingToken),
     CHAIN
   );
 
-  // convertToAssets is quoted per whole share, so scale by the share decimals
-  // (which equal the underlying's decimals on these vaults).
-  const calls = VAULTS.map((v) => ({
+  // convertToAssets is per whole share; share decimals match underlying here.
+  const shareCalls = VAULTS.map((v) => ({
     target: v.address,
     params: [(10n ** BigInt(v.decimals)).toString()],
   }));
 
-  const [totalAssets, ppsNow, pps7d, pps1d] = await Promise.all([
+  const [totalAssets, ppsNow, pps7d] = await Promise.all([
     sdk.api.abi.multiCall({
       calls: VAULTS.map((v) => ({ target: v.address })),
       abi: 'uint256:totalAssets',
@@ -70,20 +61,18 @@ const apy = async (timestamp) => {
       permitFailure: true,
     }),
     sdk.api.abi.multiCall({
-      calls,
+      calls: shareCalls,
       abi: CONVERT_TO_ASSETS_ABI,
       chain: CHAIN,
       permitFailure: true,
     }),
-    ...[block7d, block1d].map((block) =>
-      sdk.api.abi.multiCall({
-        calls,
-        abi: CONVERT_TO_ASSETS_ABI,
-        chain: CHAIN,
-        block,
-        permitFailure: true,
-      })
-    ),
+    sdk.api.abi.multiCall({
+      calls: shareCalls,
+      abi: CONVERT_TO_ASSETS_ABI,
+      chain: CHAIN,
+      block: block7d,
+      permitFailure: true,
+    }),
   ]);
 
   return VAULTS.map((v, i) => {
@@ -93,23 +82,17 @@ const apy = async (timestamp) => {
 
     const unit = 10 ** v.decimals;
     const current = Number(ppsNow.output[i]?.output);
-    // Without a current share price there is no APY to report. Drop the pool
-    // rather than publishing apyBase: 0, which would overwrite the last good
-    // value with a rate the vault never paid.
+    const past = Number(pps7d.output[i]?.output);
+    // Drop the pool if share price is unreadable rather than publishing
+    // apyBase: 0 (would overwrite the last good rate).
     if (!(current > 0)) return null;
 
-    // Annualized share-price growth over `days`, or null when the historical
-    // endpoint is missing — a vault deployed inside the window, or a failed
-    // archive call. Then apyBase: 0 is correct: no growth has been observed.
-    const growth = (pastRes, days) => {
-      const past = Number(pastRes.output[i]?.output);
-      if (!(past > 0)) return null;
-      const value = ((current / past) ** (365 / days) - 1) * 100;
-      return Number.isFinite(value) ? value : null;
-    };
-
-    const apyBase7d = growth(pps7d, 7);
-    const apyBase1d = growth(pps1d, 1);
+    let apyBase = null;
+    if (past > 0) {
+      const value =
+        ((current / past) ** (365 / LOOKBACK_DAYS) - 1) * 100;
+      apyBase = Number.isFinite(value) ? value : null;
+    }
 
     return {
       pool: `${v.address}-${CHAIN}`.toLowerCase(),
@@ -117,8 +100,7 @@ const apy = async (timestamp) => {
       project: PROJECT,
       symbol: v.symbol,
       tvlUsd: (total / unit) * price,
-      apyBase: apyBase7d ?? apyBase1d ?? 0,
-      ...(apyBase7d !== null && { apyBase7d }),
+      apyBase,
       pricePerShare: current / unit,
       underlyingTokens: [v.underlyingToken],
       token: v.address,

--- a/src/adaptors/zensats/index.js
+++ b/src/adaptors/zensats/index.js
@@ -1,0 +1,131 @@
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+const PROJECT = 'zensats';
+const CHAIN = 'ethereum';
+const URL = 'https://zensats.app';
+
+const DAY = 86400;
+
+// ZenSats "Zenji" vaults are ERC-4626 leverage loops: the collateral asset is
+// deposited, USDT is borrowed against it on LlamaLend and the proceeds are
+// looped back in. Yield accrues into the share price, so apyBase is the growth
+// of convertToAssets(1 share).
+//
+// The share price is denominated in the collateral asset while the debt is
+// stablecoin-denominated, so it is NOT monotonic — it marks to market with the
+// collateral/debt price ratio. A 24h window annualises that noise (both vaults
+// read negative over 24h while their 7d/14d/30d growth was positive), so the
+// 7 day growth is reported as apyBase and the 24h figure is only a fallback
+// for when the 7d reading is unusable (same approach as the geth adapter).
+const VAULTS = [
+  {
+    address: '0x18E2F4F2E6565187fce73ECC707579E5F7933f74',
+    symbol: 'WBTC',
+    underlyingToken: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+    decimals: 8,
+    poolMeta: 'USDT/crvUSD LlamaLend StakeDAO',
+    url: `${URL}/vault/wbtc-llamalend`,
+  },
+  {
+    address: '0x23F189dE34EED95f6303CfF1C77f7676F211Dd2c',
+    symbol: 'wstETH',
+    underlyingToken: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
+    decimals: 18,
+    poolMeta: 'USDT/crvUSD LlamaLend StakeDAO',
+    url: `${URL}/vault/wsteth-llamalend`,
+  },
+];
+
+const CONVERT_TO_ASSETS_ABI =
+  'function convertToAssets(uint256 shares) view returns (uint256)';
+
+const apy = async (timestamp) => {
+  const now = timestamp || Math.floor(Date.now() / 1e3);
+  const [block7d, block1d] = await Promise.all(
+    [7, 1].map((days) =>
+      utils
+        .getPriceApiData(`/block/${CHAIN}/${now - days * DAY}`)
+        .then((r) => r.height)
+    )
+  );
+
+  const { pricesByAddress } = await utils.getPrices(
+    [...new Set(VAULTS.map((v) => v.underlyingToken))],
+    CHAIN
+  );
+
+  // convertToAssets is quoted per whole share, so scale by the share decimals
+  // (which equal the underlying's decimals on these vaults).
+  const calls = VAULTS.map((v) => ({
+    target: v.address,
+    params: [(10n ** BigInt(v.decimals)).toString()],
+  }));
+
+  const [totalAssets, ppsNow, pps7d, pps1d] = await Promise.all([
+    sdk.api.abi.multiCall({
+      calls: VAULTS.map((v) => ({ target: v.address })),
+      abi: 'uint256:totalAssets',
+      chain: CHAIN,
+      permitFailure: true,
+    }),
+    sdk.api.abi.multiCall({
+      calls,
+      abi: CONVERT_TO_ASSETS_ABI,
+      chain: CHAIN,
+      permitFailure: true,
+    }),
+    ...[block7d, block1d].map((block) =>
+      sdk.api.abi.multiCall({
+        calls,
+        abi: CONVERT_TO_ASSETS_ABI,
+        chain: CHAIN,
+        block,
+        permitFailure: true,
+      })
+    ),
+  ]);
+
+  return VAULTS.map((v, i) => {
+    const price = pricesByAddress[v.underlyingToken.toLowerCase()];
+    const total = Number(totalAssets.output[i]?.output);
+    if (!price || !Number.isFinite(total)) return null;
+
+    const unit = 10 ** v.decimals;
+    const current = Number(ppsNow.output[i]?.output);
+
+    // Annualized share-price growth over `days`, or null when either endpoint
+    // is missing — a vault deployed inside the window, or a failed archive call.
+    const growth = (pastRes, days) => {
+      const past = Number(pastRes.output[i]?.output);
+      if (!(current > 0) || !(past > 0)) return null;
+      const value = ((current / past) ** (365 / days) - 1) * 100;
+      return Number.isFinite(value) ? value : null;
+    };
+
+    const apyBase7d = growth(pps7d, 7);
+    const apyBase1d = growth(pps1d, 1);
+
+    return {
+      pool: `${v.address}-${CHAIN}`.toLowerCase(),
+      chain: utils.formatChain(CHAIN),
+      project: PROJECT,
+      symbol: v.symbol,
+      tvlUsd: (total / unit) * price,
+      apyBase: apyBase7d ?? apyBase1d ?? 0,
+      ...(apyBase7d !== null && { apyBase7d }),
+      ...(current > 0 && { pricePerShare: current / unit }),
+      underlyingTokens: [v.underlyingToken],
+      token: v.address,
+      poolMeta: v.poolMeta,
+      url: v.url,
+    };
+  }).filter(Boolean);
+};
+
+module.exports = {
+  protocolId: '7621',
+  timetravel: false,
+  apy,
+  url: URL,
+};


### PR DESCRIPTION
Adds a yields adapter for ZenSats — ERC-4626 "Zenji" leverage-loop vaults that deposit a collateral asset, borrow USDT against it on LlamaLend, and loop the proceeds back in.

Protocol slug `zensats` (id 7621) confirmed via https://api.llama.fi/protocols. Already listed on the TVL page.

### Pools (2)

| Chain | Pools | TVL |
|---|---|---|
| Ethereum | 2 | $11,114 |

$11,114 total; 1 pool clears the $10k display floor. Both vaults launched 2026-06-13, so balances are still small.

| Chain | Symbol | Market | TVL | apyBase | pricePerShare |
|---|---|---|---|---|---|
| Ethereum | WBTC | USDT/crvUSD LlamaLend StakeDAO | $10,074 | 3.95% | 1.001482 |
| Ethereum | wstETH | USDT/crvUSD LlamaLend StakeDAO | $1,040 | 3.69% | 1.001522 |

### Data source

Entirely on-chain, no API. `totalAssets()` for TVL and `convertToAssets(1 share)` for share price, batched via `sdk.api.abi.multiCall` with `permitFailure: true`. Historical share prices use blocks resolved through `utils.getPriceApiData('/block/ethereum/{ts}')`, underlying prices via `utils.getPrices`.

Both vaults are standard ERC-4626. Verified on-chain that `asset()` matches the configured underlying, that the asset symbol matches the configured `symbol`, and that share decimals equal asset decimals (8 for WBTC, 18 for wstETH) — the `convertToAssets` scaling depends on the last one.

### APY methodology

`apyBase` is the annualized growth of `convertToAssets(1 share)` over a **7 day** window, and the same figure is emitted as `apyBase7d`. The 24h figure is computed as well, but used only as a fallback for when the 7d reading is unusable (vault younger than the window, or a failed archive call). This follows the `geth` adapter.

Not the 24h window, because these are leverage loops: the share price is collateral-denominated while the debt is stablecoin-denominated, so it marks to market with the collateral/debt ratio and is not monotonic. The 24h readings measured +2.32% and −2.38% while 7d/14d/30d growth was positive throughout, and a negative `apyBase` is clamped to 0 downstream — so the wstETH pool would publish 0% instead of 3.69%.

Harvests are discrete, so a single harvest inside the window visibly moves the number at this size. Both vaults were harvested during testing: WBTC went 3.26% → 3.95% and wstETH 2.94% → 3.69%, each off one ~0.014% step in share price. The 7d window damps this considerably relative to 24h but doesn't eliminate it.

No `apyReward` or `rewardTokens` — these vaults pay no incentive tokens, and no points or pre-TGE incentives are included.

### Three pools deliberately excluded

The TVL registry entry also lists three pmUSD/crvUSD StakeDAO vaults, omitted here for now:

| Vault | Asset | totalAssets |
|---|---|---|
| `0x617A6877…` | WBTC | 0 |
| `0xbaEc8343…` | wstETH | 0 |
| `0x7d5281D5…` | XAUt | 0.0359 (~$145) |

Two are empty. They are older contracts and they are deprecated.

Neither included pool id is claimed by another projellama.fi/pools`, both return no existing match.

### Test

```
npm run test --adapter=zensats
PASS ./test.js
Test Suites: 1 passed, 1 total
Tests:       23 passed, 23 total
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ZenSats ERC-4626 “Zenji” vault support for WBTC and wstETH.
  * Calculates TVL (USD), price-per-share, and an annualized APY using a 7-day on-chain share-to-asset comparison.
  * Includes ZenSats adapter metadata and links for discoverability.
* **Bug Fixes**
  * Improved result robustness by discarding vaults when required inputs are missing, conversions are invalid, or `totalAssets` is non-positive or failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->