### PR TITLE
liminal-basis: split tvl across chains by share supply

### DIFF
--- a/src/adaptors/liminal-basis/index.js
+++ b/src/adaptors/liminal-basis/index.js
@@ -167,6 +167,8 @@ async function getPools(product, nav, supplies) {
       key === 'hyperliquidL1' ? total : total.plus(supplies[key]),
     new BigNumber(0)
   );
+  if (bridgedSupply.gt(hubSupply)) return [];
+
   const shareValue = new BigNumber(nav).div(hubSupply);
 
   return deployments.map(([key, config]) => {

--- a/src/adaptors/liminal-basis/index.js
+++ b/src/adaptors/liminal-basis/index.js
@@ -112,27 +112,59 @@ async function getTvlUsd(navOracleAddress) {
   return navIn18Decimals.div(1e18).toNumber();
 }
 
+async function getShareSupply(address, chain) {
+  const [supplyResult, decimalsResult] = await Promise.all([
+    sdk.api.abi.call({ target: address, abi: abi.totalSupply, chain }),
+    sdk.api.abi.call({ target: address, abi: abi.decimals, chain }),
+  ]);
+
+  return new BigNumber(supplyResult.output).div(
+    new BigNumber(10).pow(decimalsResult.output)
+  );
+}
+
 async function getPools(product) {
   const hubDeployment = product.deployments.hyperliquidL1;
-  const tvlUsd = await getTvlUsd(hubDeployment.navOracle);
+  const nav = await getTvlUsd(hubDeployment.navOracle);
   const apyBase7d = await getApy7d(
     hubDeployment.navOracle,
     hubDeployment.address,
     HYPERLIQUID_L1_CHAIN
   );
 
-  return Object.entries(product.deployments).map(([key, config]) => ({
-    pool: `${config.address}-${config.chain}-${key}`.toLowerCase(),
-    chain: utils.formatChain(config.chain),
-    project: 'liminal-basis',
-    symbol: product.symbol,
-    tvlUsd,
-    apyBase: apyBase7d,
-    apyBase7d,
-    underlyingTokens: config.underlyingTokens,
-    poolMeta: product.poolMeta,
-    url: 'https://liminal.money/app/tokenized',
-  }));
+  const deployments = Object.entries(product.deployments);
+  const supplies = await Promise.all(
+    deployments.map(([, config]) => getShareSupply(config.address, config.chain))
+  );
+
+  const hubIndex = deployments.findIndex(([key]) => key === 'hyperliquidL1');
+  const hubSupply = supplies[hubIndex];
+  if (hubSupply.isZero()) return [];
+
+  const bridgedSupply = supplies.reduce(
+    (total, supply, index) =>
+      index === hubIndex ? total : total.plus(supply),
+    new BigNumber(0)
+  );
+  const shareValue = new BigNumber(nav).div(hubSupply);
+
+  return deployments.map(([key, config], index) => {
+    const shares =
+      index === hubIndex ? hubSupply.minus(bridgedSupply) : supplies[index];
+
+    return {
+      pool: `${config.address}-${config.chain}-${key}`.toLowerCase(),
+      chain: utils.formatChain(config.chain),
+      project: 'liminal-basis',
+      symbol: product.symbol,
+      tvlUsd: shares.times(shareValue).toNumber(),
+      apyBase: apyBase7d,
+      apyBase7d,
+      underlyingTokens: config.underlyingTokens,
+      poolMeta: product.poolMeta,
+      url: 'https://liminal.money/app/tokenized',
+    };
+  });
 }
 
 async function main() {

--- a/src/adaptors/liminal-basis/index.js
+++ b/src/adaptors/liminal-basis/index.js
@@ -101,56 +101,77 @@ const PRODUCTS = [
   },
 ];
 
-async function getTvlUsd(navOracleAddress) {
-  const navResult = await sdk.api.abi.call({
-    target: navOracleAddress,
+async function getTvlUsd(products) {
+  const navResults = await sdk.api.abi.multiCall({
     abi: abi.getNAV,
+    calls: products.map((product) => ({
+      target: product.deployments.hyperliquidL1.navOracle,
+    })),
     chain: HYPERLIQUID_L1_CHAIN,
   });
 
-  const navIn18Decimals = new BigNumber(navResult.output);
-  return navIn18Decimals.div(1e18).toNumber();
-}
-
-async function getShareSupply(address, chain) {
-  const [supplyResult, decimalsResult] = await Promise.all([
-    sdk.api.abi.call({ target: address, abi: abi.totalSupply, chain }),
-    sdk.api.abi.call({ target: address, abi: abi.decimals, chain }),
-  ]);
-
-  return new BigNumber(supplyResult.output).div(
-    new BigNumber(10).pow(decimalsResult.output)
+  return navResults.output.map(({ output }) =>
+    new BigNumber(output).div(1e18).toNumber()
   );
 }
 
-async function getPools(product) {
+async function getShareSupplies(products) {
+  const requests = products.flatMap((product, productIndex) =>
+    Object.entries(product.deployments).map(([key, config]) => ({
+      productIndex,
+      key,
+      chain: config.chain,
+      address: config.address,
+    }))
+  );
+
+  const supplies = products.map(() => ({}));
+
+  await Promise.all(
+    [...new Set(requests.map((request) => request.chain))].map(async (chain) => {
+      const chainRequests = requests.filter(
+        (request) => request.chain === chain
+      );
+      const calls = chainRequests.map(({ address }) => ({ target: address }));
+
+      const [supplyResults, decimalsResults] = await Promise.all([
+        sdk.api.abi.multiCall({ abi: abi.totalSupply, calls, chain }),
+        sdk.api.abi.multiCall({ abi: abi.decimals, calls, chain }),
+      ]);
+
+      chainRequests.forEach(({ productIndex, key }, index) => {
+        supplies[productIndex][key] = new BigNumber(
+          supplyResults.output[index].output
+        ).div(new BigNumber(10).pow(decimalsResults.output[index].output));
+      });
+    })
+  );
+
+  return supplies;
+}
+
+async function getPools(product, nav, supplies) {
   const hubDeployment = product.deployments.hyperliquidL1;
-  const nav = await getTvlUsd(hubDeployment.navOracle);
   const apyBase7d = await getApy7d(
     hubDeployment.navOracle,
     hubDeployment.address,
     HYPERLIQUID_L1_CHAIN
   );
 
-  const deployments = Object.entries(product.deployments);
-  const supplies = await Promise.all(
-    deployments.map(([, config]) => getShareSupply(config.address, config.chain))
-  );
-
-  const hubIndex = deployments.findIndex(([key]) => key === 'hyperliquidL1');
-  const hubSupply = supplies[hubIndex];
+  const hubSupply = supplies.hyperliquidL1;
   if (hubSupply.isZero()) return [];
 
-  const bridgedSupply = supplies.reduce(
-    (total, supply, index) =>
-      index === hubIndex ? total : total.plus(supply),
+  const deployments = Object.entries(product.deployments);
+  const bridgedSupply = deployments.reduce(
+    (total, [key]) =>
+      key === 'hyperliquidL1' ? total : total.plus(supplies[key]),
     new BigNumber(0)
   );
   const shareValue = new BigNumber(nav).div(hubSupply);
 
-  return deployments.map(([key, config], index) => {
+  return deployments.map(([key, config]) => {
     const shares =
-      index === hubIndex ? hubSupply.minus(bridgedSupply) : supplies[index];
+      key === 'hyperliquidL1' ? hubSupply.minus(bridgedSupply) : supplies[key];
 
     return {
       pool: `${config.address}-${config.chain}-${key}`.toLowerCase(),
@@ -168,7 +189,16 @@ async function getPools(product) {
 }
 
 async function main() {
-  const pools = await Promise.all(PRODUCTS.map(getPools));
+  const [navs, supplies] = await Promise.all([
+    getTvlUsd(PRODUCTS),
+    getShareSupplies(PRODUCTS),
+  ]);
+
+  const pools = await Promise.all(
+    PRODUCTS.map((product, index) =>
+      getPools(product, navs[index], supplies[index])
+    )
+  );
 
   return pools.flat().filter((p) => p.tvlUsd > 0);
 }


### PR DESCRIPTION
Fixes #2869. Diagnosis and the suggested approach are @BhariGowda's, i confirmed the open question on-chain and implemented it.

`getPools` read one NAV from the hub oracle and handed the same `tvlUsd` to all three deployments, so each product was counted three times. 12 pools, ~$69.7M reported against ~$23.2M of real NAV.

## the open question was lock-and-mint vs burn-and-mint

That was the blocker on the issue, and it decides the denominator, so i checked rather than assumed. Each spoke is a LayerZero OFT whose `peers(30367)` points at a **separate** HyperEVM contract, and that contract is a lockbox adapter holding the hub share token:

```
limUSD  peer 0x95bb9d9d46b80b654ac93bb6d20fcc557d27bb49
        token()            0x1822bd...83c8   == hub share token
        approvalRequired() true              (adapter, not a mint/burn oft)
        hub tokens locked  316,880.67
        arb + eth supply   316,880.67        <- equal to the wei
```

Same on all four:

```
          locked in adapter      arb+eth supply
limUSD        316,880.67           316,880.67
xHYPE          26,090.88            26,090.88
xBTC            1,628.76             1,628.76
xLEND               4.16                 4.16
```

So it is lock-and-mint: every spoke share is backed by a hub share that is still inside `hubTotalSupply`. The lock-and-mint reading in the issue holds, and `hubSupply - sum(spokes)` is the right hub figure.

Independent check on the same conclusion, `NAV / (hub + spokes)` gives limUSD a share value of 0.990007, i.e. below par for a vault that only accrues, while `NAV / hubSupply` gives 1.019537, in line with its siblings (1.0175 - 1.0440).

## fix

Read `totalSupply` (and `decimals`) per deployment, value every chain at the hub share value `NAV / hubSupply`, and give the hub `hubSupply - sum(spokes)`.

## result

Each product now sums back to its NAV exactly:

```
xHYPE   published $ 5,821,405   NAV $ 5,821,405   diff -0.00
xBTC    published $ 1,228,707   NAV $ 1,228,707   diff -0.00
xLEND   published $ 5,334,525   NAV $ 5,334,525   diff -0.00
limUSD  published $10,828,731   NAV $10,828,731   diff  0.00

TOTAL   published $23,213,368   NAV $23,213,368   diff  $0.00
```

was $69.7M, so this drops ~$46.4M of duplicated pool TVL while keeping the per-chain breakdown.

72/72 tests pass. Pool count goes 12 -> 11: xLEND on ethereum has zero share supply, so it values to 0 and the existing `tvlUsd > 0` filter drops it instead of showing a $5.3M phantom. apy is untouched, it was already a hub-level number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool TVL reporting by calculating values separately for each deployment.
  * Correctly accounts for bridged token supply and assigns remaining supply to the Hyperliquid hub.
  * Normalized token supply values for more consistent and accurate displays.
  * Pools are no longer shown when the hub has no available supply or bridged supply is excessive.
  * Improved consistency and accuracy of TVL and supply data across supported products and deployments.
  * Improved data retrieval efficiency for more timely pool information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->