### PR TITLE
Origin adapters tvl apy

### DIFF
--- a/src/adaptors/origin-arm/index.js
+++ b/src/adaptors/origin-arm/index.js
@@ -1,56 +1,200 @@
+/*
+ * Origin ARM (Automated Redemption Manager) vaults.
+ *
+ * Every number here is read on-chain or from Merkl; Origin's squid is used only to enumerate the
+ * ARMs, since there is no on-chain registry to discover them from.
+ *
+ * Each ARM is a share vault denominated in its liquidity asset (`assets[0]`):
+ *   - `totalAssets()` is the net value backing the shares: it nets out the pending withdrawal
+ *     queue and includes assets parked in the ARM's lending market, so it is the complete pool TVL.
+ *   - `convertToAssets(1e18)` is the share price. Its trailing growth is the base yield.
+ *   - Merkl incentives come from the shared helper, which reads Merkl's own API.
+ */
+const { gql, request } = require('graphql-request');
 const sdk = require('@defillama/sdk');
+
 const utils = require('../utils');
+const { addMerklRewardApy } = require('../merkl/merkl-additional-reward');
 
-const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
-const STETH_ADDRESS = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84';
-const ARM_WETH_STETH_ADDRESS = '0x85b78aca6deae198fbf201c82daf6ca21942acc6';
+const GRAPH_URL = 'https://origin.squids.live/origin-squid/graphql';
 
-const apy = async () => {
-  const priceData = await utils.getPriceApiData('/prices/current/coingecko:ethereum?searchWidth=4h');
-  const ethPrice = priceData.coins['coingecko:ethereum'].price;
+// chainId -> [DefiLlama chain name, sdk/coins-api chain key]
+const CHAINS = {
+  1: ['Ethereum', 'ethereum'],
+  146: ['Sonic', 'sonic'],
+};
 
-  const apyData = await utils.getData(
-    'https://api.originprotocol.com/api/v2/arm-weth-steth/apr/trailing'
+const SHARE_PRICE_ABI = 'function convertToAssets(uint256 shares) view returns (uint256 assets)';
+const ONE_SHARE = '1000000000000000000';
+
+// Trailing window for the base APY: two reads, now and 30 days ago. 30d rather than something
+// shorter because ARM yield arrives in lumps -- over 14d the OS ARM reads 0% and the Ethena ARM
+// swings by 2pp.
+const TRAILING_DAYS = 30;
+const DAY_SECONDS = 86400;
+
+// An ARM earns single-digit percent a year, i.e. well under 0.05%/day. A larger move across the
+// window is a seeding or re-initialisation event, not yield -- the USDC ARM's share price doubled
+// overnight when it was funded out of its dust seed, which annualises to 7.1e9%.
+const MAX_DAILY_MOVE = 0.005;
+
+// Shorter windows tried, longest first, only for ARMs whose full window is unusable: either they
+// did not exist 30 days ago, or a jump like the above sits inside it. Everything else costs two
+// calls and never touches these. Kept short deliberately -- each entry is a round trip, and this
+// only applies to ARMs younger than the window or recently reseeded, which both age out of it.
+const FALLBACK_DAYS = [14, 7, 3];
+
+// The OS ARM (Sonic) is wound down -- a few hundred dollars of residual TVL, no longer a live
+// product -- so it is excluded rather than listed as an active pool.
+const EXCLUDED = new Set(['0x2f872623d1e1af5835b08b0e49aad2d81d649d30']);
+
+const armsQuery = gql`
+  query Arms {
+    arms(limit: 100) {
+      address
+      chainId
+      symbol
+      assets
+      assetDecimals
+    }
+  }
+`;
+
+const sharePricesAt = (chainKey, addresses, block) =>
+  sdk.api.abi
+    .multiCall({
+      chain: chainKey,
+      abi: SHARE_PRICE_ABI,
+      calls: addresses.map((target) => ({ target, params: ONE_SHARE })),
+      block,
+      permitFailure: true,
+    })
+    .then((r) => r.output.map((o) => (o.output === null ? null : Number(o.output))));
+
+const sharePricesDaysAgo = (chainKey, addresses, days) =>
+  utils
+    .getPriceApiData(
+      `/block/${chainKey}/${Math.floor(Date.now() / 1000) - days * DAY_SECONDS}`
+    )
+    .then((r) => sharePricesAt(chainKey, addresses, r.height));
+
+// Compound the share-price growth across a window into an annual rate. Null when the ARM did not
+// exist at the far end, or when the move is too large to be yield.
+const windowApy = (current, previous, days) => {
+  if (!(current > 0) || !(previous > 0)) return null;
+  if (Math.abs(current / previous - 1) > (1 + MAX_DAILY_MOVE) ** days - 1) return null;
+  return ((current / previous) ** (365 / days) - 1) * 100;
+};
+
+// Base APY for every ARM on a chain. The common path is two reads; only ARMs that fail the full
+// window fall through to the shorter ones.
+const chainApys = async (chainKey, addresses) => {
+  const [current, previous] = await Promise.all([
+    sharePricesAt(chainKey, addresses, undefined),
+    sharePricesDaysAgo(chainKey, addresses, TRAILING_DAYS),
+  ]);
+
+  const apys = addresses.map((_, i) => windowApy(current[i], previous[i], TRAILING_DAYS));
+
+  const pending = apys.map((apy, i) => (apy === null ? i : -1)).filter((i) => i >= 0);
+  if (!pending.length) return apys;
+
+  const pendingAddresses = pending.map((i) => addresses[i]);
+  const rows = await Promise.all(
+    FALLBACK_DAYS.map((days) => sharePricesDaysAgo(chainKey, pendingAddresses, days))
   );
 
-  const [wethBalance, stethBalance, outstandingStethBalance] =
-    await Promise.all([
-      sdk.api.abi.call({
-        chain: 'ethereum',
-        target: WETH_ADDRESS,
-        abi: 'erc20:balanceOf',
-        params: [ARM_WETH_STETH_ADDRESS],
-      }),
-      sdk.api.abi.call({
-        chain: 'ethereum',
-        target: STETH_ADDRESS,
-        abi: 'erc20:balanceOf',
-        params: [ARM_WETH_STETH_ADDRESS],
-      }),
-      sdk.api.abi.call({
-        chain: 'ethereum',
-        target: ARM_WETH_STETH_ADDRESS,
-        abi: 'uint256:lidoWithdrawalQueueAmount',
-      }),
-    ]);
+  pending.forEach((armIndex, k) => {
+    for (let j = 0; j < FALLBACK_DAYS.length; j += 1) {
+      const apy = windowApy(current[armIndex], rows[j][k], FALLBACK_DAYS[j]);
+      if (apy !== null) {
+        apys[armIndex] = apy;
+        return;
+      }
+    }
+  });
 
-  const tvlUsd =
-    (wethBalance.output / 1e18 +
-      stethBalance.output / 1e18 +
-      outstandingStethBalance.output / 1e18) *
-    ethPrice;
+  return apys;
+};
 
-  return [
-    {
-      pool: ARM_WETH_STETH_ADDRESS,
-      chain: utils.formatChain('Ethereum'),
-      project: 'origin-arm',
-      symbol: 'ARM-WETH-stETH',
-      tvlUsd,
-      apy: Number(apyData.apy),
-      underlyingTokens: [WETH_ADDRESS, STETH_ADDRESS],
-    },
-  ];
+const apy = async () => {
+  const { arms } = await request(GRAPH_URL, armsQuery);
+  const supported = arms.filter(
+    (arm) => CHAINS[arm.chainId] && !EXCLUDED.has(arm.address.toLowerCase())
+  );
+
+  const priceKeys = supported.map(
+    (arm) => `${CHAINS[arm.chainId][1]}:${arm.assets[0]}`
+  );
+  const prices = (
+    await utils.getPriceApiData(
+      `/prices/current/${[...new Set(priceKeys)].join(',')}`
+    )
+  ).coins;
+
+  // Grouped per chain so the block lookups and share-price reads are shared across its ARMs.
+  const byChain = {};
+  supported.forEach((arm, i) => {
+    const chainKey = CHAINS[arm.chainId][1];
+    (byChain[chainKey] = byChain[chainKey] || []).push({ arm, i });
+  });
+
+  const totalAssets = [];
+  const apyBase = [];
+
+  await Promise.all(
+    Object.entries(byChain).map(async ([chainKey, entries]) => {
+      const addresses = entries.map((e) => e.arm.address);
+
+      try {
+        const [assets, apys] = await Promise.all([
+          sdk.api.abi.multiCall({
+            chain: chainKey,
+            abi: 'uint256:totalAssets',
+            calls: addresses.map((target) => ({ target })),
+            permitFailure: true,
+          }),
+          chainApys(chainKey, addresses),
+        ]);
+
+        entries.forEach((entry, k) => {
+          totalAssets[entry.i] = assets.output[k].output;
+          apyBase[entry.i] = apys[k];
+        });
+      } catch (e) {
+        // A chain's RPC or block lookup failing shouldn't take the other chains' pools with it.
+        // Its ARMs stay unresolved, get filtered out below, and are picked up next run.
+        console.log(`origin-arm: skipping ${chainKey} this run: ${e.message}`);
+      }
+    })
+  );
+
+  const pools = supported
+    .map((arm, i) => {
+      const [chain, priceChain] = CHAINS[arm.chainId];
+      const address = arm.address.toLowerCase();
+      const price = prices[`${priceChain}:${arm.assets[0]}`]?.price;
+      if (price === undefined || totalAssets[i] == null) return null;
+      if (!Number.isFinite(apyBase[i])) return null;
+
+      return {
+        // Bare lowercase address: the format the Lido ARM has always used, kept so its
+        // existing yield history stays attached. Also what Merkl keys its opportunities on.
+        pool: address,
+        chain,
+        project: 'origin-arm',
+        symbol: arm.symbol,
+        tvlUsd: (Number(totalAssets[i]) / 10 ** arm.assetDecimals[0]) * price,
+        apyBase: apyBase[i],
+        underlyingTokens: arm.assets,
+        token: address,
+        // Deep link to the ARM's own page, the form originprotocol.com/arm links to.
+        url: `https://app.originprotocol.com/#/arm/${arm.chainId}:${arm.symbol}`,
+      };
+    })
+    .filter((pool) => pool !== null && Number.isFinite(pool.tvlUsd));
+
+  return addMerklRewardApy(pools, 'origin');
 };
 
 module.exports = {

--- a/src/adaptors/origin-arm/index.js
+++ b/src/adaptors/origin-arm/index.js
@@ -76,7 +76,13 @@ const sharePricesDaysAgo = (chainKey, addresses, days) =>
     .getPriceApiData(
       `/block/${chainKey}/${Math.floor(Date.now() / 1000) - days * DAY_SECONDS}`
     )
-    .then((r) => sharePricesAt(chainKey, addresses, r.height));
+    .then((r) => {
+      // Without a height the read would silently fall back to the latest block, making the
+      // window's two ends identical and reporting 0% rather than failing. Throwing hands it to
+      // the per-chain catch, which skips this chain and retries next run.
+      if (!r?.height) throw new Error(`no block height for ${chainKey} ${days}d ago`);
+      return sharePricesAt(chainKey, addresses, r.height);
+    });
 
 // Compound the share-price growth across a window into an annual rate. Null when the ARM did not
 // exist at the far end, or when the move is too large to be yield.

--- a/src/adaptors/origin-dollar/index.js
+++ b/src/adaptors/origin-dollar/index.js
@@ -59,7 +59,7 @@ const apy = async () => {
       underlyingTokens: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
       token: OUSD,
       isIntrinsicSource: true,
-      url: 'https://originprotocol.eth.limo/#/ousd',
+      url: 'https://app.originprotocol.com/#/ousd',
     },
   ];
 };

--- a/src/adaptors/origin-dollar/index.js
+++ b/src/adaptors/origin-dollar/index.js
@@ -1,63 +1,67 @@
-const axios = require('axios');
+/*
+ * Origin Dollar: OUSD.
+ *
+ * TVL comes from Origin's production squid. `protocolDailyStatDetails.tvl` is the backing that
+ * belongs to holders: it nets out the OUSD the vault's own Curve AMO minted into the pool, which
+ * is protocol-owned liquidity rather than depositor funds. That runs ~11% below OUSD's total
+ * supply, which is what a naive totalSupply x price reports.
+ */
 const { gql, request } = require('graphql-request');
-const sdk = require('@defillama/sdk');
-const { getPriceApiData } = require('../utils');
+
+const utils = require('../utils');
+const { onChainApy } = require('../origin-ether/otokenApy');
 
 const OUSD = '0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86';
+const PRICE_KEY = `ethereum:${OUSD}`;
+
 const graphUrl = 'https://origin.squids.live/origin-squid/graphql';
 
-const apy = async () => {
-  const query = gql`
-    query OTokenApy($chainId: Int!, $token: String!) {
-      oTokenApies(
-        limit: 1
-        orderBy: timestamp_DESC
-        where: { chainId_eq: $chainId, otoken_containsInsensitive: $token }
-      ) {
-        apy7DayAvg
-        apy14DayAvg
-        apy30DayAvg
-        apr
-        apy
-      }
+const statsQuery = gql`
+  query OusdStats {
+    protocolDailyStatDetails(
+      limit: 1
+      orderBy: date_DESC
+      where: { product_eq: "OUSD" }
+    ) {
+      tvl
+      rateETH
     }
-  `;
+  }
+`;
 
-  const variables = {
-    token: OUSD,
-    chainId: 1,
-  };
+const apy = async () => {
+  const [stats, priceData, apyBase] = await Promise.all([
+    request(graphUrl, statsQuery),
+    utils.getPriceApiData(`/prices/current/${PRICE_KEY}`),
+    onChainApy('ethereum', OUSD),
+  ]);
 
-  const apy =
-    (await request(graphUrl, query, variables)).oTokenApies[0].apy7DayAvg * 100;
+  const row = stats.protocolDailyStatDetails[0];
+  // Product rows report `tvl` in ETH; `rateETH` is OUSD's price in ETH, so this recovers the
+  // OUSD-denominated amount and avoids valuing a dollar product through the ETH price.
+  const tvlOusd = Number(row.tvl) / Number(row.rateETH);
+  const tvlUsd = tvlOusd * priceData.coins[PRICE_KEY].price;
 
-  const totalSupply =
-    (
-      await sdk.api.abi.call({
-        target: OUSD,
-        abi: 'erc20:totalSupply',
-      })
-    ).output / 1e18;
+  // Emit nothing rather than a partial pool: a failed archive read just means no sample this
+  // run, and the next one picks it up.
+  if (!Number.isFinite(tvlUsd) || !Number.isFinite(apyBase)) return [];
 
-  const priceKey = `ethereum:${OUSD}`;
-  const price = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey].price;
-
-  const ousd = {
-    pool: OUSD,
-    chain: 'Ethereum',
-    project: 'origin-dollar',
-    symbol: 'OUSD',
-    tvlUsd: totalSupply * price,
-    apy,
-    underlyingTokens: [
-      '0xdac17f958d2ee523a2206206994597c13d831ec7',
-      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-      '0x6b175474e89094c44da98b954eedeac495271d0f',
-    ],
-    url: 'https://originprotocol.eth.limo/#/ousd',
-  };
-
-  return [ousd];
+  return [
+    {
+      pool: OUSD,
+      chain: 'Ethereum',
+      project: 'origin-dollar',
+      symbol: 'OUSD',
+      tvlUsd,
+      // OUSD yield is all base yield: strategy returns rebase into the token.
+      apyBase,
+      // The vault's only collateral asset today; it used to also hold USDT and DAI.
+      underlyingTokens: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
+      token: OUSD,
+      isIntrinsicSource: true,
+      url: 'https://originprotocol.eth.limo/#/ousd',
+    },
+  ];
 };
 
 module.exports = {

--- a/src/adaptors/origin-dollar/index.js
+++ b/src/adaptors/origin-dollar/index.js
@@ -37,6 +37,8 @@ const apy = async () => {
   ]);
 
   const row = stats.protocolDailyStatDetails[0];
+  if (!row) return [];
+
   // Product rows report `tvl` in ETH; `rateETH` is OUSD's price in ETH, so this recovers the
   // OUSD-denominated amount and avoids valuing a dollar product through the ETH price.
   const tvlOusd = Number(row.tvl) / Number(row.rateETH);

--- a/src/adaptors/origin-ether/index.js
+++ b/src/adaptors/origin-ether/index.js
@@ -1,125 +1,102 @@
-const axios = require('axios');
+/*
+ * Origin Ether: OETH (Ethereum) and superOETHb (Base).
+ *
+ * Both TVL and APY come from Origin's production squid, so these pools carry the same numbers
+ * Origin reports itself.
+ *
+ * `protocolDailyStatDetails.tvl` is the backing that belongs to holders: it nets out the OToken
+ * the vault's own AMO strategies minted into Curve/Aerodrome pools, which is protocol-owned
+ * liquidity rather than depositor funds. Raw `vault.totalValue()` includes it and puts
+ * superOETHb at ~$29M against ~$19M of holder-owned backing.
+ *
+ * This is deliberately not Origin Ether's protocol TVL on DefiLlama, which on Base also drops
+ * the bridged wOETH strategy (~8.4k WETH, the row's `bridgedTvl`) because that backing is
+ * already counted on Ethereum. Netting it out is right for protocol TVL, but wrong for pool
+ * size -- the bridged wOETH is precisely what backs superOETHb holders' balances.
+ */
 const { gql, request } = require('graphql-request');
-const sdk = require('@defillama/sdk');
 
-const { capitalizeFirstLetter, getPriceApiUrl } = require('../utils');
+const utils = require('../utils');
+const { onChainApy } = require('./otokenApy');
 
 const ETHEREUM_OETH_TOKEN = '0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3';
-const BASE_WETH_TOKEN = '0x4200000000000000000000000000000000000006';
 const BASE_SUPER_OETH_TOKEN = '0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3';
-const PLUME_WETH_TOKEN = '0xca59cA09E5602fAe8B629DeE83FfA819741f14be';
-const PLUME_SUPER_OETH_TOKEN = '0xFCbe50DbE43bF7E5C88C6F6Fb9ef432D4165406E';
 
-const oethVaultAddress = '0x39254033945AA2E4809Cc2977E7087BEE48bd7Ab';
-const superOETHbVaultAddress = '0x98a0CbeF61bD2D21435f433bE4CD42B56B38CC93';
-const superOETHpVaultAddress = '0xc8c8F8bEA5631A8AF26440AF32a55002138cB76a';
+const NATIVE_ETH = '0x0000000000000000000000000000000000000000';
+const ETH_PRICE_KEY = `ethereum:${NATIVE_ETH}`;
 
 const graphUrl = 'https://origin.squids.live/origin-squid/graphql';
 
-const vaultABI = {
-  inputs: [],
-  name: 'totalValue',
-  outputs: [{ internalType: 'uint256', name: 'value', type: 'uint256' }],
-  stateMutability: 'view',
-  type: 'function',
-};
+const PRODUCTS = [
+  {
+    product: 'OETH',
+    symbol: 'OETH',
+    chain: 'Ethereum',
+    sdkChain: 'ethereum',
+    token: ETHEREUM_OETH_TOKEN,
+  },
+  {
+    product: 'superOETHb',
+    symbol: 'superOETHb',
+    chain: 'Base',
+    sdkChain: 'base',
+    token: BASE_SUPER_OETH_TOKEN,
+  },
+];
 
-const fetchPoolData = async ({
-  chain,
-  vaultAddress,
-  token,
-  symbol,
-  project,
-  underlyingToken,
-  tokenAddress,
-  chainId,
-}) => {
-  const query = gql`
-    query OTokenApy($chainId: Int!, $token: String!) {
-      oTokenApies(
-        limit: 1
-        orderBy: timestamp_DESC
-        where: { chainId_eq: $chainId, otoken_containsInsensitive: $token }
-      ) {
-        apy7DayAvg
-      }
+const statsQuery = gql`
+  query ProductStats($product: String!) {
+    protocolDailyStatDetails(
+      limit: 1
+      orderBy: date_DESC
+      where: { product_eq: $product }
+    ) {
+      tvl
+      rateETH
     }
-  `;
+  }
+`;
 
-  const variables = {
-    token,
-    chainId,
-  };
+const fetchPoolData = async ({ product, symbol, chain, sdkChain, token }, ethPrice) => {
+  const [stats, apyBase] = await Promise.all([
+    request(graphUrl, statsQuery, { product }),
+    onChainApy(sdkChain, token),
+  ]);
 
-  const apyData = await request(graphUrl, query, variables);
-  const rawApy = apyData.oTokenApies[0]?.apy7DayAvg;
-  const apy = rawApy != null ? rawApy * 100 : null;
-
-  const totalValueEth = (
-    await sdk.api.abi.call({
-      chain,
-      target: vaultAddress,
-      abi: vaultABI,
-    })
-  ).output;
-
-  const ethPriceKey = 'ethereum:0x0000000000000000000000000000000000000000';
-  const ethPriceRes = await axios.get(
-    getPriceApiUrl(`/prices/current/${ethPriceKey}`)
-  );
-  const ethPrice = ethPriceRes.data.coins[ethPriceKey].price;
-
-  const tvlUsd = (totalValueEth / 1e18) * ethPrice;
+  const row = stats.protocolDailyStatDetails[0];
+  // `tvl` is denominated in ETH on every product row, so it converts straight through the ETH
+  // price. (`rateETH` is 1 for the ETH-denominated products; dividing keeps this correct if a
+  // future product is denominated in something else.)
+  const tvlEth = Number(row?.tvl) / Number(row?.rateETH);
 
   return {
     pool: token,
-    chain: capitalizeFirstLetter(chain),
-    project,
+    chain,
+    project: 'origin-ether',
     symbol,
-    tvlUsd,
-    apy,
-    underlyingTokens: [underlyingToken],
-    searchTokenOverride: tokenAddress,
+    tvlUsd: tvlEth * ethPrice,
+    // OToken yield is all base yield: the vault's strategy returns rebase into the token.
+    apyBase,
+    underlyingTokens: [NATIVE_ETH],
+    token,
+    searchTokenOverride: token,
+    isIntrinsicSource: true,
   };
 };
 
 const apy = async () => {
-  const pools = await Promise.allSettled([
-    fetchPoolData({
-      chain: 'ethereum',
-      chainId: 1,
-      vaultAddress: oethVaultAddress,
-      token: ETHEREUM_OETH_TOKEN,
-      symbol: 'OETH',
-      project: 'origin-ether',
-      underlyingToken: '0x0000000000000000000000000000000000000000',
-      tokenAddress: ETHEREUM_OETH_TOKEN,
-      isIntrinsicSource: true,
-    }),
-    fetchPoolData({
-      chain: 'base',
-      chainId: 8453,
-      vaultAddress: superOETHbVaultAddress,
-      token: BASE_SUPER_OETH_TOKEN,
-      symbol: 'superOETHb',
-      project: 'origin-ether',
-      underlyingToken: '0x0000000000000000000000000000000000000000',
-      tokenAddress: BASE_SUPER_OETH_TOKEN,
-      isIntrinsicSource: true,
-    }),
-    fetchPoolData({
-      chain: 'plume_mainnet',
-      chainId: 98866,
-      vaultAddress: superOETHpVaultAddress,
-      token: PLUME_SUPER_OETH_TOKEN,
-      symbol: 'superOETHp',
-      project: 'origin-ether',
-      underlyingToken: '0x0000000000000000000000000000000000000000',
-      tokenAddress: PLUME_SUPER_OETH_TOKEN,
-      isIntrinsicSource: true,
-    }),
-  ]);
-  return pools.filter((i) => i.status === 'fulfilled').map((i) => i.value);
+  const ethPrice = (
+    await utils.getPriceApiData(`/prices/current/${ETH_PRICE_KEY}`)
+  ).coins[ETH_PRICE_KEY].price;
+
+  const pools = await Promise.allSettled(
+    PRODUCTS.map((p) => fetchPoolData(p, ethPrice))
+  );
+
+  return pools
+    .filter((i) => i.status === 'fulfilled')
+    .map((i) => i.value)
+    .filter((p) => Number.isFinite(p.tvlUsd) && Number.isFinite(p.apyBase));
 };
 
 module.exports = {

--- a/src/adaptors/origin-ether/index.js
+++ b/src/adaptors/origin-ether/index.js
@@ -34,6 +34,7 @@ const PRODUCTS = [
     chain: 'Ethereum',
     sdkChain: 'ethereum',
     token: ETHEREUM_OETH_TOKEN,
+    url: 'https://app.originprotocol.com/#/oeth',
   },
   {
     product: 'superOETHb',
@@ -41,6 +42,7 @@ const PRODUCTS = [
     chain: 'Base',
     sdkChain: 'base',
     token: BASE_SUPER_OETH_TOKEN,
+    url: 'https://app.originprotocol.com/#/super',
   },
 ];
 
@@ -57,7 +59,7 @@ const statsQuery = gql`
   }
 `;
 
-const fetchPoolData = async ({ product, symbol, chain, sdkChain, token }, ethPrice) => {
+const fetchPoolData = async ({ product, symbol, chain, sdkChain, token, url }, ethPrice) => {
   const [stats, apyBase] = await Promise.all([
     request(graphUrl, statsQuery, { product }),
     onChainApy(sdkChain, token),
@@ -81,6 +83,7 @@ const fetchPoolData = async ({ product, symbol, chain, sdkChain, token }, ethPri
     token,
     searchTokenOverride: token,
     isIntrinsicSource: true,
+    url,
   };
 };
 

--- a/src/adaptors/origin-ether/otokenApy.js
+++ b/src/adaptors/origin-ether/otokenApy.js
@@ -1,0 +1,52 @@
+/*
+ * Base APY for an Origin OToken (OETH, superOETHb, OUSD, OS), read on-chain.
+ *
+ * An OToken's rebasing multiplier is 1 / rebasingCreditsPerToken, so the ratio of that value
+ * across a window is exactly what the token rebased over it -- the realised base yield, taken
+ * straight off the token with no vault or AMO accounting involved.
+ *
+ * Shared by the origin-* adaptors. This is base yield only -- the rebase does not carry Merkl
+ * incentives, which are reported separately as `apyReward` where they apply.
+ *
+ * It reads ~0.2pp above the squid's `apy7DayAvg` because that average includes the in-progress
+ * day, whose yield is annualised over a full day regardless of how much of it has actually
+ * elapsed (origin-squid `docs/fix-apy-window.md`). Measuring a real elapsed window avoids that.
+ */
+const sdk = require('@defillama/sdk');
+
+const utils = require('../utils');
+
+const CREDITS_ABI = 'uint256:rebasingCreditsPerTokenHighres';
+const WINDOW_DAYS = 7;
+const DAY_SECONDS = 86400;
+
+const creditsAt = (chain, token, block) =>
+  sdk.api.abi.call({ chain, target: token, abi: CREDITS_ABI, block });
+
+// Returns null if the window can't be read, so callers can fall back rather than drop the pool.
+const onChainApy = async (chain, token) => {
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const then = now - WINDOW_DAYS * DAY_SECONDS;
+
+    const [blockNow, blockThen] = await Promise.all([
+      utils.getPriceApiData(`/block/${chain}/${now}`),
+      utils.getPriceApiData(`/block/${chain}/${then}`),
+    ]);
+
+    const [creditsNow, creditsThen] = await Promise.all([
+      creditsAt(chain, token, blockNow.height),
+      creditsAt(chain, token, blockThen.height),
+    ]);
+
+    // Credits per token only falls as the token rebases up, so this ratio is >= 1.
+    const ratio = Number(creditsThen.output) / Number(creditsNow.output);
+    if (!(ratio > 0)) return null;
+
+    return (ratio ** (365 / WINDOW_DAYS) - 1) * 100;
+  } catch (e) {
+    return null;
+  }
+};
+
+module.exports = { onChainApy };

--- a/src/adaptors/origin-sonic/index.js
+++ b/src/adaptors/origin-sonic/index.js
@@ -1,59 +1,82 @@
+/*
+ * Origin Sonic: OS, a rebasing LST backed by wrapped Sonic.
+ *
+ * TVL and APY come from Origin's production squid, so this pool carries the numbers Origin
+ * reports itself. The APY replaces a day-over-day wOS exchange-rate delta, which needed two
+ * block-height lookups and annualised a single noisy day.
+ */
 const sdk = require('@defillama/sdk');
-const axios = require('axios');
+const { gql, request } = require('graphql-request');
+
 const { getPriceApiData } = require('../utils');
+const { onChainApy } = require('../origin-ether/otokenApy');
 
 const WRAPPED_ORIGIN_SONIC = '0x9F0dF7799f6FDAd409300080cfF680f5A23df4b1';
 const ORIGIN_SONIC = '0xb1e25689d55734fd3fffc939c4c3eb52dff8a794';
 const SONIC = '0x0000000000000000000000000000000000000000';
-const project = 'origin-sonic';
-const symbol = 'OS';
-const exchangeRateAbi = 'function convertToAssets(uint256 shares) view returns (uint256 assets)';
+const PRICE_KEY = `sonic:${SONIC}`;
+
+const graphUrl = 'https://origin.squids.live/origin-squid/graphql';
+
+const exchangeRateAbi =
+  'function convertToAssets(uint256 shares) view returns (uint256 assets)';
+
+const statsQuery = gql`
+  query OsStats {
+    protocolDailyStatDetails(
+      limit: 1
+      orderBy: date_DESC
+      where: { product_eq: "OS" }
+    ) {
+      tvl
+      rateETH
+    }
+  }
+`;
 
 const apy = async () => {
-    const tvl = (await sdk.api.erc20.totalSupply({ target: ORIGIN_SONIC, chain: 'sonic' })).output / 1e18;
+  const [stats, priceData, apyBase, exchangeRate] = await Promise.all([
+    request(graphUrl, statsQuery),
+    getPriceApiData(`/prices/current/${PRICE_KEY}`),
+    onChainApy('sonic', ORIGIN_SONIC),
+    sdk.api.abi.call({
+      target: WRAPPED_ORIGIN_SONIC,
+      chain: 'sonic',
+      abi: exchangeRateAbi,
+      params: ['1000000000000000000'],
+    }),
+  ]);
 
-    const priceKey = `sonic:${SONIC}`;
-    const sonicPrice = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;
+  const row = stats.protocolDailyStatDetails[0];
+  // Product rows report `tvl` in ETH; `rateETH` is S's price in ETH, so this recovers the
+  // S-denominated amount and avoids valuing a Sonic product through the ETH price.
+  const tvlSonic = Number(row.tvl) / Number(row.rateETH);
+  const tvlUsd = tvlSonic * priceData.coins[PRICE_KEY].price;
+  const pricePerShare = Number(exchangeRate.output) / 1e18;
 
-    const timestampNow = Math.floor(Date.now() / 1000);
-    const timestampYesterday = timestampNow - 86400;
+  // Emit nothing rather than a partial pool: a failed archive read just means no sample this
+  // run, and the next one picks it up.
+  if (!Number.isFinite(tvlUsd) || !Number.isFinite(apyBase)) return [];
 
-    const blockNow = (await getPriceApiData(`/block/sonic/${timestampNow}`)).height;
-
-    const blockYesterday = (await getPriceApiData(`/block/sonic/${timestampYesterday}`)).height;
-
-    const exchangeRateYesterday = await sdk.api.abi.call({
-        target: WRAPPED_ORIGIN_SONIC,
-        chain: 'sonic',
-        abi: exchangeRateAbi,
-        params: ['1000000000000000000'],
-        block: blockYesterday,
-    });
-
-    const exchangeRateToday = await sdk.api.abi.call({
-        target: WRAPPED_ORIGIN_SONIC,
-        chain: 'sonic',
-        abi: exchangeRateAbi,
-        params: ['1000000000000000000'],
-        block: blockNow,
-    });
-
-    const apr =
-        ((exchangeRateToday.output - exchangeRateYesterday.output) /
-            exchangeRateYesterday.output) * 365 * 100;
-
-    return [
-        {
-            pool: `${ORIGIN_SONIC}`,
-            chain: 'sonic',
-            project,
-            symbol,
-            underlyingTokens: [SONIC],
-            apyBase: apr,
-            ...(Number(exchangeRateToday.output) / 1e18 > 0 && { pricePerShare: Number(exchangeRateToday.output) / 1e18 }),
-            tvlUsd: (tvl * sonicPrice),
-        },
-    ];
+  return [
+    {
+      pool: ORIGIN_SONIC,
+      chain: 'Sonic',
+      project: 'origin-sonic',
+      symbol: 'OS',
+      tvlUsd,
+      apyBase,
+      underlyingTokens: [SONIC],
+      token: ORIGIN_SONIC,
+      isIntrinsicSource: true,
+      ...(pricePerShare > 0 && { pricePerShare }),
+    },
+  ];
 };
 
-module.exports = { protocolId: '5688', apy, url: 'https://www.originprotocol.com/os' };
+module.exports = {
+  protocolId: '5688',
+  timetravel: false,
+  apy,
+  url: 'https://www.originprotocol.com/os',
+};

--- a/src/adaptors/origin-sonic/index.js
+++ b/src/adaptors/origin-sonic/index.js
@@ -78,5 +78,7 @@ module.exports = {
   protocolId: '5688',
   timetravel: false,
   apy,
-  url: 'https://www.originprotocol.com/os',
+  // OS has no product page of its own any more, so this points at the site root rather than the
+  // old /os path, which now serves a soft 404.
+  url: 'https://www.originprotocol.com',
 };

--- a/src/adaptors/origin-sonic/index.js
+++ b/src/adaptors/origin-sonic/index.js
@@ -48,6 +48,8 @@ const apy = async () => {
   ]);
 
   const row = stats.protocolDailyStatDetails[0];
+  if (!row) return [];
+
   // Product rows report `tvl` in ETH; `rateETH` is S's price in ETH, so this recovers the
   // S-denominated amount and avoids valuing a Sonic product through the ETH price.
   const tvlSonic = Number(row.tvl) / Number(row.rateETH);


### PR DESCRIPTION
origin-arm listed only the Lido ARM. It now lists all five live ARMs (~$8.8M):
TVL from totalAssets(), APY from convertToAssets() over a trailing 30d window,
and Merkl incentives via the shared merkl helper as apyReward.

The OTokens valued TVL with vault.totalValue(), which counts the OToken their
AMOs mint into Curve/Aerodrome pools -- protocol liquidity, not deposits. That
roughly doubled the reported pool size (superOETHb $28M against ~$19M). They now
read Origin's protocolDailyStatDetails.tvl, which is already net of it, and
measure APY on-chain from rebasingCreditsPerTokenHighres over 7d.

superOETHb's pool TVL intentionally differs from Origin Ether's protocol TVL on
DefiLlama, which additionally nets out the bridged wOETH already counted on
Ethereum: right for protocol TVL, wrong for pool size, since that wOETH is what
backs superOETHb holders' balances.

superOETHp is dropped (retired). Smaller fixes: apyBase rather than apy, OUSD's
underlyingTokens (USDT/DAI -> USDC), and chain names.

also update url links for each of the products

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic discovery and tracking for Origin ARM vaults on Ethereum and Sonic.
  * Added support for OETH, superOETHb, OUSD, and Origin Sonic products.
  * Added Merkl incentive APY where available.

* **Bug Fixes**
  * Improved TVL and APY accuracy using Origin production statistics and on-chain yield data.
  * Excluded retired, unsupported, or invalid vault results.
  * Updated product links, metadata, pricing, and displayed underlying assets.
  * Removed unsupported superOETHp data from Plume.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->