### PR TITLE
securitize funds: skip the pool when the 30d oracle read fails instead of publishing 0% apy

### DIFF
--- a/src/adaptors/apollo-diversified-credit-securitize-fund/index.js
+++ b/src/adaptors/apollo-diversified-credit-securitize-fund/index.js
@@ -40,10 +40,9 @@ const apy = async () => {
     block30d ? getOraclePrice(block30d).catch(() => null) : null,
   ]);
 
-  const apyBase =
-    price30d && price30d > 0
-      ? ((priceNow - price30d) / price30d) * (365 / 30) * 100
-      : 0;
+  if (!(price30d > 0)) return [];
+
+  const apyBase = ((priceNow - price30d) / price30d) * (365 / 30) * 100;
 
   // Fetch EVM supplies, decimals, and Solana supply
   const [supplyResults, decimalsResults, solSupply] = await Promise.all([

--- a/src/adaptors/apollo-diversified-credit-securitize-fund/index.js
+++ b/src/adaptors/apollo-diversified-credit-securitize-fund/index.js
@@ -40,7 +40,7 @@ const apy = async () => {
     block30d ? getOraclePrice(block30d).catch(() => null) : null,
   ]);
 
-  if (!(price30d > 0)) return [];
+  if (!(priceNow > 0) || !(price30d > 0)) return [];
 
   const apyBase = ((priceNow - price30d) / price30d) * (365 / 30) * 100;
 

--- a/src/adaptors/blockchain-capital/index.js
+++ b/src/adaptors/blockchain-capital/index.js
@@ -36,7 +36,7 @@ const apy = async () => {
     block30d ? getOraclePrice(block30d).catch(() => null) : null,
   ]);
 
-  if (!(price30d > 0)) return [];
+  if (!(priceNow > 0) || !(price30d > 0)) return [];
 
   const apyBase = ((priceNow - price30d) / price30d) * (365 / 30) * 100;
 

--- a/src/adaptors/blockchain-capital/index.js
+++ b/src/adaptors/blockchain-capital/index.js
@@ -36,10 +36,9 @@ const apy = async () => {
     block30d ? getOraclePrice(block30d).catch(() => null) : null,
   ]);
 
-  const apyBase =
-    price30d && price30d > 0
-      ? ((priceNow - price30d) / price30d) * (365 / 30) * 100
-      : 0;
+  if (!(price30d > 0)) return [];
+
+  const apyBase = ((priceNow - price30d) / price30d) * (365 / 30) * 100;
 
   const [supplyRes, decimalsRes] = await Promise.all([
     sdk.api.erc20

--- a/src/adaptors/hamilton-lane-senior-credit-opportunities-securitize-fund/index.js
+++ b/src/adaptors/hamilton-lane-senior-credit-opportunities-securitize-fund/index.js
@@ -53,7 +53,7 @@ const apy = async () => {
     block30d ? getOraclePrice(block30d).catch(() => null) : null,
   ]);
 
-  if (!(price30d > 0)) return [];
+  if (!(priceNow > 0) || !(price30d > 0)) return [];
 
   const apyBase = ((priceNow - price30d) / price30d) * (365 / 30) * 100;
 

--- a/src/adaptors/hamilton-lane-senior-credit-opportunities-securitize-fund/index.js
+++ b/src/adaptors/hamilton-lane-senior-credit-opportunities-securitize-fund/index.js
@@ -53,10 +53,9 @@ const apy = async () => {
     block30d ? getOraclePrice(block30d).catch(() => null) : null,
   ]);
 
-  const apyBase =
-    price30d && price30d > 0
-      ? ((priceNow - price30d) / price30d) * (365 / 30) * 100
-      : 0;
+  if (!(price30d > 0)) return [];
+
+  const apyBase = ((priceNow - price30d) / price30d) * (365 / 30) * 100;
 
   // Fetch supplies and decimals in parallel
   const [supplyResults, decimalsResults] = await Promise.all([

--- a/src/adaptors/securitize-tokenized-aaa-clo-fund/index.js
+++ b/src/adaptors/securitize-tokenized-aaa-clo-fund/index.js
@@ -36,7 +36,7 @@ const apy = async () => {
     block30d ? getOraclePrice(block30d).catch(() => null) : null,
   ]);
 
-  if (!(price30d > 0)) return [];
+  if (!(priceNow > 0) || !(price30d > 0)) return [];
 
   const apyBase = ((priceNow - price30d) / price30d) * (365 / 30) * 100;
 

--- a/src/adaptors/securitize-tokenized-aaa-clo-fund/index.js
+++ b/src/adaptors/securitize-tokenized-aaa-clo-fund/index.js
@@ -36,10 +36,9 @@ const apy = async () => {
     block30d ? getOraclePrice(block30d).catch(() => null) : null,
   ]);
 
-  const apyBase =
-    price30d && price30d > 0
-      ? ((priceNow - price30d) / price30d) * (365 / 30) * 100
-      : 0;
+  if (!(price30d > 0)) return [];
+
+  const apyBase = ((priceNow - price30d) / price30d) * (365 / 30) * 100;
 
   const [supplyRes, decimalsRes] = await Promise.all([
     sdk.api.erc20


### PR DESCRIPTION
Four securitize-family adaptors compute `apyBase` from a RedStone oracle price now vs 30 days ago. The 30d leg is a historical read, and both of its inputs are wrapped in `.catch(() => null)`:

```js
const [blockNow, block30d] = await Promise.all([
  getBlock(now),
  getBlock(now - 86400 * 30).catch(() => null),
]);
const [priceNow, price30d] = await Promise.all([
  getOraclePrice(blockNow).catch(() => null),
  block30d ? getOraclePrice(block30d).catch(() => null): null,
]);

const apyBase =
  price30d && price30d > 0
    ? ((priceNow - price30d) / price30d) * (365 / 30) * 100:
    0;
```

When that read fails the ternary falls to `0`, but `tvlUsd` is derived from `priceNow` and is still fine, so the pool gets published with its full TVL and a 0% yield. The other missing-input cases in these same files already `return []` / `continue`; only the apy input fabricates a value.

It shows up in the served data as isolated zero days with flat TVL and healthy neighbours. securitize-tokenized-aaa-clo-fund is at 0 right now:

```
2026-08-03 apyBase=4.64979 tvl=$102,849,551
2026-08-04 apyBase=4.90216 tvl=$102,870,804
2026-08-05 apyBase=4.80353 tvl=$102,898,186
2026-08-06 apyBase=0       tvl=$102,898,186
```

Over the last 90 days, across the three listed projects, 122 of 810 pool-days (15.1%) carry a zeroed apyBase. All 6 ACRED pools flip on the same days (2026-06-23, 2026-08-02) because they share one apyBase off a single ethereum oracle read, and both HLSCOPE pools do the same; a shared read failing, not yield actually going to zero. It also drags apyMean30d down (STAC reads 4.02 against a recent 4.3-4.9 range).

Fix is to skip the pool when the reference price is unavailable rather than invent a 0. Nothing changes on the happy path.

Verified with `npm run test --adapter=<name>` on all four, output unchanged:

| adaptor | pools | apyBase |
| --- | --- | --- |
| securitize-tokenized-aaa-clo-fund | 1 | 4.8035 |
| apollo-diversified-credit-securitize-fund | 6 | 1.9771 |
| hamilton-lane-senior-credit-opportunities-securitize-fund | 2 | 6.8552 |
| blockchain-capital | 1 | -4.6782 |

And with the historical oracle read forced to throw, before vs after:

```
before: 10 pools published, every one apyBase=0, $1.1B tvl between them
after:  0 pools published
```

which reproduces the zero days seen in production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APY reporting for several credit and tokenized fund products.
  * Products now return no APY result when current or 30-day oracle prices are missing, invalid, or not positive, avoiding misleading zero-value APYs.
  * Valid positive prices continue to use the existing annualized return calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->