### PR TITLE
add neutral-trade adapter

### DIFF
--- a/src/adaptors/neutral-trade/index.js
+++ b/src/adaptors/neutral-trade/index.js
@@ -1,0 +1,41 @@
+const utils = require('../utils');
+
+// Public, unauthenticated endpoint served by Neutral Trade's bundle indexer.
+// Contract: { data: { vaults: [{ bundleKey, name, asset: { mint, symbol },
+// tvlUsd, apy7dAfterFees, apy30dAfterFees, apyInceptionAfterFees }] } }
+// with rates as decimal fractions net of performance + management fees.
+const API_URL = 'https://bundle-indexer-api.onrender.com/public/yields';
+
+const toPct = (rate) => (Number.isFinite(rate) ? rate * 100 : null);
+
+const getApy = async () => {
+  const { data } = await utils.withRetry(() => utils.getData(API_URL));
+
+  return data.vaults
+    .filter((vault) => vault.asset?.mint && vault.asset?.symbol)
+    .map((vault) => ({
+      pool: vault.bundleKey,
+      chain: utils.formatChain('solana'),
+      project: 'neutral-trade',
+      symbol: utils.formatSymbol(vault.asset.symbol),
+      poolMeta: vault.name ?? undefined,
+      underlyingTokens: [vault.asset.mint],
+      // null when the indexer has no fresh USD price; dropped by keepFinite
+      tvlUsd: vault.tvlUsd,
+      // 7d NAV growth net of fees; longer windows cover young vaults
+      apyBase: toPct(
+        vault.apy7dAfterFees ??
+          vault.apy30dAfterFees ??
+          vault.apyInceptionAfterFees
+      ),
+      apyBase7d: toPct(vault.apy7dAfterFees),
+    }))
+    .filter(utils.keepFinite);
+};
+
+module.exports = {
+  protocolId: '5548',
+  timetravel: false,
+  apy: getApy,
+  url: 'https://www.neutral.trade/',
+};

--- a/src/adaptors/neutral-trade/index.js
+++ b/src/adaptors/neutral-trade/index.js
@@ -4,7 +4,7 @@ const utils = require('../utils');
 // Contract: { data: { vaults: [{ bundleKey, name, asset: { mint, symbol },
 // tvlUsd, apy7dAfterFees, apy30dAfterFees, apyInceptionAfterFees }] } }
 // with rates as decimal fractions net of performance + management fees.
-const API_URL = 'https://bundle-indexer-api.onrender.com/public/yields';
+const API_URL = 'https://api.neutral.trade/public/yields';
 
 const toPct = (rate) => (Number.isFinite(rate) ? rate * 100 : null);
 

--- a/src/adaptors/neutral-trade/index.js
+++ b/src/adaptors/neutral-trade/index.js
@@ -1,37 +1,98 @@
 const utils = require('../utils');
 
-// Public, unauthenticated endpoint served by Neutral Trade's bundle indexer.
-// Contract: { data: { vaults: [{ bundleKey, name, asset: { mint, symbol },
-// tvlUsd, apy7dAfterFees, apy30dAfterFees, apyInceptionAfterFees }] } }
-// with rates as decimal fractions net of performance + management fees.
-const API_URL = 'https://api.neutral.trade/public/yields';
+const APP_URL = 'https://www.neutral.trade';
+const YIELDS_API_URL = 'https://api.neutral.trade/public/yields';
+
+const vaultMetadata = {
+  '2bPiNfGc7exUcGkvV5nbsSkuNH3inFU18kgNEkB8fiaT': {
+    snapshotVaultId: 71,
+    strategySlug: 'hyperithm1',
+  },
+  '3vZKAcd74bzwNYZmsJndYExkGj6ABQwrUoiMtdNfzLZe': {
+    snapshotVaultId: 80,
+    strategySlug: 'options-mm-z',
+  },
+  '46gSEJLNTdDFq7DPjH8RbcTmG1gyw4JCKCr1XfuAfYvh': {
+    snapshotVaultId: 75,
+    strategySlug: 'adverseguard-alpha',
+  },
+  '4QBTzqUbn1crLg2PDUGt8abJfqHjeuZkjNLjCCit69ui': {
+    snapshotVaultId: 74,
+    strategySlug: 'volatility-alpha-strategy-1',
+  },
+  '9cMB2bMsLa9hZjRnjxFhg2DM9CLmjabMsGvfQUtdgupk': {
+    snapshotVaultId: 65,
+    strategySlug: 'jlpdn',
+  },
+  C68A4mAhA9EE4rWq9HmFnq3SPcbNmst6qiBWcna5VDHy: {
+    snapshotVaultId: 82,
+    strategySlug: 'hft-multi-factor',
+  },
+  De47QBuMP7xukYBek5r4ScZF4HEk1kHW34ymKASz3DLt: {
+    snapshotVaultId: 78,
+    strategySlug: 'velox-cross-usdc-bundle',
+  },
+  Ec6uSz5EsffwfXp43pvpz4rf9ttJRFKES4ZSVX7gVVkQ: {
+    snapshotVaultId: 77,
+    strategySlug: 'systematic-alpha',
+  },
+  Eo3m78EQcHnwMyHtxaiz1vw4nwHa85RuGE8jLsrELhxj: {
+    snapshotVaultId: 72,
+    strategySlug: 'cta-adaptive-alpha',
+  },
+  G5aMxQTbGWMnYycpfjHpD7Y1muoKBwaB1HtCdpUUcQZp: {
+    snapshotVaultId: 83,
+    strategySlug: 'cta-longshort-alpha',
+  },
+  nE1x7KQq2sm3GQrafQUUdBkSPPT52FmiMM9qAS1dgnC: {
+    snapshotVaultId: 48,
+    strategySlug: 'hlfundingarb',
+  },
+};
 
 const toPct = (rate) => (Number.isFinite(rate) ? rate * 100 : null);
 
-const getApy = async () => {
-  const { data } = await utils.withRetry(() => utils.getData(API_URL));
+const getPricePerShare = async (snapshotVaultId) => {
+  const { data } = await utils.withRetry(() =>
+    utils.getData(
+      `${APP_URL}/api/daily-vault-snapshot/${snapshotVaultId}?limit=1&sort=desc`
+    )
+  );
+  const pricePerShare = data?.[0]?.pps_token_close;
 
-  return data.vaults
-    .filter((vault) => vault.asset?.mint && vault.asset?.symbol)
-    .map((vault) => ({
+  if (!Number.isFinite(pricePerShare) || pricePerShare <= 0) {
+    throw new Error(`Invalid price per share for vault ${snapshotVaultId}`);
+  }
+
+  return pricePerShare;
+};
+
+const getApy = async () => {
+  const { data } = await utils.withRetry(() => utils.getData(YIELDS_API_URL));
+  const vaults = data.vaults.filter(
+    (vault) =>
+      vault.asset?.mint && vault.asset?.symbol && vaultMetadata[vault.bundleKey]
+  );
+  const pricesPerShare = await Promise.all(
+    vaults.map((vault) =>
+      getPricePerShare(vaultMetadata[vault.bundleKey].snapshotVaultId)
+    )
+  );
+
+  return vaults
+    .map((vault, index) => ({
       pool: vault.bundleKey,
       chain: utils.formatChain('solana'),
       project: 'neutral-trade',
-      symbol: utils.formatSymbol(vault.asset.symbol),
+      symbol: vault.asset.symbol,
       poolMeta: vault.name ?? undefined,
       underlyingTokens: [vault.asset.mint],
-      // bundle shares are a virtual u128 on the vault account; no SPL share
-      // mint exists
       token: null,
-      // null when the indexer has no fresh USD price; dropped by keepFinite
       tvlUsd: vault.tvlUsd,
-      // 7d NAV growth net of fees; longer windows cover young vaults
-      apyBase: toPct(
-        vault.apy7dAfterFees ??
-          vault.apy30dAfterFees ??
-          vault.apyInceptionAfterFees
-      ),
+      apyBase: toPct(vault.apy7dAfterFees),
       apyBase7d: toPct(vault.apy7dAfterFees),
+      pricePerShare: pricesPerShare[index],
+      url: `${APP_URL}/strategies/${vaultMetadata[vault.bundleKey].strategySlug}`,
     }))
     .filter(utils.keepFinite);
 };

--- a/src/adaptors/neutral-trade/index.js
+++ b/src/adaptors/neutral-trade/index.js
@@ -44,6 +44,10 @@ const vaultMetadata = {
     snapshotVaultId: 83,
     strategySlug: 'cta-longshort-alpha',
   },
+  J7qhMAKnB6G5dvoAN9281ufabajKbyGQxxd2bq6R7fPJ: {
+    snapshotVaultId: 76,
+    strategySlug: 'neutral-autopilot',
+  },
   nE1x7KQq2sm3GQrafQUUdBkSPPT52FmiMM9qAS1dgnC: {
     snapshotVaultId: 48,
     strategySlug: 'hlfundingarb',

--- a/src/adaptors/neutral-trade/index.js
+++ b/src/adaptors/neutral-trade/index.js
@@ -20,6 +20,9 @@ const getApy = async () => {
       symbol: utils.formatSymbol(vault.asset.symbol),
       poolMeta: vault.name ?? undefined,
       underlyingTokens: [vault.asset.mint],
+      // bundle shares are a virtual u128 on the vault account; no SPL share
+      // mint exists
+      token: null,
       // null when the indexer has no fresh USD price; dropped by keepFinite
       tvlUsd: vault.tvlUsd,
       // 7d NAV growth net of fees; longer windows cover young vaults


### PR DESCRIPTION
Adds a yields adapter for Neutral Trade Solana bundle vaults running quantitative strategies on USDC deposits. Vault NAV is pushed onchain daily by a keeper oracle. Shares are virtual u128 values on the vault account with no Token share mint, so `pool` is the bundle account address and `token` is explicitly `null`.

Protocol slug `neutral-trade` (id `5548`) is listed on the DefiLlama TVL page.

### Pools

The adapter maps all 12 public, enabled, catalog-visible Solana USDC bundle vaults in the bundle-indexer registry, including Neutral Autopilot (legacy vault id `76`). During validation, the aggregate yields endpoint still returned its previous 11-pool set while that visibility change propagates; all 11 returned pools were above the $10k display floor. Autopilot's live daily snapshot is already available and its adapter row was validated separately.

### Data sources

- `https://api.neutral.trade/public/yields` provides a 60-second cached projection of each visible vault's TVL and after-fee 7-day APY. TVL combines the onchain token balance with keeper-oracle-posted equity deployed at external venues, matching the existing DefiLlama TVL adapter's definition.
- `https://www.neutral.trade/api/daily-vault-snapshot/<vaultId>?limit=1&sort=desc` provides each vault's latest token-denominated daily share-price close. The adapter also maps every bundle account to its specific strategy page.

These public read-only APIs are used because share-price history lives in program event logs. Reconstructing the same history from a public RPC requires a paced walk through signatures and transactions for every vault.

### APY methodology

`apyBase` and `apyBase7d` both use the same trailing 7-day share-price growth, annualized as `(pps_now / pps_then)^(365 / window) - 1` and net of performance and management fees. A vault without a complete 7-day observation is omitted until that window is available. A 24-hour window is not used because NAV updates once per day, so it can straddle one or two oracle updates. The protocol's points program is excluded, so no `apyReward` is emitted.

`pricePerShare` is the latest underlying-token amount per virtual share.

`npm run test --adapter=neutral-trade`: 94 passed against the current 11-pool live response. The Autopilot fixture-path check also passed with its live token PPS and pool-specific URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Neutral Trade vaults.
  * Added APY and price-per-share data retrieval with validation and retry handling.
  * Added standardized Solana pool records for supported vaults.
  * Converted APY values to percentage format and excluded invalid results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->