### PR TITLE
origin-ether: fix TVL, measure APY on-chain, drop superOETHp

### DIFF
--- a/src/adaptors/origin-ether/index.js
+++ b/src/adaptors/origin-ether/index.js
@@ -1,125 +1,105 @@
-const axios = require('axios');
+/*
+ * Origin Ether: OETH (Ethereum) and superOETHb (Base).
+ *
+ * Both TVL and APY come from Origin's production squid, so these pools carry the same numbers
+ * Origin reports itself.
+ *
+ * `protocolDailyStatDetails.tvl` is the backing that belongs to holders: it nets out the OToken
+ * the vault's own AMO strategies minted into Curve/Aerodrome pools, which is protocol-owned
+ * liquidity rather than depositor funds. Raw `vault.totalValue()` includes it and puts
+ * superOETHb at ~$29M against ~$19M of holder-owned backing.
+ *
+ * This is deliberately not Origin Ether's protocol TVL on DefiLlama, which on Base also drops
+ * the bridged wOETH strategy (~8.4k WETH, the row's `bridgedTvl`) because that backing is
+ * already counted on Ethereum. Netting it out is right for protocol TVL, but wrong for pool
+ * size -- the bridged wOETH is precisely what backs superOETHb holders' balances.
+ */
 const { gql, request } = require('graphql-request');
-const sdk = require('@defillama/sdk');
 
-const { capitalizeFirstLetter, getPriceApiUrl } = require('../utils');
+const utils = require('../utils');
+const { onChainApy } = require('./otokenApy');
 
 const ETHEREUM_OETH_TOKEN = '0x856c4efb76c1d1ae02e20ceb03a2a6a08b0b8dc3';
-const BASE_WETH_TOKEN = '0x4200000000000000000000000000000000000006';
 const BASE_SUPER_OETH_TOKEN = '0xDBFeFD2e8460a6Ee4955A68582F85708BAEA60A3';
-const PLUME_WETH_TOKEN = '0xca59cA09E5602fAe8B629DeE83FfA819741f14be';
-const PLUME_SUPER_OETH_TOKEN = '0xFCbe50DbE43bF7E5C88C6F6Fb9ef432D4165406E';
 
-const oethVaultAddress = '0x39254033945AA2E4809Cc2977E7087BEE48bd7Ab';
-const superOETHbVaultAddress = '0x98a0CbeF61bD2D21435f433bE4CD42B56B38CC93';
-const superOETHpVaultAddress = '0xc8c8F8bEA5631A8AF26440AF32a55002138cB76a';
+const NATIVE_ETH = '0x0000000000000000000000000000000000000000';
+const ETH_PRICE_KEY = `ethereum:${NATIVE_ETH}`;
 
 const graphUrl = 'https://origin.squids.live/origin-squid/graphql';
 
-const vaultABI = {
-  inputs: [],
-  name: 'totalValue',
-  outputs: [{ internalType: 'uint256', name: 'value', type: 'uint256' }],
-  stateMutability: 'view',
-  type: 'function',
-};
+const PRODUCTS = [
+  {
+    product: 'OETH',
+    symbol: 'OETH',
+    chain: 'Ethereum',
+    sdkChain: 'ethereum',
+    token: ETHEREUM_OETH_TOKEN,
+    url: 'https://app.originprotocol.com/#/oeth',
+  },
+  {
+    product: 'superOETHb',
+    symbol: 'superOETHb',
+    chain: 'Base',
+    sdkChain: 'base',
+    token: BASE_SUPER_OETH_TOKEN,
+    url: 'https://app.originprotocol.com/#/super',
+  },
+];
 
-const fetchPoolData = async ({
-  chain,
-  vaultAddress,
-  token,
-  symbol,
-  project,
-  underlyingToken,
-  tokenAddress,
-  chainId,
-}) => {
-  const query = gql`
-    query OTokenApy($chainId: Int!, $token: String!) {
-      oTokenApies(
-        limit: 1
-        orderBy: timestamp_DESC
-        where: { chainId_eq: $chainId, otoken_containsInsensitive: $token }
-      ) {
-        apy7DayAvg
-      }
+const statsQuery = gql`
+  query ProductStats($product: String!) {
+    protocolDailyStatDetails(
+      limit: 1
+      orderBy: date_DESC
+      where: { product_eq: $product }
+    ) {
+      tvl
+      rateETH
     }
-  `;
+  }
+`;
 
-  const variables = {
-    token,
-    chainId,
-  };
+const fetchPoolData = async ({ product, symbol, chain, sdkChain, token, url }, ethPrice) => {
+  const [stats, apyBase] = await Promise.all([
+    request(graphUrl, statsQuery, { product }),
+    onChainApy(sdkChain, token),
+  ]);
 
-  const apyData = await request(graphUrl, query, variables);
-  const rawApy = apyData.oTokenApies[0]?.apy7DayAvg;
-  const apy = rawApy != null ? rawApy * 100 : null;
-
-  const totalValueEth = (
-    await sdk.api.abi.call({
-      chain,
-      target: vaultAddress,
-      abi: vaultABI,
-    })
-  ).output;
-
-  const ethPriceKey = 'ethereum:0x0000000000000000000000000000000000000000';
-  const ethPriceRes = await axios.get(
-    getPriceApiUrl(`/prices/current/${ethPriceKey}`)
-  );
-  const ethPrice = ethPriceRes.data.coins[ethPriceKey].price;
-
-  const tvlUsd = (totalValueEth / 1e18) * ethPrice;
+  const row = stats.protocolDailyStatDetails[0];
+  // `tvl` is denominated in ETH on every product row, so it converts straight through the ETH
+  // price. (`rateETH` is 1 for the ETH-denominated products; dividing keeps this correct if a
+  // future product is denominated in something else.)
+  const tvlEth = Number(row?.tvl) / Number(row?.rateETH);
 
   return {
     pool: token,
-    chain: capitalizeFirstLetter(chain),
-    project,
+    chain,
+    project: 'origin-ether',
     symbol,
-    tvlUsd,
-    apy,
-    underlyingTokens: [underlyingToken],
-    searchTokenOverride: tokenAddress,
+    tvlUsd: tvlEth * ethPrice,
+    // OToken yield is all base yield: the vault's strategy returns rebase into the token.
+    apyBase,
+    underlyingTokens: [NATIVE_ETH],
+    token,
+    searchTokenOverride: token,
+    isIntrinsicSource: true,
+    url,
   };
 };
 
 const apy = async () => {
-  const pools = await Promise.allSettled([
-    fetchPoolData({
-      chain: 'ethereum',
-      chainId: 1,
-      vaultAddress: oethVaultAddress,
-      token: ETHEREUM_OETH_TOKEN,
-      symbol: 'OETH',
-      project: 'origin-ether',
-      underlyingToken: '0x0000000000000000000000000000000000000000',
-      tokenAddress: ETHEREUM_OETH_TOKEN,
-      isIntrinsicSource: true,
-    }),
-    fetchPoolData({
-      chain: 'base',
-      chainId: 8453,
-      vaultAddress: superOETHbVaultAddress,
-      token: BASE_SUPER_OETH_TOKEN,
-      symbol: 'superOETHb',
-      project: 'origin-ether',
-      underlyingToken: '0x0000000000000000000000000000000000000000',
-      tokenAddress: BASE_SUPER_OETH_TOKEN,
-      isIntrinsicSource: true,
-    }),
-    fetchPoolData({
-      chain: 'plume_mainnet',
-      chainId: 98866,
-      vaultAddress: superOETHpVaultAddress,
-      token: PLUME_SUPER_OETH_TOKEN,
-      symbol: 'superOETHp',
-      project: 'origin-ether',
-      underlyingToken: '0x0000000000000000000000000000000000000000',
-      tokenAddress: PLUME_SUPER_OETH_TOKEN,
-      isIntrinsicSource: true,
-    }),
-  ]);
-  return pools.filter((i) => i.status === 'fulfilled').map((i) => i.value);
+  const ethPrice = (
+    await utils.getPriceApiData(`/prices/current/${ETH_PRICE_KEY}`)
+  ).coins[ETH_PRICE_KEY].price;
+
+  const pools = await Promise.allSettled(
+    PRODUCTS.map((p) => fetchPoolData(p, ethPrice))
+  );
+
+  return pools
+    .filter((i) => i.status === 'fulfilled')
+    .map((i) => i.value)
+    .filter((p) => Number.isFinite(p.tvlUsd) && Number.isFinite(p.apyBase));
 };
 
 module.exports = {

--- a/src/adaptors/origin-ether/otokenApy.js
+++ b/src/adaptors/origin-ether/otokenApy.js
@@ -1,0 +1,52 @@
+/*
+ * Base APY for an Origin OToken (OETH, superOETHb, OUSD, OS), read on-chain.
+ *
+ * An OToken's rebasing multiplier is 1 / rebasingCreditsPerToken, so the ratio of that value
+ * across a window is exactly what the token rebased over it -- the realised base yield, taken
+ * straight off the token with no vault or AMO accounting involved.
+ *
+ * Shared by the origin-* adaptors. This is base yield only -- the rebase does not carry Merkl
+ * incentives, which are reported separately as `apyReward` where they apply.
+ *
+ * It reads ~0.2pp above the squid's `apy7DayAvg` because that average includes the in-progress
+ * day, whose yield is annualised over a full day regardless of how much of it has actually
+ * elapsed (origin-squid `docs/fix-apy-window.md`). Measuring a real elapsed window avoids that.
+ */
+const sdk = require('@defillama/sdk');
+
+const utils = require('../utils');
+
+const CREDITS_ABI = 'uint256:rebasingCreditsPerTokenHighres';
+const WINDOW_DAYS = 7;
+const DAY_SECONDS = 86400;
+
+const creditsAt = (chain, token, block) =>
+  sdk.api.abi.call({ chain, target: token, abi: CREDITS_ABI, block });
+
+// Returns null if the window can't be read, so callers can fall back rather than drop the pool.
+const onChainApy = async (chain, token) => {
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const then = now - WINDOW_DAYS * DAY_SECONDS;
+
+    const [blockNow, blockThen] = await Promise.all([
+      utils.getPriceApiData(`/block/${chain}/${now}`),
+      utils.getPriceApiData(`/block/${chain}/${then}`),
+    ]);
+
+    const [creditsNow, creditsThen] = await Promise.all([
+      creditsAt(chain, token, blockNow.height),
+      creditsAt(chain, token, blockThen.height),
+    ]);
+
+    // Credits per token only falls as the token rebases up, so this ratio is >= 1.
+    const ratio = Number(creditsThen.output) / Number(creditsNow.output);
+    if (!(ratio > 0)) return null;
+
+    return (ratio ** (365 / WINDOW_DAYS) - 1) * 100;
+  } catch (e) {
+    return null;
+  }
+};
+
+module.exports = { onChainApy };


### PR DESCRIPTION
Adapter breakout from https://github.com/DefiLlama/yield-server/pull/2885

------

TVL came from vault.totalValue(), which counts the OToken the vault's own AMO strategies mint into Curve/Aerodrome pools -- protocol-owned liquidity, not depositor funds. That put superOETHb at ~$29M against ~$19M of holder-owned backing. It now reads Origin's protocolDailyStatDetails.tvl, which is already net of it.

That figure is deliberately not Origin Ether's protocol TVL on DefiLlama, which on Base additionally drops the bridged wOETH strategy because that backing is already counted on Ethereum. Netting it out is right for protocol TVL and wrong for pool size: the bridged wOETH is precisely what backs superOETHb holders' balances.

APY is now measured on-chain from rebasingCreditsPerTokenHighres over 7d, in a helper shared with the other origin-* adaptors. The squid's apy7DayAvg reads ~0.2pp low because it includes the in-progress day, annualised over a full day regardless of how much of it has elapsed.

superOETHp is dropped -- the Plume product is retired. Smaller fixes: apyBase rather than apy, a per-pool url (there was none), and hardcoded chain names instead of capitalizing the sdk chain key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OETH on Ethereum and superOETHb on Base.
  * Added TVL reporting based on Origin protocol statistics and current ETH pricing.
  * Added on-chain base APY calculations using realized seven-day yield.
  * Pool details now identify native ETH as the underlying asset and include base APY information.
* **Bug Fixes**
  * Invalid, unavailable, or failed TVL and APY results are excluded from displayed data.
  * Improved token search labeling and pool metadata accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->