### PR TITLE
feat(ekubo): add Robinhood ve33 STONX yields

### DIFF
--- a/src/adaptors/ekubo/index.js
+++ b/src/adaptors/ekubo/index.js
@@ -1,12 +1,12 @@
 const utils = require('../utils');
 const { chunk } = require('lodash');
-const ethers = require('ethers');
+const sdk = require('@defillama/sdk');
 
 const API_URL = 'https://prod-api.ekubo.org';
 const ETHEREUM_CHAIN_ID = '0x1';
 const STARKNET_CHAIN_ID = '0x534e5f4d41494e';
 const ROBINHOOD_CHAIN_ID = '0x1237';
-const ROBINHOOD_RPC_URL = 'https://rpc.mainnet.chain.robinhood.com';
+const ROBINHOOD_SDK_CHAIN = 'robinhood';
 const VE33_ADDRESS = '0xd18685a514e59b06d59824e16db07e73345d9953';
 const VE33_DATA_FETCHER_ADDRESS = '0x61f03754b1c7a7f0e584fd8869c00ba898ab888d';
 const STONX_ADDRESS = '0x570c5aa79c798e7a418412cc8399ae5bcce570c5';
@@ -18,9 +18,8 @@ const Q64 = 1n << 64n;
 const Q32 = 1n << 32n;
 const SECONDS_PER_DAY = 86400n;
 
-const VE33_DATA_FETCHER_ABI = [
-  'function getEmissionState() view returns (tuple(uint64 currentTimestamp, uint160 currentEmissionRate, uint256 totalRemainingEmissions, tuple(uint64 time, int256 emissionRateDelta, uint160 emissionRateAfter)[] futureEmissionRateChanges) state)',
-];
+const GET_EMISSION_STATE_ABI =
+  'function getEmissionState() view returns (tuple(uint64 currentTimestamp, uint160 currentEmissionRate, uint256 totalRemainingEmissions, tuple(uint64 time, int256 emissionRateDelta, uint160 emissionRateAfter)[] futureEmissionRateChanges) state)';
 
 const LEGACY_STARKNET_POOL_IDS_BY_CANONICAL_ID = {
   'ekubo-0x534e5f4d41494e-0x5dd3d2f4429af886cd1a3b08289dbcea99a294197e9eb43b0e0325b4b-0x01002120c2f49c83a9d777123a4061cd371cfc24fb40cddd9bd8450ce3f464ac':
@@ -309,12 +308,12 @@ async function getVe33Data(normalizedChainId) {
 
   let currentEmissionRate = null;
   try {
-    const emissionState = await new ethers.Contract(
-      VE33_DATA_FETCHER_ADDRESS,
-      VE33_DATA_FETCHER_ABI,
-      new ethers.providers.StaticJsonRpcProvider(ROBINHOOD_RPC_URL, 4663)
-    ).getEmissionState();
-    currentEmissionRate = BigInt(emissionState.currentEmissionRate.toString());
+    const { output: emissionState } = await sdk.api.abi.call({
+      target: VE33_DATA_FETCHER_ADDRESS,
+      abi: GET_EMISSION_STATE_ABI,
+      chain: ROBINHOOD_SDK_CHAIN,
+    });
+    currentEmissionRate = BigInt(emissionState.currentEmissionRate);
   } catch (error) {
     console.error(
       `Ekubo ve33 emission-state fetch failed for chain ${normalizedChainId}: ${error.message}`

--- a/src/adaptors/ekubo/index.js
+++ b/src/adaptors/ekubo/index.js
@@ -295,26 +295,33 @@ function buildCampaignRewards(campaigns, tokenByKey) {
 async function getVe33Data(normalizedChainId) {
   if (normalizedChainId !== normalizeChainId(ROBINHOOD_CHAIN_ID)) return null;
 
-  const [poolsResponse, emissionState] = await Promise.all([
-    utils.getData(
-      `${API_URL}/ve33/${VE33_ADDRESS}/pools?chainId=${normalizedChainId}&pageSize=200`,
-    ),
-    new ethers.Contract(
-      VE33_DATA_FETCHER_ADDRESS,
-      VE33_DATA_FETCHER_ABI,
-      new ethers.providers.StaticJsonRpcProvider(ROBINHOOD_RPC_URL, 4663),
-    ).getEmissionState(),
-  ]);
+  try {
+    const [poolsResponse, emissionState] = await Promise.all([
+      utils.getData(
+        `${API_URL}/ve33/${VE33_ADDRESS}/pools?chainId=${normalizedChainId}&pageSize=200`,
+      ),
+      new ethers.Contract(
+        VE33_DATA_FETCHER_ADDRESS,
+        VE33_DATA_FETCHER_ABI,
+        new ethers.providers.StaticJsonRpcProvider(ROBINHOOD_RPC_URL, 4663),
+      ).getEmissionState(),
+    ]);
 
-  const poolsById = new Map(
-    poolsResponse.data.map((pool) => [BigInt(pool.pool_id).toString(), pool]),
-  );
+    const poolsById = new Map(
+      poolsResponse.data.map((pool) => [BigInt(pool.pool_id).toString(), pool]),
+    );
 
-  return {
-    poolsById,
-    totalVoteWeight: BigInt(poolsResponse.total_vote_weight),
-    currentEmissionRate: BigInt(emissionState.currentEmissionRate.toString()),
-  };
+    return {
+      poolsById,
+      totalVoteWeight: BigInt(poolsResponse.total_vote_weight),
+      currentEmissionRate: BigInt(emissionState.currentEmissionRate.toString()),
+    };
+  } catch (error) {
+    console.error(
+      `Ekubo ve33 data fetch failed for chain ${normalizedChainId}: ${error.message}`,
+    );
+    return null;
+  }
 }
 
 function getVe33Reward(ve33Data, poolInfo, stonxToken, tvlUsd) {

--- a/src/adaptors/ekubo/index.js
+++ b/src/adaptors/ekubo/index.js
@@ -158,7 +158,7 @@ function getLegacyPoolId(chainId, canonicalPoolId) {
 
 function getCanonicalPoolId(chainId, poolInfo) {
   return `ekubo-${formatNumericHex(chainId)}-${formatNumericHex(
-    poolInfo.core_address,
+    poolInfo.core_address
   )}-${formatNumericHex(poolInfo.pool_id, 64)}`.toLowerCase();
 }
 
@@ -185,7 +185,7 @@ function getPoolUrl(chainId, poolInfo) {
       : 'evm';
 
   return `https://ekubo.org/${chainPath}/charts/pool/${chainId}/${formatNumericHex(
-    poolInfo.core_address,
+    poolInfo.core_address
   )}/${formatNumericHex(poolInfo.pool_id, 64)}`;
 }
 
@@ -266,11 +266,11 @@ function buildCampaignRewards(campaigns, tokenByKey) {
       const depthUsd =
         getAmountUsd(
           tokenByKey[normalizeTokenRef(campaign.chain_id, pair.token0)],
-          pair.depth0,
+          pair.depth0
         ) +
         getAmountUsd(
           tokenByKey[normalizeTokenRef(campaign.chain_id, pair.token1)],
-          pair.depth1,
+          pair.depth1
         );
 
       if (!depthUsd) continue;
@@ -283,7 +283,7 @@ function buildCampaignRewards(campaigns, tokenByKey) {
 
       existing.apyReward += (dailyRewardUsd * 365 * 100) / depthUsd;
       existing.rewardTokens.add(
-        formatTokenAddress(campaign.chain_id, rewardToken.address),
+        formatTokenAddress(campaign.chain_id, rewardToken.address)
       );
       rewardsByPair.set(pairKey, existing);
     }
@@ -298,17 +298,17 @@ async function getVe33Data(normalizedChainId) {
   try {
     const [poolsResponse, emissionState] = await Promise.all([
       utils.getData(
-        `${API_URL}/ve33/${VE33_ADDRESS}/pools?chainId=${normalizedChainId}&pageSize=200`,
+        `${API_URL}/ve33/${VE33_ADDRESS}/pools?chainId=${normalizedChainId}&pageSize=200`
       ),
       new ethers.Contract(
         VE33_DATA_FETCHER_ADDRESS,
         VE33_DATA_FETCHER_ABI,
-        new ethers.providers.StaticJsonRpcProvider(ROBINHOOD_RPC_URL, 4663),
+        new ethers.providers.StaticJsonRpcProvider(ROBINHOOD_RPC_URL, 4663)
       ).getEmissionState(),
     ]);
 
     const poolsById = new Map(
-      poolsResponse.data.map((pool) => [BigInt(pool.pool_id).toString(), pool]),
+      poolsResponse.data.map((pool) => [BigInt(pool.pool_id).toString(), pool])
     );
 
     return {
@@ -318,7 +318,7 @@ async function getVe33Data(normalizedChainId) {
     };
   } catch (error) {
     console.error(
-      `Ekubo ve33 data fetch failed for chain ${normalizedChainId}: ${error.message}`,
+      `Ekubo ve33 data fetch failed for chain ${normalizedChainId}: ${error.message}`
     );
     return null;
   }
@@ -345,13 +345,70 @@ function getVe33Reward(ve33Data, poolInfo, stonxToken, tvlUsd) {
   };
 }
 
+function isVe33Pool(poolInfo) {
+  return (
+    poolInfo.extension !== undefined &&
+    BigInt(poolInfo.extension) === BigInt(VE33_ADDRESS)
+  );
+}
+
+function buildVe33VoterPools(ve33Data, tokenByAddr) {
+  if (!ve33Data) return [];
+
+  const chainId = ROBINHOOD_CHAIN_ID;
+  const stonxToken = tokenByAddr[normalizeTokenRef(chainId, STONX_ADDRESS)];
+  if (!stonxToken?.usd_price) return [];
+
+  return [...ve33Data.poolsById.values()]
+    .map((pool) => {
+      const token0 = tokenByAddr[normalizeTokenRef(chainId, pool.token0)];
+      const token1 = tokenByAddr[normalizeTokenRef(chainId, pool.token1)];
+      if (!token0 || !token1) return null;
+
+      const voteWeightUsd = getAmountUsd(
+        stonxToken,
+        pool.pool_total_vote_weight
+      );
+      if (voteWeightUsd < MIN_TVL_USD) return null;
+
+      const voterFeesUsd = getLiquidityUsd(
+        token0,
+        token1,
+        pool.ve33_fees0_24h,
+        pool.ve33_fees1_24h
+      );
+      const rewardTokens = [
+        BigInt(pool.ve33_fees0_24h) > 0n ? token0.address : null,
+        BigInt(pool.ve33_fees1_24h) > 0n ? token1.address : null,
+      ]
+        .filter(Boolean)
+        .map((address) => formatTokenAddress(chainId, address));
+
+      return {
+        pool: `ekubo-vestonx-${formatNumericHex(pool.pool_id, 64)}`,
+        chain: utils.formatChain('robinhood'),
+        project: 'ekubo',
+        symbol: 'veSTONX',
+        underlyingTokens: [formatTokenAddress(chainId, STONX_ADDRESS)],
+        tvlUsd: voteWeightUsd,
+        apyReward: (voterFeesUsd * 365 * 100) / voteWeightUsd,
+        rewardTokens,
+        poolMeta: `${token0.symbol}-${token1.symbol} voter fees`,
+        url: `https://ekubo.org/evm/STONX/vote?pool=${encodeURIComponent(
+          pool.pool_key_id
+        )}`,
+      };
+    })
+    .filter(Boolean);
+}
+
 async function getChainData({ normalizedChainId }) {
   const query = `chainId=${encodeURIComponent(normalizedChainId)}`;
 
   const [tokens, pairData, campaigns, ve33Data] = await Promise.all([
     utils.getData(`${API_URL}/tokens?${query}&pageSize=10000`),
     utils.getData(
-      `${API_URL}/overview/pairs?${query}&minTvlUsd=${MIN_TVL_USD}`,
+      `${API_URL}/overview/pairs?${query}&minTvlUsd=${MIN_TVL_USD}`
     ),
     utils.getData(`${API_URL}/campaigns?${query}`),
     getVe33Data(normalizedChainId),
@@ -361,16 +418,18 @@ async function getChainData({ normalizedChainId }) {
   let topPoolFailureCount = 0;
   for (const pairsBatch of chunk(
     pairData.topPairs,
-    TOP_POOL_REQUEST_CONCURRENCY,
+    TOP_POOL_REQUEST_CONCURRENCY
   )) {
     const batchEntries = await Promise.all(
       pairsBatch.map(async (pair) => {
         const pairKey = getPairKey(pair.chain_id, pair.token0, pair.token1);
         try {
           const pools = await utils.getData(
-            `${API_URL}/pair/${encodeURIComponent(normalizedChainId)}/${encodeURIComponent(
-              pair.token0,
-            )}/${encodeURIComponent(pair.token1)}/pools?minTvlUsd=${MIN_TVL_USD}`,
+            `${API_URL}/pair/${encodeURIComponent(
+              normalizedChainId
+            )}/${encodeURIComponent(pair.token0)}/${encodeURIComponent(
+              pair.token1
+            )}/pools?minTvlUsd=${MIN_TVL_USD}`
           );
           const topPools = pools?.topPools || [];
           if (topPools.length === 0) return null;
@@ -378,23 +437,23 @@ async function getChainData({ normalizedChainId }) {
           return [pairKey, topPools];
         } catch (error) {
           console.error(
-            `Ekubo top pool fetch failed for chain ${normalizedChainId} pair ${pairKey}: ${error.message}`,
+            `Ekubo top pool fetch failed for chain ${normalizedChainId} pair ${pairKey}: ${error.message}`
           );
           return { error: true, pairKey };
         }
-      }),
+      })
     );
     const failedEntries = batchEntries.filter((entry) => entry?.error);
     topPoolFailureCount += failedEntries.length;
 
     if (topPoolFailureCount > MAX_TOP_POOL_FAILURES) {
       throw new Error(
-        `Ekubo top pool fetch failures exceeded threshold for chain ${normalizedChainId}: ${topPoolFailureCount}`,
+        `Ekubo top pool fetch failures exceeded threshold for chain ${normalizedChainId}: ${topPoolFailureCount}`
       );
     }
 
     topPoolEntries.push(
-      ...batchEntries.filter((entry) => entry && !entry.error),
+      ...batchEntries.filter((entry) => entry && !entry.error)
     );
   }
 
@@ -403,7 +462,7 @@ async function getChainData({ normalizedChainId }) {
     tokens,
     pairs: pairData.topPairs,
     topPoolsByPair: new Map(
-      topPoolEntries.filter(([, pools]) => pools?.length),
+      topPoolEntries.filter(([, pools]) => pools?.length)
     ),
     campaigns: campaigns.campaigns,
     ve33Data,
@@ -414,7 +473,7 @@ async function apy() {
   const results = await Promise.all(CHAINS.map(getChainData));
   const tokens = results.flatMap((result) => result.tokens);
   const topPoolsByPair = new Map(
-    results.flatMap((result) => [...result.topPoolsByPair.entries()]),
+    results.flatMap((result) => [...result.topPoolsByPair.entries()])
   );
   const tokenByAddr = {};
   for (const token of tokens) {
@@ -423,15 +482,15 @@ async function apy() {
 
   const campaignRewards = buildCampaignRewards(
     results.flatMap((result) => result.campaigns),
-    tokenByAddr,
+    tokenByAddr
   );
   const ve33DataByChainId = new Map(
     results
       .filter((result) => result.ve33Data)
-      .map((result) => [result.normalizedChainId, result.ve33Data]),
+      .map((result) => [result.normalizedChainId, result.ve33Data])
   );
 
-  return results
+  const liquidityPools = results
     .flatMap((result) => result.pairs)
     .map((p) => {
       const chainId = p.chain_id;
@@ -443,7 +502,7 @@ async function apy() {
       const campaignReward =
         campaignRewards.get(getPairKey(chainId, p.token0, p.token1)) || null;
       const topPools = topPoolsByPair.get(
-        getPairKey(chainId, p.token0, p.token1),
+        getPairKey(chainId, p.token0, p.token1)
       );
 
       if (!topPools?.length) return [];
@@ -454,7 +513,7 @@ async function apy() {
             token0,
             token1,
             topPool.tvl0_total,
-            topPool.tvl1_total,
+            topPool.tvl1_total
           );
 
           if (tvlUsd < MIN_TVL_USD) return null;
@@ -463,33 +522,26 @@ async function apy() {
             token0,
             token1,
             topPool.fees0_24h,
-            topPool.fees1_24h,
+            topPool.fees1_24h
           );
           const depthUsd = getLiquidityUsd(
             token0,
             token1,
             topPool.depth0,
-            topPool.depth1,
+            topPool.depth1
           );
 
+          const ve33Data = ve33DataByChainId.get(normalizeChainId(chainId));
+          const ve33Pool = isVe33Pool(topPool);
           const ve33Reward = getVe33Reward(
-            ve33DataByChainId.get(normalizeChainId(chainId)),
+            ve33Data,
             topPool,
             tokenByAddr[normalizeTokenRef(chainId, STONX_ADDRESS)],
-            tvlUsd,
+            tvlUsd
           );
-          const ve33FeesUsd = ve33Reward
-            ? getLiquidityUsd(
-                token0,
-                token1,
-                ve33Reward.ve33Pool.ve33_fees0_24h,
-                ve33Reward.ve33Pool.ve33_fees1_24h,
-              )
-            : 0;
-
-          const apyBase =
-            (Math.max(feesUsd - ve33FeesUsd, 0) * 100 * 365) /
-            (ve33Reward ? tvlUsd : depthUsd || tvlUsd);
+          const apyBase = ve33Pool
+            ? 0
+            : (feesUsd * 100 * 365) / (depthUsd || tvlUsd);
           const rewardTokens = new Set(campaignReward?.rewardTokens || []);
           if (ve33Reward) {
             rewardTokens.add(formatTokenAddress(chainId, STONX_ADDRESS));
@@ -499,9 +551,8 @@ async function apy() {
             pool: getPoolId(chainId, topPool),
             chain: utils.formatChain(
               CHAINS.find(
-                (chain) =>
-                  chain.normalizedChainId === normalizeChainId(chainId),
-              )?.chain ?? chainId,
+                (chain) => chain.normalizedChainId === normalizeChainId(chainId)
+              )?.chain ?? chainId
             ),
             project: 'ekubo',
             symbol: `${token0.symbol}-${token1.symbol}`,
@@ -520,7 +571,13 @@ async function apy() {
         })
         .filter(Boolean);
     })
-    .flat()
+    .flat();
+  const voterPools = buildVe33VoterPools(
+    ve33DataByChainId.get(normalizeChainId(ROBINHOOD_CHAIN_ID)),
+    tokenByAddr
+  );
+
+  return [...liquidityPools, ...voterPools]
     .filter((p) => p && utils.keepFinite(p))
     .sort((a, b) => b.tvlUsd - a.tvlUsd);
 }

--- a/src/adaptors/ekubo/index.js
+++ b/src/adaptors/ekubo/index.js
@@ -294,11 +294,16 @@ function buildCampaignRewards(campaigns, tokenByKey) {
 async function getVe33Data(normalizedChainId) {
   if (normalizedChainId !== normalizeChainId(ROBINHOOD_CHAIN_ID)) return null;
 
-  let poolsResponse;
+  let poolsById;
+  let totalVoteWeight;
   try {
-    poolsResponse = await utils.getData(
+    const poolsResponse = await utils.getData(
       `${API_URL}/ve33/${VE33_ADDRESS}/pools?chainId=${normalizedChainId}&pageSize=200`
     );
+    poolsById = new Map(
+      poolsResponse.data.map((pool) => [BigInt(pool.pool_id).toString(), pool])
+    );
+    totalVoteWeight = BigInt(poolsResponse.total_vote_weight);
   } catch (error) {
     console.error(
       `Ekubo ve33 pool fetch failed for chain ${normalizedChainId}: ${error.message}`
@@ -320,13 +325,7 @@ async function getVe33Data(normalizedChainId) {
     );
   }
 
-  return {
-    poolsById: new Map(
-      poolsResponse.data.map((pool) => [BigInt(pool.pool_id).toString(), pool])
-    ),
-    totalVoteWeight: BigInt(poolsResponse.total_vote_weight),
-    currentEmissionRate,
-  };
+  return { poolsById, totalVoteWeight, currentEmissionRate };
 }
 
 function getVe33Reward(ve33Data, poolInfo, stonxToken, tvlUsd) {

--- a/src/adaptors/ekubo/index.js
+++ b/src/adaptors/ekubo/index.js
@@ -1,14 +1,26 @@
 const utils = require('../utils');
 const { chunk } = require('lodash');
+const ethers = require('ethers');
 
 const API_URL = 'https://prod-api.ekubo.org';
 const ETHEREUM_CHAIN_ID = '0x1';
 const STARKNET_CHAIN_ID = '0x534e5f4d41494e';
+const ROBINHOOD_CHAIN_ID = '0x1237';
+const ROBINHOOD_RPC_URL = 'https://rpc.mainnet.chain.robinhood.com';
+const VE33_ADDRESS = '0xd18685a514e59b06d59824e16db07e73345d9953';
+const VE33_DATA_FETCHER_ADDRESS = '0x61f03754b1c7a7f0e584fd8869c00ba898ab888d';
+const STONX_ADDRESS = '0x570c5aa79c798e7a418412cc8399ae5bcce570c5';
 const MIN_TVL_USD = 10000;
 const TOP_POOL_REQUEST_CONCURRENCY = 5;
 const MAX_TOP_POOL_FAILURES = 3;
 const Q128 = 1n << 128n;
 const Q64 = 1n << 64n;
+const Q32 = 1n << 32n;
+const SECONDS_PER_DAY = 86400n;
+
+const VE33_DATA_FETCHER_ABI = [
+  'function getEmissionState() view returns (tuple(uint64 currentTimestamp, uint160 currentEmissionRate, uint256 totalRemainingEmissions, tuple(uint64 time, int256 emissionRateDelta, uint160 emissionRateAfter)[] futureEmissionRateChanges) state)',
+];
 
 const LEGACY_STARKNET_POOL_IDS_BY_CANONICAL_ID = {
   'ekubo-0x534e5f4d41494e-0x5dd3d2f4429af886cd1a3b08289dbcea99a294197e9eb43b0e0325b4b-0x01002120c2f49c83a9d777123a4061cd371cfc24fb40cddd9bd8450ce3f464ac':
@@ -116,6 +128,11 @@ const CHAINS = [
     normalizedChainId: normalizeChainId(STARKNET_CHAIN_ID),
     chain: 'starknet',
   },
+  {
+    chainId: ROBINHOOD_CHAIN_ID,
+    normalizedChainId: normalizeChainId(ROBINHOOD_CHAIN_ID),
+    chain: 'robinhood',
+  },
 ];
 
 function normalizeTokenRef(chainId, address) {
@@ -141,7 +158,7 @@ function getLegacyPoolId(chainId, canonicalPoolId) {
 
 function getCanonicalPoolId(chainId, poolInfo) {
   return `ekubo-${formatNumericHex(chainId)}-${formatNumericHex(
-    poolInfo.core_address
+    poolInfo.core_address,
   )}-${formatNumericHex(poolInfo.pool_id, 64)}`.toLowerCase();
 }
 
@@ -168,7 +185,7 @@ function getPoolUrl(chainId, poolInfo) {
       : 'evm';
 
   return `https://ekubo.org/${chainPath}/charts/pool/${chainId}/${formatNumericHex(
-    poolInfo.core_address
+    poolInfo.core_address,
   )}/${formatNumericHex(poolInfo.pool_id, 64)}`;
 }
 
@@ -179,8 +196,7 @@ function formatFeePercent(chainId, fee) {
     normalizeChainId(chainId) === normalizeChainId(STARKNET_CHAIN_ID)
       ? Q128
       : Q64;
-  const scaledPercent =
-    (BigInt(fee) * 10000n + denominator / 2n) / denominator;
+  const scaledPercent = (BigInt(fee) * 10000n + denominator / 2n) / denominator;
   const whole = scaledPercent / 100n;
   const fraction = (scaledPercent % 100n).toString().padStart(2, '0');
 
@@ -214,7 +230,8 @@ function getAmountUsd(token, amount) {
   if (!token?.usd_price) return 0;
 
   return (
-    (token.usd_price * Number(amount || 0)) / Math.pow(10, Number(token.decimals))
+    (token.usd_price * Number(amount || 0)) /
+    Math.pow(10, Number(token.decimals))
   );
 }
 
@@ -224,7 +241,9 @@ function getLiquidityUsd(token0, token1, amount0, amount1) {
 
 function isCampaignActive(campaign, now) {
   const startTime = new Date(campaign.startTime).getTime();
-  const endTime = campaign.endTime ? new Date(campaign.endTime).getTime() : Infinity;
+  const endTime = campaign.endTime
+    ? new Date(campaign.endTime).getTime()
+    : Infinity;
 
   return startTime <= now && now < endTime;
 }
@@ -236,7 +255,8 @@ function buildCampaignRewards(campaigns, tokenByKey) {
   for (const campaign of campaigns) {
     if (!isCampaignActive(campaign, now)) continue;
 
-    const rewardToken = tokenByKey[normalizeTokenRef(campaign.chain_id, campaign.rewardToken)];
+    const rewardToken =
+      tokenByKey[normalizeTokenRef(campaign.chain_id, campaign.rewardToken)];
     if (!rewardToken?.usd_price) continue;
 
     for (const pair of campaign.pairs) {
@@ -246,11 +266,11 @@ function buildCampaignRewards(campaigns, tokenByKey) {
       const depthUsd =
         getAmountUsd(
           tokenByKey[normalizeTokenRef(campaign.chain_id, pair.token0)],
-          pair.depth0
+          pair.depth0,
         ) +
         getAmountUsd(
           tokenByKey[normalizeTokenRef(campaign.chain_id, pair.token1)],
-          pair.depth1
+          pair.depth1,
         );
 
       if (!depthUsd) continue;
@@ -263,7 +283,7 @@ function buildCampaignRewards(campaigns, tokenByKey) {
 
       existing.apyReward += (dailyRewardUsd * 365 * 100) / depthUsd;
       existing.rewardTokens.add(
-        formatTokenAddress(campaign.chain_id, rewardToken.address)
+        formatTokenAddress(campaign.chain_id, rewardToken.address),
       );
       rewardsByPair.set(pairKey, existing);
     }
@@ -272,61 +292,114 @@ function buildCampaignRewards(campaigns, tokenByKey) {
   return rewardsByPair;
 }
 
+async function getVe33Data(normalizedChainId) {
+  if (normalizedChainId !== normalizeChainId(ROBINHOOD_CHAIN_ID)) return null;
+
+  const [poolsResponse, emissionState] = await Promise.all([
+    utils.getData(
+      `${API_URL}/ve33/${VE33_ADDRESS}/pools?chainId=${normalizedChainId}&pageSize=200`,
+    ),
+    new ethers.Contract(
+      VE33_DATA_FETCHER_ADDRESS,
+      VE33_DATA_FETCHER_ABI,
+      new ethers.providers.StaticJsonRpcProvider(ROBINHOOD_RPC_URL, 4663),
+    ).getEmissionState(),
+  ]);
+
+  const poolsById = new Map(
+    poolsResponse.data.map((pool) => [BigInt(pool.pool_id).toString(), pool]),
+  );
+
+  return {
+    poolsById,
+    totalVoteWeight: BigInt(poolsResponse.total_vote_weight),
+    currentEmissionRate: BigInt(emissionState.currentEmissionRate.toString()),
+  };
+}
+
+function getVe33Reward(ve33Data, poolInfo, stonxToken, tvlUsd) {
+  if (!ve33Data || !stonxToken?.usd_price || !tvlUsd) return null;
+
+  const ve33Pool = ve33Data.poolsById.get(BigInt(poolInfo.pool_id).toString());
+  if (!ve33Pool) return null;
+
+  const projectedEmissions =
+    ve33Data.totalVoteWeight === 0n
+      ? 0n
+      : (ve33Data.currentEmissionRate *
+          SECONDS_PER_DAY *
+          BigInt(ve33Pool.pool_total_vote_weight)) /
+        (Q32 * ve33Data.totalVoteWeight);
+  const dailyRewardUsd = getAmountUsd(stonxToken, projectedEmissions);
+
+  return {
+    apyReward: (dailyRewardUsd * 365 * 100) / tvlUsd,
+    ve33Pool,
+  };
+}
+
 async function getChainData({ normalizedChainId }) {
   const query = `chainId=${encodeURIComponent(normalizedChainId)}`;
 
-  const [tokens, pairData, campaigns] = await Promise.all([
+  const [tokens, pairData, campaigns, ve33Data] = await Promise.all([
     utils.getData(`${API_URL}/tokens?${query}&pageSize=10000`),
-    utils.getData(`${API_URL}/overview/pairs?${query}&minTvlUsd=${MIN_TVL_USD}`),
+    utils.getData(
+      `${API_URL}/overview/pairs?${query}&minTvlUsd=${MIN_TVL_USD}`,
+    ),
     utils.getData(`${API_URL}/campaigns?${query}`),
+    getVe33Data(normalizedChainId),
   ]);
 
   const topPoolEntries = [];
   let topPoolFailureCount = 0;
-  for (const pairsBatch of chunk(pairData.topPairs, TOP_POOL_REQUEST_CONCURRENCY)) {
+  for (const pairsBatch of chunk(
+    pairData.topPairs,
+    TOP_POOL_REQUEST_CONCURRENCY,
+  )) {
     const batchEntries = await Promise.all(
       pairsBatch.map(async (pair) => {
         const pairKey = getPairKey(pair.chain_id, pair.token0, pair.token1);
         try {
           const pools = await utils.getData(
             `${API_URL}/pair/${encodeURIComponent(normalizedChainId)}/${encodeURIComponent(
-              pair.token0
-            )}/${encodeURIComponent(pair.token1)}/pools?minTvlUsd=${MIN_TVL_USD}`
+              pair.token0,
+            )}/${encodeURIComponent(pair.token1)}/pools?minTvlUsd=${MIN_TVL_USD}`,
           );
           const topPools = pools?.topPools || [];
           if (topPools.length === 0) return null;
 
-          return [
-            pairKey,
-            topPools,
-          ];
+          return [pairKey, topPools];
         } catch (error) {
           console.error(
-            `Ekubo top pool fetch failed for chain ${normalizedChainId} pair ${pairKey}: ${error.message}`
+            `Ekubo top pool fetch failed for chain ${normalizedChainId} pair ${pairKey}: ${error.message}`,
           );
           return { error: true, pairKey };
         }
-      })
+      }),
     );
     const failedEntries = batchEntries.filter((entry) => entry?.error);
     topPoolFailureCount += failedEntries.length;
 
     if (topPoolFailureCount > MAX_TOP_POOL_FAILURES) {
       throw new Error(
-        `Ekubo top pool fetch failures exceeded threshold for chain ${normalizedChainId}: ${topPoolFailureCount}`
+        `Ekubo top pool fetch failures exceeded threshold for chain ${normalizedChainId}: ${topPoolFailureCount}`,
       );
     }
 
     topPoolEntries.push(
-      ...batchEntries.filter((entry) => entry && !entry.error)
+      ...batchEntries.filter((entry) => entry && !entry.error),
     );
   }
 
   return {
+    normalizedChainId,
     tokens,
     pairs: pairData.topPairs,
-    topPoolsByPair: new Map(topPoolEntries.filter(([, pools]) => pools?.length)),
+    topPoolsByPair: new Map(
+      topPoolEntries.filter(([, pools]) => pools?.length),
+    ),
     campaigns: campaigns.campaigns,
+    ve33Data,
   };
 }
 
@@ -334,7 +407,7 @@ async function apy() {
   const results = await Promise.all(CHAINS.map(getChainData));
   const tokens = results.flatMap((result) => result.tokens);
   const topPoolsByPair = new Map(
-    results.flatMap((result) => [...result.topPoolsByPair.entries()])
+    results.flatMap((result) => [...result.topPoolsByPair.entries()]),
   );
   const tokenByAddr = {};
   for (const token of tokens) {
@@ -343,7 +416,12 @@ async function apy() {
 
   const campaignRewards = buildCampaignRewards(
     results.flatMap((result) => result.campaigns),
-    tokenByAddr
+    tokenByAddr,
+  );
+  const ve33DataByChainId = new Map(
+    results
+      .filter((result) => result.ve33Data)
+      .map((result) => [result.normalizedChainId, result.ve33Data]),
   );
 
   return results
@@ -357,7 +435,9 @@ async function apy() {
       if (!token0 || !token1) return;
       const campaignReward =
         campaignRewards.get(getPairKey(chainId, p.token0, p.token1)) || null;
-      const topPools = topPoolsByPair.get(getPairKey(chainId, p.token0, p.token1));
+      const topPools = topPoolsByPair.get(
+        getPairKey(chainId, p.token0, p.token1),
+      );
 
       if (!topPools?.length) return [];
 
@@ -367,7 +447,7 @@ async function apy() {
             token0,
             token1,
             topPool.tvl0_total,
-            topPool.tvl1_total
+            topPool.tvl1_total,
           );
 
           if (tvlUsd < MIN_TVL_USD) return null;
@@ -376,23 +456,45 @@ async function apy() {
             token0,
             token1,
             topPool.fees0_24h,
-            topPool.fees1_24h
+            topPool.fees1_24h,
           );
           const depthUsd = getLiquidityUsd(
             token0,
             token1,
             topPool.depth0,
-            topPool.depth1
+            topPool.depth1,
           );
 
-          const apyBase = (feesUsd * 100 * 365) / (depthUsd || tvlUsd);
+          const ve33Reward = getVe33Reward(
+            ve33DataByChainId.get(normalizeChainId(chainId)),
+            topPool,
+            tokenByAddr[normalizeTokenRef(chainId, STONX_ADDRESS)],
+            tvlUsd,
+          );
+          const ve33FeesUsd = ve33Reward
+            ? getLiquidityUsd(
+                token0,
+                token1,
+                ve33Reward.ve33Pool.ve33_fees0_24h,
+                ve33Reward.ve33Pool.ve33_fees1_24h,
+              )
+            : 0;
+
+          const apyBase =
+            (Math.max(feesUsd - ve33FeesUsd, 0) * 100 * 365) /
+            (ve33Reward ? tvlUsd : depthUsd || tvlUsd);
+          const rewardTokens = new Set(campaignReward?.rewardTokens || []);
+          if (ve33Reward) {
+            rewardTokens.add(formatTokenAddress(chainId, STONX_ADDRESS));
+          }
 
           return {
             pool: getPoolId(chainId, topPool),
             chain: utils.formatChain(
               CHAINS.find(
-                (chain) => chain.normalizedChainId === normalizeChainId(chainId)
-              )?.chain ?? chainId
+                (chain) =>
+                  chain.normalizedChainId === normalizeChainId(chainId),
+              )?.chain ?? chainId,
             ),
             project: 'ekubo',
             symbol: `${token0.symbol}-${token1.symbol}`,
@@ -402,8 +504,9 @@ async function apy() {
             ],
             tvlUsd,
             apyBase,
-            apyReward: campaignReward?.apyReward || 0,
-            rewardTokens: campaignReward ? [...campaignReward.rewardTokens] : [],
+            apyReward:
+              (campaignReward?.apyReward || 0) + (ve33Reward?.apyReward || 0),
+            rewardTokens: [...rewardTokens],
             poolMeta: getPoolMeta(chainId, topPool),
             url: getPoolUrl(chainId, topPool),
           };

--- a/src/adaptors/ekubo/index.js
+++ b/src/adaptors/ekubo/index.js
@@ -295,37 +295,49 @@ function buildCampaignRewards(campaigns, tokenByKey) {
 async function getVe33Data(normalizedChainId) {
   if (normalizedChainId !== normalizeChainId(ROBINHOOD_CHAIN_ID)) return null;
 
+  let poolsResponse;
   try {
-    const [poolsResponse, emissionState] = await Promise.all([
-      utils.getData(
-        `${API_URL}/ve33/${VE33_ADDRESS}/pools?chainId=${normalizedChainId}&pageSize=200`
-      ),
-      new ethers.Contract(
-        VE33_DATA_FETCHER_ADDRESS,
-        VE33_DATA_FETCHER_ABI,
-        new ethers.providers.StaticJsonRpcProvider(ROBINHOOD_RPC_URL, 4663)
-      ).getEmissionState(),
-    ]);
-
-    const poolsById = new Map(
-      poolsResponse.data.map((pool) => [BigInt(pool.pool_id).toString(), pool])
+    poolsResponse = await utils.getData(
+      `${API_URL}/ve33/${VE33_ADDRESS}/pools?chainId=${normalizedChainId}&pageSize=200`
     );
-
-    return {
-      poolsById,
-      totalVoteWeight: BigInt(poolsResponse.total_vote_weight),
-      currentEmissionRate: BigInt(emissionState.currentEmissionRate.toString()),
-    };
   } catch (error) {
     console.error(
-      `Ekubo ve33 data fetch failed for chain ${normalizedChainId}: ${error.message}`
+      `Ekubo ve33 pool fetch failed for chain ${normalizedChainId}: ${error.message}`
     );
     return null;
   }
+
+  let currentEmissionRate = null;
+  try {
+    const emissionState = await new ethers.Contract(
+      VE33_DATA_FETCHER_ADDRESS,
+      VE33_DATA_FETCHER_ABI,
+      new ethers.providers.StaticJsonRpcProvider(ROBINHOOD_RPC_URL, 4663)
+    ).getEmissionState();
+    currentEmissionRate = BigInt(emissionState.currentEmissionRate.toString());
+  } catch (error) {
+    console.error(
+      `Ekubo ve33 emission-state fetch failed for chain ${normalizedChainId}: ${error.message}`
+    );
+  }
+
+  return {
+    poolsById: new Map(
+      poolsResponse.data.map((pool) => [BigInt(pool.pool_id).toString(), pool])
+    ),
+    totalVoteWeight: BigInt(poolsResponse.total_vote_weight),
+    currentEmissionRate,
+  };
 }
 
 function getVe33Reward(ve33Data, poolInfo, stonxToken, tvlUsd) {
-  if (!ve33Data || !stonxToken?.usd_price || !tvlUsd) return null;
+  if (
+    !ve33Data ||
+    ve33Data.currentEmissionRate === null ||
+    !stonxToken?.usd_price ||
+    !tvlUsd
+  )
+    return null;
 
   const ve33Pool = ve33Data.poolsById.get(BigInt(poolInfo.pool_id).toString());
   if (!ve33Pool) return null;


### PR DESCRIPTION
## Summary

- add Robinhood Chain pools to the Ekubo yield adapter
- report projected STONX emissions as supplemental reward APY for ve33 liquidity providers
- set ve33 LP base APY to zero because pool fees accrue to voters, not LPs
- add separate veSTONX voter opportunities using 24h ve33 fees divided by STONX-valued vote weight, matching the Ekubo interface
- use the existing Ekubo token API USD price for STONX
- isolate optional ve33 API/RPC failures so other adapter data remains available

## Testing

- `npm_config_adapter=ekubo npx jest --watchman=false --runInBand` (621 tests passed)
- live adapter run returned 88 pools, including 5 Robinhood ve33 LP pools and 11 veSTONX voter opportunities above the existing $10k threshold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for displaying Ekubo pools on the Robinhood chain.
  - Added Ve33 reward information, including projected STONX rewards and campaign rewards.
  - Added synthetic veSTONX voter pools based on voter fee data.

- **Improvements**
  - Updated pool APY calculations to account for Ve33-attributed fees.
  - Improved Robinhood coverage with chain-specific pool, emission, and reward data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->