### PR TITLE
feat(k613): add xK613 reward apy (supply + borrow)

### DIFF
--- a/src/adaptors/k613/index.js
+++ b/src/adaptors/k613/index.js
@@ -181,8 +181,8 @@ const apy = async () => {
         symbol: pool.symbol,
         tvlUsd,
         apyBase: (Number(p.liquidityRate) / 10 ** 27) * 100,
-        ...(apyReward != null && {
-          apyReward,
+        ...(apyReward != null && { apyReward }),
+        ...((apyReward != null || apyRewardBorrow != null) && {
           rewardTokens: [XK613],
         }),
         underlyingTokens: [pool.tokenAddress],

--- a/src/adaptors/k613/index.js
+++ b/src/adaptors/k613/index.js
@@ -4,9 +4,17 @@ const utils = require('../utils');
 const poolAbi = require('../aave-v3/poolAbi');
 
 const PROTOCOL_DATA_PROVIDER = '0xfc87bE7f3657AAD69baDb6247A88E924D1F8bc53';
+const REWARDS_CONTROLLER = '0xe1d8B642c83587Df813a36F361C682C0475c4ea4';
+const XK613 = '0x9064d55A8A8473fA39c41A16492Fa1094Eb4E8b5';
+const K613 = '0xb09582631336068d4B0089d943f40CbF46dE5189';
 const CHAIN = 'monad';
 const PROJECT = 'k613';
 const APP_URL = 'https://k613.net';
+const SECONDS_PER_YEAR = 31536000;
+
+// (index, emissionPerSecond, lastUpdateTimestamp, distributionEnd)
+const rewardsDataAbi =
+  'function getRewardsData(address asset, address reward) view returns (uint256, uint256, uint256, uint256)';
 
 const apy = async () => {
   const reserveTokens = (
@@ -79,12 +87,64 @@ const apy = async () => {
     })
   ).output.map((o) => o.output);
 
+  const reserveTokensAddresses = (
+    await sdk.api.abi.multiCall({
+      calls: reserveTokens.map((p) => ({
+        target: PROTOCOL_DATA_PROVIDER,
+        params: p.tokenAddress,
+      })),
+      abi: poolAbi.find((m) => m.name === 'getReserveTokensAddresses'),
+      chain: CHAIN,
+    })
+  ).output.map((o) => o.output);
+
+  const supplyRewards = (
+    await sdk.api.abi.multiCall({
+      calls: aTokens.map((t) => ({
+        target: REWARDS_CONTROLLER,
+        params: [t.tokenAddress, XK613],
+      })),
+      abi: rewardsDataAbi,
+      chain: CHAIN,
+      permitFailure: true,
+    })
+  ).output.map((o) => o.output);
+
+  const borrowRewards = (
+    await sdk.api.abi.multiCall({
+      calls: reserveTokensAddresses.map((t) => ({
+        target: REWARDS_CONTROLLER,
+        params: [t.variableDebtTokenAddress, XK613],
+      })),
+      abi: rewardsDataAbi,
+      chain: CHAIN,
+      permitFailure: true,
+    })
+  ).output.map((o) => o.output);
+
   const priceKeys = reserveTokens
     .map((t) => `${CHAIN}:${t.tokenAddress}`)
+    .concat(`${CHAIN}:${K613}`)
     .join(',');
   const prices = (
     await utils.getPriceApiData(`/prices/current/${priceKeys}`)
   ).coins;
+  // xK613 is backed 1:1 by K613, so K613's price is used for reward emissions
+  const k613Price = prices[`${CHAIN}:${K613}`]?.price;
+
+  const now = Math.floor(Date.now() / 1000);
+  // getRewardsData -> [index, emissionPerSecond, lastUpdateTimestamp, distributionEnd]
+  const rewardApy = (data, denomUsd) => {
+    if (!k613Price || !data || !denomUsd) return null;
+    const emissionPerSecond = Number(data[1]);
+    const distributionEnd = Number(data[3]);
+    if (!(emissionPerSecond > 0) || distributionEnd <= now) return null;
+    return (
+      (((emissionPerSecond / 1e18) * SECONDS_PER_YEAR * k613Price) /
+        denomUsd) *
+      100
+    );
+  };
 
   const pools = reserveTokens
     .map((pool, i) => {
@@ -111,6 +171,9 @@ const apy = async () => {
         ? Math.max(Math.min(tvlUsd, borrowCapUsd - totalBorrowUsd), 0)
         : tvlUsd;
 
+      const apyReward = rewardApy(supplyRewards[i], totalSupplyUsd);
+      const apyRewardBorrow = rewardApy(borrowRewards[i], totalBorrowUsd);
+
       return {
         pool: `${aTokens[i].tokenAddress}-${CHAIN}`.toLowerCase(),
         chain: utils.formatChain(CHAIN),
@@ -118,12 +181,17 @@ const apy = async () => {
         symbol: pool.symbol,
         tvlUsd,
         apyBase: (Number(p.liquidityRate) / 10 ** 27) * 100,
+        ...(apyReward != null && {
+          apyReward,
+          rewardTokens: [XK613],
+        }),
         underlyingTokens: [pool.tokenAddress],
         totalSupplyUsd,
         ...(supplyCap > 0 && { supplyCapUsd: supplyCap * price }),
         totalBorrowUsd,
         availableBorrowUsd,
         apyBaseBorrow: Number(p.variableBorrowRate) / 1e25,
+        ...(apyRewardBorrow != null && { apyRewardBorrow }),
         borrowToken: pool.tokenAddress,
         ltv: Number(cfg.ltv) / 10000,
         borrowable: cfg.borrowingEnabled,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reward emission APY calculations for both lending and borrowing activity.
  * Shows active reward APYs (when available) and the corresponding reward token alongside existing APY metrics.
  * Avoids misleading outputs by returning no reward APY when reward data is missing, invalid, or rewards are inactive/expired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->