### PR TITLE
accountable: set pool token to the vault share token

### DIFF
--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -216,6 +216,7 @@ const apy = async() => {
 
             return {
                 pool: `${item.loan_address}-${chainName}`.toLowerCase(),
+                token: vaultAddress ?? null,
                 chain: utils.formatChain(chainName),
                 project: 'accountable',
                 symbol: item.asset_symbol,


### PR DESCRIPTION
Our pool ids are `<loan_address>-<chain>`, so `extractTokenFromPoolId` resolves the pool's `token` to the loan (strategy) contract. That contract is not an ERC-20 (`totalSupply()` and `symbol()` revert), so every Accountable pool ends up with a token address that has no holders.

The share token is the vault, which the adapter already resolves on-chain via `vault()` in `fetchLoanMeta`, so this just passes it through. Pools where the `vault()` call fails send an explicit `null` instead of falling back to the loan address.

Verified locally: 17 pools, all with a `token` set, TVL and APY unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pool information now includes the associated vault address when available.
  - Pools without an available vault address display a null value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->