### PR TITLE
inline protocolId test + failure comment improvements

### DIFF
--- a/.github/workflows/commentResult.js
+++ b/.github/workflows/commentResult.js
@@ -8,10 +8,28 @@ function main() {
   const passed = /PASS\s+.*test\.js/.test(file);
   const failed = /FAIL\s+.*test\.js/.test(file);
 
-  // Everything from "Test Suites:" onward (includes pool output from afterTests.js)
+  const MAX_FAILURE_DETAIL_CHARS = 20000;
+
+  // On success: everything from "Test Suites:" onward (includes pool output from
+  // afterTests.js). On failure: the jest failure blocks too, capped, so the
+  // reason is visible in the comment and not just the counts.
   const summaryIndex = file.indexOf('Test Suites:');
   if (summaryIndex === -1) return;
-  const output = file.substring(summaryIndex);
+
+  const failureIndex = file.indexOf('●');
+  const hasFailureDetail =
+    failed && failureIndex !== -1 && failureIndex < summaryIndex;
+
+  let output = file.substring(summaryIndex);
+  if (hasFailureDetail) {
+    let detail = file.substring(failureIndex, summaryIndex);
+    if (detail.length > MAX_FAILURE_DETAIL_CHARS) {
+      detail =
+        detail.substring(0, MAX_FAILURE_DETAIL_CHARS) +
+        '\n\n... failure output truncated ...\n\n';
+    }
+    output = detail + output;
+  }
 
   let body;
   if (passed && !failed) {

--- a/src/adaptors/beforeTests.js
+++ b/src/adaptors/beforeTests.js
@@ -60,6 +60,7 @@ module.exports = async function () {
   const module = require(resolvedAdapterPath);
 
   global.adapter = adapter;
+  global.adapterPath = resolvedAdapterPath;
   global.protocolId = module.protocolId;
   global.apy = (await module.apy(timestamp)).sort(
     (a, b) => b.tvlUsd - a.tvlUsd

--- a/src/adaptors/test.js
+++ b/src/adaptors/test.js
@@ -5,7 +5,10 @@ const baseFields = {
   symbol: 'string',
 };
 
+const fs = require('fs');
+
 const adapter = global.adapter;
+const adapterPath = global.adapterPath;
 const apy = global.apy;
 const poolsUrl = global.poolsUrl;
 const protocolId = global.protocolId;
@@ -203,6 +206,28 @@ describe(`Running ${process.env.npm_config_adapter} Test`, () => {
     expect(protocol).toBeDefined();
     expect(typeof protocolId).toBe('string');
     expect(protocolId).toBe(String(protocol.id));
+  });
+
+  test('Adapter assigns protocolId as a string literal inside module.exports', () => {
+    const v2Pattern =
+      /\bmodule\.exports\s*=\s*\{[\s\S]*?\bprotocolId\s*:\s*['"](\d+)['"]/;
+    const source = fs
+      .readFileSync(adapterPath, 'utf8')
+      .replace(/^\s*\/\/.*$/gm, '');
+
+    const staticId = source.match(v2Pattern)?.[1] ?? null;
+
+    if (staticId === null) {
+      const assignment = source.match(/\bprotocolId\s*:\s*([^,\n}]+)/);
+      throw new Error(
+        assignment
+          ? `protocolId is not a literal that yield-server-v2 can read: \`protocolId: ${assignment[1].trim()}\`. ` +
+            `Inline it, eg: protocolId: '${protocolId}'`
+          : `no \`protocolId: '1234'\` found inside a \`module.exports = { ... }\` object literal`
+      );
+    }
+
+    expect(staticId).toBe(String(protocolId));
   });
 
   describe('Check additional field data rules', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed test reporting by preserving relevant Jest failure details, with truncation for very long output.
  * Added validation to ensure adapters declare the expected protocol identifier in a supported format.
  * Added clearer error messages when adapter protocol identifiers are missing, dynamic, or incorrect.
* **Tests**
  * Enhanced test setup to expose the resolved adapter path for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->