### PR TITLE
use 7d window for etherfi.stake weeth

### DIFF
--- a/src/adaptors/ether.fi-stake/index.js
+++ b/src/adaptors/ether.fi-stake/index.js
@@ -44,7 +44,6 @@ const apy = async () => {
   const [weETHRates, eBTCRates] = await Promise.all([
     Promise.all([
       sdk.api.abi.call({ target: weETH, abi }),
-      sdk.api.abi.call({ target: weETH, abi, block: block1dayAgo }),
       sdk.api.abi.call({ target: weETH, abi, block: block7dayAgo }),
     ]),
     Promise.all([
@@ -54,11 +53,8 @@ const apy = async () => {
     ]),
   ]);
 
-  const apr1d =
-    ((weETHRates[0].output - weETHRates[1].output) / weETHRates[1].output) * 365 * 100;
-
   const apr7d =
-    ((weETHRates[0].output - weETHRates[2].output) / weETHRates[2].output / 7) * 365 * 100;
+    ((weETHRates[0].output - weETHRates[1].output) / weETHRates[1].output / 7) * 365 * 100;
 
   const eBTCRateCurrent = Number(eBTCRates[0].output);
   const eBTCRate1dAgo = Number(eBTCRates[1].output);
@@ -120,7 +116,7 @@ const apy = async () => {
 
   const pricePerShare = Number(weETHRates[0].output) / 1e18;
   const bridgedWeethPools = await getBridgedWeethPools({
-    apyBase: apr1d,
+    apyBase: apr7d,
     apyBase7d: apr7d,
     apyReward: restakingApy,
     pricePerShare,
@@ -133,7 +129,7 @@ const apy = async () => {
       project: 'ether.fi-stake',
       symbol: 'weETH',
       tvlUsd: totalSupply * price,
-      apyBase: apr1d,
+      apyBase: apr7d,
       apyBase7d: apr7d,
       apyReward: restakingApy,
       ...(pricePerShare > 0 && { pricePerShare }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated APY calculations for weETH pools to use 7-day performance metrics instead of 1-day metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->