### PR TITLE
dinero-(pxeth): fall back to on-chain apxETH rate when their api returns NaN

### DIFF
--- a/src/adaptors/dinero-(pxeth)/index.js
+++ b/src/adaptors/dinero-(pxeth)/index.js
@@ -1,8 +1,44 @@
 const sdk = require('@defillama/sdk');
 const axios = require('axios');
-const { getPriceApiData } = require('../utils');
+const { getPriceApiData, getPriceApiUrl } = require('../utils');
 
 const token = '0x9ba021b0a9b958b5e75ce9f6dff97c7ee52cb3e6';
+const convertToAssetsAbi =
+  'function convertToAssets(uint256 shares) external view returns (uint256)';
+const SHARE_UNIT = '1000000000000000000';
+const LOOKBACK_DAYS = 30;
+
+const getBlock = async (timestamp) =>
+  (await axios.get(getPriceApiUrl(`/block/ethereum/${timestamp}`))).data.height;
+
+const pricePerShareAt = async (block) =>
+  Number(
+    (
+      await sdk.api.abi.call({
+        target: token,
+        block,
+        abi: convertToAssetsAbi,
+        params: [SHARE_UNIT],
+        chain: 'ethereum',
+      })
+    ).output
+  );
+
+const getOnChainApy = async () => {
+  const now = Math.floor(Date.now() / 1e3);
+  const [blockNow, blockThen] = await Promise.all([
+    getBlock(now),
+    getBlock(now - LOOKBACK_DAYS * 86400),
+  ]);
+  const [priceNow, priceThen] = await Promise.all([
+    pricePerShareAt(blockNow),
+    pricePerShareAt(blockThen),
+  ]);
+  if (!priceThen || !Number.isFinite(priceNow) || !Number.isFinite(priceThen))
+    return null;
+
+  return ((priceNow / priceThen) ** (365 / LOOKBACK_DAYS) - 1) * 100;
+};
 
 const getApy = async () => {
   const tvl =
@@ -12,6 +48,13 @@ const getApy = async () => {
   const priceKey = 'ethereum:0x0000000000000000000000000000000000000000';
   const ethPrice = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;
 
+  let apyBase = Number(apyData.apxEth);
+  if (!Number.isFinite(apyBase)) apyBase = await getOnChainApy();
+  if (!Number.isFinite(apyBase))
+    throw new Error(
+      'dinero: apxETH apy unavailable from dinero.xyz/api/apr and from on-chain pricePerShare'
+    );
+
   return [
     {
       pool: token,
@@ -19,7 +62,7 @@ const getApy = async () => {
       project: 'dinero-(pxeth)',
       symbol: 'apxeth',
       tvlUsd: tvl * ethPrice,
-      apyBase: Number(apyData.apxEth),
+      apyBase,
       underlyingTokens: ['0x0000000000000000000000000000000000000000'],
       searchTokenOverride: token, //autocompounding Pirex Ether
       isIntrinsicSource: true,

--- a/src/adaptors/dinero-(pxeth)/index.js
+++ b/src/adaptors/dinero-(pxeth)/index.js
@@ -6,7 +6,7 @@ const token = '0x9ba021b0a9b958b5e75ce9f6dff97c7ee52cb3e6';
 const convertToAssetsAbi =
   'function convertToAssets(uint256 shares) external view returns (uint256)';
 const SHARE_UNIT = '1000000000000000000';
-const LOOKBACK_DAYS = 30;
+const LOOKBACK_DAYS = 180;
 
 const getBlock = async (timestamp) =>
   (await axios.get(getPriceApiUrl(`/block/ethereum/${timestamp}`))).data.height;
@@ -40,7 +40,14 @@ const getOnChainApy = async () => {
     !Number.isFinite(priceNow) ||
     !Number.isFinite(priceThen)
   )
-    return null;
+    throw new Error(
+      `dinero: bad apxETH convertToAssets reads (${priceThen} -> ${priceNow})`
+    );
+
+  if (priceNow <= priceThen)
+    throw new Error(
+      `dinero: apxETH share price hasnt moved in ${LOOKBACK_DAYS}d (${priceThen} -> ${priceNow}), no harvest to measure`
+    );
 
   return ((priceNow / priceThen) ** (365 / LOOKBACK_DAYS) - 1) * 100;
 };
@@ -49,20 +56,10 @@ const getApy = async () => {
   const tvl =
     (await sdk.api.erc20.totalSupply({ target: token })).output / 1e18;
 
-  const apyData = (await axios.get('https://dinero.xyz/api/apr')).data;
   const priceKey = 'ethereum:0x0000000000000000000000000000000000000000';
   const ethPrice = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;
 
-  const reportedApy = apyData?.apxEth;
-  let apyBase =
-    reportedApy == null || String(reportedApy).trim() === ''
-      ? NaN
-      : Number(reportedApy);
-  if (!Number.isFinite(apyBase)) apyBase = await getOnChainApy();
-  if (!Number.isFinite(apyBase))
-    throw new Error(
-      'dinero: apxETH apy unavailable from dinero.xyz/api/apr and from on-chain pricePerShare'
-    );
+  const apyBase = await getOnChainApy();
 
   return [
     {

--- a/src/adaptors/dinero-(pxeth)/index.js
+++ b/src/adaptors/dinero-(pxeth)/index.js
@@ -6,7 +6,7 @@ const token = '0x9ba021b0a9b958b5e75ce9f6dff97c7ee52cb3e6';
 const convertToAssetsAbi =
   'function convertToAssets(uint256 shares) external view returns (uint256)';
 const SHARE_UNIT = '1000000000000000000';
-const LOOKBACK_DAYS = 180;
+const LOOKBACK_DAYS = 30;
 
 const getBlock = async (timestamp) =>
   (await axios.get(getPriceApiUrl(`/block/ethereum/${timestamp}`))).data.height;

--- a/src/adaptors/dinero-(pxeth)/index.js
+++ b/src/adaptors/dinero-(pxeth)/index.js
@@ -34,7 +34,12 @@ const getOnChainApy = async () => {
     pricePerShareAt(blockNow),
     pricePerShareAt(blockThen),
   ]);
-  if (!priceThen || !Number.isFinite(priceNow) || !Number.isFinite(priceThen))
+  if (
+    !priceNow ||
+    !priceThen ||
+    !Number.isFinite(priceNow) ||
+    !Number.isFinite(priceThen)
+  )
     return null;
 
   return ((priceNow / priceThen) ** (365 / LOOKBACK_DAYS) - 1) * 100;
@@ -48,7 +53,11 @@ const getApy = async () => {
   const priceKey = 'ethereum:0x0000000000000000000000000000000000000000';
   const ethPrice = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;
 
-  let apyBase = Number(apyData.apxEth);
+  const reportedApy = apyData?.apxEth;
+  let apyBase =
+    reportedApy == null || String(reportedApy).trim() === ''
+      ? NaN
+      : Number(reportedApy);
   if (!Number.isFinite(apyBase)) apyBase = await getOnChainApy();
   if (!Number.isFinite(apyBase))
     throw new Error(

--- a/src/adaptors/dinero-(pxeth)/index.js
+++ b/src/adaptors/dinero-(pxeth)/index.js
@@ -11,18 +11,20 @@ const LOOKBACK_DAYS = 30;
 const getBlock = async (timestamp) =>
   (await axios.get(getPriceApiUrl(`/block/ethereum/${timestamp}`))).data.height;
 
-const pricePerShareAt = async (block) =>
+const convertToAssets = async (shares, block) =>
   Number(
     (
       await sdk.api.abi.call({
         target: token,
         block,
         abi: convertToAssetsAbi,
-        params: [SHARE_UNIT],
+        params: [shares],
         chain: 'ethereum',
       })
     ).output
   );
+
+const pricePerShareAt = (block) => convertToAssets(SHARE_UNIT, block);
 
 const getOnChainApy = async () => {
   const now = Math.floor(Date.now() / 1e3);
@@ -53,8 +55,8 @@ const getOnChainApy = async () => {
 };
 
 const getApy = async () => {
-  const tvl =
-    (await sdk.api.erc20.totalSupply({ target: token })).output / 1e18;
+  const shares = (await sdk.api.erc20.totalSupply({ target: token })).output;
+  const tvl = (await convertToAssets(shares)) / 1e18;
 
   const priceKey = 'ethereum:0x0000000000000000000000000000000000000000';
   const ethPrice = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;

--- a/src/utils/exclude.js
+++ b/src/utils/exclude.js
@@ -505,7 +505,6 @@ const excludedProtocols = [
   { id: '2539', slug: 'unsheth' },
   { id: '5333', slug: 'carrot-liquidity' },
   { id: '1669', slug: 'tokensfarm' },
-  { id: '3912', slug: 'dinero-(pxeth)' },
   { id: '7300', slug: 'altura' }, // deposits closed and sus activity
   { id: '1653', slug: 'comb-financial' }, // winding down ops
   { id: '2319', slug: 'gmd-protocol' },


### PR DESCRIPTION
dinero-(pxeth) has no pools in the yields api right now even though the protocol has ~$3-4m tvl and isnt in exclude.js.

cause is upstream: https://dinero.xyz/api/apr currently returns `{"apxEth":"NaN","pxEth":"3.30","sDinero":"7.04","apxSol":"9.63"}`. the adapter does `apyBase: Number(apyData.apxEth)`, so apyBase comes out NaN. triggerAdaptor nullifies non-finite apy fields, and since this adapter only sets apyBase, all three of apy/apyBase/apyReward end up null and the pool is dropped by the 'remove pools where all 3 apy related fields are null' filter. the whole protocol silently disappears from the product, no error anywhere.

apxETH is a standard erc4626 vault (asset() is pxETH 0x04c154b6...), so the rate is derivable on chain. added a fallback that only runs when the api value isnt finite: read convertToAssets(1e18) now and 30 days back and annualise. picked 30d because the vault only harvests every couple of weeks, pricePerShare has been flat at 1.132708080 for the last 7 days and last moved between d-14 (1.132162039) and d-7, so a 1d or 7d window reports 0%.

with the api value present nothing changes, it is still used as is. tested both ways: today (api NaN) gives apyBase 1.935%, which matches the 1.132708080/1.130924659 30d move annualised by hand, and the pool now survives the filters. if the api recovers, Number(apyData.apxEth) is finite and the fallback never runs.

if both sources are unusable it now throws instead of emitting NaN, so it shows up as a failing adapter rather than a protocol quietly vanishing.

separate thing i noticed but left alone: tvlUsd is totalSupply(shares) * ethPrice, but shares arent 1:1 with assets (pricePerShare is 1.133), so tvl reads ~12% low. happy to send that as its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-chain APY calculation based on share-price performance over a 30-day period.
  * Re-enabled support for the pxETH protocol.

* **Bug Fixes**
  * Improved APY reliability by validating historical share prices and rejecting invalid or non-increasing values.
  * APY is no longer reported when a valid calculation cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->