### PR TITLE
origin-dollar: fix TVL, measure APY on-chain, fix underlyingTokens

### DIFF
--- a/src/adaptors/origin-dollar/index.js
+++ b/src/adaptors/origin-dollar/index.js
@@ -1,63 +1,69 @@
-const axios = require('axios');
+/*
+ * Origin Dollar: OUSD.
+ *
+ * TVL comes from Origin's production squid. `protocolDailyStatDetails.tvl` is the backing that
+ * belongs to holders: it nets out the OUSD the vault's own Curve AMO minted into the pool, which
+ * is protocol-owned liquidity rather than depositor funds. That runs ~11% below OUSD's total
+ * supply, which is what a naive totalSupply x price reports.
+ */
 const { gql, request } = require('graphql-request');
-const sdk = require('@defillama/sdk');
-const { getPriceApiData } = require('../utils');
+
+const utils = require('../utils');
+const { onChainApy } = require('../origin-ether/otokenApy');
 
 const OUSD = '0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86';
+const PRICE_KEY = `ethereum:${OUSD}`;
+
 const graphUrl = 'https://origin.squids.live/origin-squid/graphql';
 
-const apy = async () => {
-  const query = gql`
-    query OTokenApy($chainId: Int!, $token: String!) {
-      oTokenApies(
-        limit: 1
-        orderBy: timestamp_DESC
-        where: { chainId_eq: $chainId, otoken_containsInsensitive: $token }
-      ) {
-        apy7DayAvg
-        apy14DayAvg
-        apy30DayAvg
-        apr
-        apy
-      }
+const statsQuery = gql`
+  query OusdStats {
+    protocolDailyStatDetails(
+      limit: 1
+      orderBy: date_DESC
+      where: { product_eq: "OUSD" }
+    ) {
+      tvl
+      rateETH
     }
-  `;
+  }
+`;
 
-  const variables = {
-    token: OUSD,
-    chainId: 1,
-  };
+const apy = async () => {
+  const [stats, priceData, apyBase] = await Promise.all([
+    request(graphUrl, statsQuery),
+    utils.getPriceApiData(`/prices/current/${PRICE_KEY}`),
+    onChainApy('ethereum', OUSD),
+  ]);
 
-  const apy =
-    (await request(graphUrl, query, variables)).oTokenApies[0].apy7DayAvg * 100;
+  const row = stats.protocolDailyStatDetails[0];
+  if (!row) return [];
 
-  const totalSupply =
-    (
-      await sdk.api.abi.call({
-        target: OUSD,
-        abi: 'erc20:totalSupply',
-      })
-    ).output / 1e18;
+  // Product rows report `tvl` in ETH; `rateETH` is OUSD's price in ETH, so this recovers the
+  // OUSD-denominated amount and avoids valuing a dollar product through the ETH price.
+  const tvlOusd = Number(row.tvl) / Number(row.rateETH);
+  const tvlUsd = tvlOusd * priceData.coins[PRICE_KEY].price;
 
-  const priceKey = `ethereum:${OUSD}`;
-  const price = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey].price;
+  // Emit nothing rather than a partial pool: a failed archive read just means no sample this
+  // run, and the next one picks it up.
+  if (!Number.isFinite(tvlUsd) || !Number.isFinite(apyBase)) return [];
 
-  const ousd = {
-    pool: OUSD,
-    chain: 'Ethereum',
-    project: 'origin-dollar',
-    symbol: 'OUSD',
-    tvlUsd: totalSupply * price,
-    apy,
-    underlyingTokens: [
-      '0xdac17f958d2ee523a2206206994597c13d831ec7',
-      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-      '0x6b175474e89094c44da98b954eedeac495271d0f',
-    ],
-    url: 'https://originprotocol.eth.limo/#/ousd',
-  };
-
-  return [ousd];
+  return [
+    {
+      pool: OUSD,
+      chain: 'Ethereum',
+      project: 'origin-dollar',
+      symbol: 'OUSD',
+      tvlUsd,
+      // OUSD yield is all base yield: strategy returns rebase into the token.
+      apyBase,
+      // The vault's only collateral asset today; it used to also hold USDT and DAI.
+      underlyingTokens: ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'],
+      token: OUSD,
+      isIntrinsicSource: true,
+      url: 'https://app.originprotocol.com/#/ousd',
+    },
+  ];
 };
 
 module.exports = {

--- a/src/adaptors/origin-ether/otokenApy.js
+++ b/src/adaptors/origin-ether/otokenApy.js
@@ -1,0 +1,52 @@
+/*
+ * Base APY for an Origin OToken (OETH, superOETHb, OUSD, OS), read on-chain.
+ *
+ * An OToken's rebasing multiplier is 1 / rebasingCreditsPerToken, so the ratio of that value
+ * across a window is exactly what the token rebased over it -- the realised base yield, taken
+ * straight off the token with no vault or AMO accounting involved.
+ *
+ * Shared by the origin-* adaptors. This is base yield only -- the rebase does not carry Merkl
+ * incentives, which are reported separately as `apyReward` where they apply.
+ *
+ * It reads ~0.2pp above the squid's `apy7DayAvg` because that average includes the in-progress
+ * day, whose yield is annualised over a full day regardless of how much of it has actually
+ * elapsed (origin-squid `docs/fix-apy-window.md`). Measuring a real elapsed window avoids that.
+ */
+const sdk = require('@defillama/sdk');
+
+const utils = require('../utils');
+
+const CREDITS_ABI = 'uint256:rebasingCreditsPerTokenHighres';
+const WINDOW_DAYS = 7;
+const DAY_SECONDS = 86400;
+
+const creditsAt = (chain, token, block) =>
+  sdk.api.abi.call({ chain, target: token, abi: CREDITS_ABI, block });
+
+// Returns null if the window can't be read, so callers can fall back rather than drop the pool.
+const onChainApy = async (chain, token) => {
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const then = now - WINDOW_DAYS * DAY_SECONDS;
+
+    const [blockNow, blockThen] = await Promise.all([
+      utils.getPriceApiData(`/block/${chain}/${now}`),
+      utils.getPriceApiData(`/block/${chain}/${then}`),
+    ]);
+
+    const [creditsNow, creditsThen] = await Promise.all([
+      creditsAt(chain, token, blockNow.height),
+      creditsAt(chain, token, blockThen.height),
+    ]);
+
+    // Credits per token only falls as the token rebases up, so this ratio is >= 1.
+    const ratio = Number(creditsThen.output) / Number(creditsNow.output);
+    if (!(ratio > 0)) return null;
+
+    return (ratio ** (365 / WINDOW_DAYS) - 1) * 100;
+  } catch (e) {
+    return null;
+  }
+};
+
+module.exports = { onChainApy };


### PR DESCRIPTION
Adapter breakout from https://github.com/DefiLlama/yield-server/pull/2885

------

TVL was totalSupply x price, which counts the OUSD the vault's own Curve AMO minted into the pool -- protocol-owned liquidity, not depositor funds. It runs ~11% above the backing that belongs to holders. It now reads Origin's protocolDailyStatDetails.tvl, which is already net of it, converted out of the row's ETH denomination through rateETH so a dollar product is not valued through the ETH price.

APY is now measured on-chain from rebasingCreditsPerTokenHighres over 7d, via a helper shared with the other origin-* adaptors (added here as origin-ether/otokenApy.js -- identical to the copy in the origin-ether and origin-sonic branches, so whichever lands first, the rest apply cleanly). The squid's apy7DayAvg reads ~0.2pp low because it includes the in-progress day, annualised over a full day regardless of how much of it has elapsed.

underlyingTokens listed USDT and DAI, which the vault no longer holds; USDC is its only collateral asset today. An empty stats result previously threw a TypeError on row.tvl -- it now returns no pool for that run. Smaller fixes: apyBase rather than apy, and the pool url pointed at originprotocol.eth.limo rather than the app route the live product page links to.