### PR TITLE
origin-sonic: fix TVL, measure APY on-chain, fix the pool url

### DIFF
--- a/src/adaptors/origin-ether/otokenApy.js
+++ b/src/adaptors/origin-ether/otokenApy.js
@@ -1,0 +1,52 @@
+/*
+ * Base APY for an Origin OToken (OETH, superOETHb, OUSD, OS), read on-chain.
+ *
+ * An OToken's rebasing multiplier is 1 / rebasingCreditsPerToken, so the ratio of that value
+ * across a window is exactly what the token rebased over it -- the realised base yield, taken
+ * straight off the token with no vault or AMO accounting involved.
+ *
+ * Shared by the origin-* adaptors. This is base yield only -- the rebase does not carry Merkl
+ * incentives, which are reported separately as `apyReward` where they apply.
+ *
+ * It reads ~0.2pp above the squid's `apy7DayAvg` because that average includes the in-progress
+ * day, whose yield is annualised over a full day regardless of how much of it has actually
+ * elapsed (origin-squid `docs/fix-apy-window.md`). Measuring a real elapsed window avoids that.
+ */
+const sdk = require('@defillama/sdk');
+
+const utils = require('../utils');
+
+const CREDITS_ABI = 'uint256:rebasingCreditsPerTokenHighres';
+const WINDOW_DAYS = 7;
+const DAY_SECONDS = 86400;
+
+const creditsAt = (chain, token, block) =>
+  sdk.api.abi.call({ chain, target: token, abi: CREDITS_ABI, block });
+
+// Returns null if the window can't be read, so callers can fall back rather than drop the pool.
+const onChainApy = async (chain, token) => {
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const then = now - WINDOW_DAYS * DAY_SECONDS;
+
+    const [blockNow, blockThen] = await Promise.all([
+      utils.getPriceApiData(`/block/${chain}/${now}`),
+      utils.getPriceApiData(`/block/${chain}/${then}`),
+    ]);
+
+    const [creditsNow, creditsThen] = await Promise.all([
+      creditsAt(chain, token, blockNow.height),
+      creditsAt(chain, token, blockThen.height),
+    ]);
+
+    // Credits per token only falls as the token rebases up, so this ratio is >= 1.
+    const ratio = Number(creditsThen.output) / Number(creditsNow.output);
+    if (!(ratio > 0)) return null;
+
+    return (ratio ** (365 / WINDOW_DAYS) - 1) * 100;
+  } catch (e) {
+    return null;
+  }
+};
+
+module.exports = { onChainApy };

--- a/src/adaptors/origin-sonic/index.js
+++ b/src/adaptors/origin-sonic/index.js
@@ -1,59 +1,86 @@
+/*
+ * Origin Sonic: OS, a rebasing LST backed by wrapped Sonic.
+ *
+ * TVL and APY come from Origin's production squid, so this pool carries the numbers Origin
+ * reports itself. The APY replaces a day-over-day wOS exchange-rate delta, which needed two
+ * block-height lookups and annualised a single noisy day.
+ */
 const sdk = require('@defillama/sdk');
-const axios = require('axios');
+const { gql, request } = require('graphql-request');
+
 const { getPriceApiData } = require('../utils');
+const { onChainApy } = require('../origin-ether/otokenApy');
 
 const WRAPPED_ORIGIN_SONIC = '0x9F0dF7799f6FDAd409300080cfF680f5A23df4b1';
 const ORIGIN_SONIC = '0xb1e25689d55734fd3fffc939c4c3eb52dff8a794';
 const SONIC = '0x0000000000000000000000000000000000000000';
-const project = 'origin-sonic';
-const symbol = 'OS';
-const exchangeRateAbi = 'function convertToAssets(uint256 shares) view returns (uint256 assets)';
+const PRICE_KEY = `sonic:${SONIC}`;
+
+const graphUrl = 'https://origin.squids.live/origin-squid/graphql';
+
+const exchangeRateAbi =
+  'function convertToAssets(uint256 shares) view returns (uint256 assets)';
+
+const statsQuery = gql`
+  query OsStats {
+    protocolDailyStatDetails(
+      limit: 1
+      orderBy: date_DESC
+      where: { product_eq: "OS" }
+    ) {
+      tvl
+      rateETH
+    }
+  }
+`;
 
 const apy = async () => {
-    const tvl = (await sdk.api.erc20.totalSupply({ target: ORIGIN_SONIC, chain: 'sonic' })).output / 1e18;
+  const [stats, priceData, apyBase, exchangeRate] = await Promise.all([
+    request(graphUrl, statsQuery),
+    getPriceApiData(`/prices/current/${PRICE_KEY}`),
+    onChainApy('sonic', ORIGIN_SONIC),
+    sdk.api.abi.call({
+      target: WRAPPED_ORIGIN_SONIC,
+      chain: 'sonic',
+      abi: exchangeRateAbi,
+      params: ['1000000000000000000'],
+    }),
+  ]);
 
-    const priceKey = `sonic:${SONIC}`;
-    const sonicPrice = (await getPriceApiData(`/prices/current/${priceKey}`)).coins[priceKey]?.price;
+  const row = stats.protocolDailyStatDetails[0];
+  if (!row) return [];
 
-    const timestampNow = Math.floor(Date.now() / 1000);
-    const timestampYesterday = timestampNow - 86400;
+  // Product rows report `tvl` in ETH; `rateETH` is S's price in ETH, so this recovers the
+  // S-denominated amount and avoids valuing a Sonic product through the ETH price.
+  const tvlSonic = Number(row.tvl) / Number(row.rateETH);
+  const tvlUsd = tvlSonic * priceData.coins[PRICE_KEY].price;
+  const pricePerShare = Number(exchangeRate.output) / 1e18;
 
-    const blockNow = (await getPriceApiData(`/block/sonic/${timestampNow}`)).height;
+  // Emit nothing rather than a partial pool: a failed archive read just means no sample this
+  // run, and the next one picks it up.
+  if (!Number.isFinite(tvlUsd) || !Number.isFinite(apyBase)) return [];
 
-    const blockYesterday = (await getPriceApiData(`/block/sonic/${timestampYesterday}`)).height;
-
-    const exchangeRateYesterday = await sdk.api.abi.call({
-        target: WRAPPED_ORIGIN_SONIC,
-        chain: 'sonic',
-        abi: exchangeRateAbi,
-        params: ['1000000000000000000'],
-        block: blockYesterday,
-    });
-
-    const exchangeRateToday = await sdk.api.abi.call({
-        target: WRAPPED_ORIGIN_SONIC,
-        chain: 'sonic',
-        abi: exchangeRateAbi,
-        params: ['1000000000000000000'],
-        block: blockNow,
-    });
-
-    const apr =
-        ((exchangeRateToday.output - exchangeRateYesterday.output) /
-            exchangeRateYesterday.output) * 365 * 100;
-
-    return [
-        {
-            pool: `${ORIGIN_SONIC}`,
-            chain: 'sonic',
-            project,
-            symbol,
-            underlyingTokens: [SONIC],
-            apyBase: apr,
-            ...(Number(exchangeRateToday.output) / 1e18 > 0 && { pricePerShare: Number(exchangeRateToday.output) / 1e18 }),
-            tvlUsd: (tvl * sonicPrice),
-        },
-    ];
+  return [
+    {
+      pool: ORIGIN_SONIC,
+      chain: 'Sonic',
+      project: 'origin-sonic',
+      symbol: 'OS',
+      tvlUsd,
+      apyBase,
+      underlyingTokens: [SONIC],
+      token: ORIGIN_SONIC,
+      isIntrinsicSource: true,
+      ...(pricePerShare > 0 && { pricePerShare }),
+    },
+  ];
 };
 
-module.exports = { protocolId: '5688', apy, url: 'https://www.originprotocol.com/os' };
+module.exports = {
+  protocolId: '5688',
+  timetravel: false,
+  apy,
+  // OS has no product page of its own any more, so this points at the site root rather than the
+  // old /os path, which now serves a soft 404.
+  url: 'https://www.originprotocol.com',
+};


### PR DESCRIPTION
Adapter breakout from https://github.com/DefiLlama/yield-server/pull/2885

------

TVL was totalSupply x price, counting OS the protocol itself holds rather than the backing that belongs to holders. It now reads Origin's protocolDailyStatDetails.tvl, converted out of the row's ETH denomination through rateETH so a Sonic product is not valued through the ETH price.

APY was a day-over-day wOS exchange-rate delta: two block-height lookups, and a single noisy day annualised. It is now measured on-chain from rebasingCreditsPerTokenHighres over 7d, via a helper shared with the other origin-* adaptors (added here as origin-ether/otokenApy.js -- identical to the copy in the origin-ether and origin-dollar branches, so whichever lands first, the rest apply cleanly).

The url was https://www.originprotocol.com/os, which returns 200 but renders a "page not found" -- OS has no product page of its own any more. Pointed at the site root, and OS gets no per-pool url.

An empty stats result previously threw a TypeError on row.tvl; it now returns no pool for that run. Chain name capitalised to Sonic.