### PR TITLE
fix aave merkl rewards

### DIFF
--- a/src/adaptors/merkl/merkl-additional-reward.js
+++ b/src/adaptors/merkl/merkl-additional-reward.js
@@ -1,5 +1,5 @@
 const { networks, chainAliases } = require('./config');
-const { merklGet } = require('./merkl-client');
+const { merklGet, getRewardApr } = require('./merkl-client');
 
 const getChainAliases = (canonical) =>
   chainAliases[canonical] || [canonical];
@@ -77,9 +77,10 @@ exports.addMerklRewardApy = async (
           pool.rewardsRecord?.breakdowns.map(x => x.token.address) || [],
         ),
       ];
+      const apr = getRewardApr(pool);
       const entry = isBorrow
-        ? { apyRewardBorrow: pool.apr, rewardTokens }
-        : { apyReward: pool.apr, rewardTokens };
+        ? { apyRewardBorrow: apr, rewardTokens }
+        : { apyReward: apr, rewardTokens };
       const id = pool.identifier.toLowerCase();
       // Also index under each token address so adapters keying on a
       // receipt/wrapper token (e.g. an aToken or vault share) can match

--- a/src/adaptors/merkl/merkl-by-identifier.js
+++ b/src/adaptors/merkl/merkl-by-identifier.js
@@ -1,4 +1,4 @@
-const { merklGet } = require('./merkl-client');
+const { merklGet, getRewardApr } = require('./merkl-client');
 
 // Chain ID mapping for Merkl API
 const CHAIN_IDS = {
@@ -57,7 +57,8 @@ const getMerklRewardsByIdentifier = async (
     if (!data || data.length === 0) return null;
 
     const opportunity = data[0];
-    if (!opportunity.apr || opportunity.apr <= 0) return null;
+    const apyReward = getRewardApr(opportunity);
+    if (!apyReward || apyReward <= 0) return null;
 
     const rewardTokens =
       opportunity.rewardsRecord?.breakdowns
@@ -70,7 +71,7 @@ const getMerklRewardsByIdentifier = async (
     }
 
     return {
-      apyReward: opportunity.apr, // Merkl returns APR as percentage
+      apyReward, // Merkl returns APR as percentage
       rewardTokens: [...new Set(rewardTokens)],
     };
   } catch (e) {

--- a/src/adaptors/merkl/merkl-client.js
+++ b/src/adaptors/merkl/merkl-client.js
@@ -24,8 +24,34 @@ const merklGet = async (pathOrUrl, options = {}) => {
   return res.data;
 };
 
+// Aave "net APR" campaigns top the market rate up to a target APR instead of
+// paying on top of it, and Merkl reports the *target* in `apr` rather than the
+// incremental part it actually distributes. Subtract the market rate Merkl
+// already counted (`nativeApr`) so it isn't double counted against apyBase.
+const TARGET_APR_DISTRIBUTION_TYPES = new Set([
+  'AAVE_NET_APR',
+  'AAVE_V4_NET_APR',
+]);
+
+const getRewardApr = (opportunity) => {
+  const breakdowns = opportunity.aprRecord?.breakdowns?.filter(
+    (x) => x.type === 'CAMPAIGN'
+  );
+  if (!breakdowns?.length) return opportunity.apr;
+
+  return breakdowns.reduce(
+    (acc, x) =>
+      acc +
+      (TARGET_APR_DISTRIBUTION_TYPES.has(x.distributionType)
+        ? Math.max(0, x.value - (opportunity.nativeApr || 0))
+        : x.value),
+    0
+  );
+};
+
 module.exports = {
   MERKL_BASE_URL: BASE_URL,
   getMerklHeaders,
   merklGet,
+  getRewardApr,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward APR calculations for Merkl opportunities.
  * Prevented native market APR from being counted twice in applicable campaign rewards.
  * Correctly separates borrowing and non-borrowing reward APR values.
  * Opportunities with missing or non-positive reward APRs are now handled more reliably.
  * Added support for calculating rewards from detailed campaign breakdowns, with fallback behavior when breakdown data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->