### PR TITLE
neutral-trade: read apy7d, the field the API actually returns

### DIFF
--- a/src/adaptors/neutral-trade/index.js
+++ b/src/adaptors/neutral-trade/index.js
@@ -93,8 +93,8 @@ const getApy = async () => {
       underlyingTokens: [vault.asset.mint],
       token: null,
       tvlUsd: vault.tvlUsd,
-      apyBase: toPct(vault.apy7dAfterFees),
-      apyBase7d: toPct(vault.apy7dAfterFees),
+      apyBase: toPct(vault.apy7d),
+      apyBase7d: toPct(vault.apy7d),
       pricePerShare: pricesPerShare[index],
       url: `${APP_URL}/strategies/${vaultMetadata[vault.bundleKey].strategySlug}`,
     }))


### PR DESCRIPTION
The adapter reads `vault.apy7dAfterFees`, but `api.neutral.trade/public/yields` returns `apy7d`, `apy30d`, `apy90d` and `apyInception`. None of the 12 vaults has an `apy7dAfterFees` key, so `toPct()` gets `undefined` and returns `null` for both `apyBase` and `apyBase7d`. `utils.keepFinite` then requires at least one finite `apyBase`/`apyReward`/`apy`, so every pool is filtered out and the adapter publishes nothing.

Running the adapter on current master returns 0 pools. After this change it returns all 12 vaults, $12.44M TVL:

```
Cross-Exchange Arb                 tvl=  421653  apyBase=  -0.101%
Options Market Making              tvl=  637569  apyBase=  -0.682%
Mid-frequency Market Making        tvl= 1331172  apyBase=  15.014%
Multi-Asset Volatility Arbitrage   tvl=  628252  apyBase= -99.620%
JLP Delta Neutral                  tvl=   17820  apyBase=  -7.060%
HFT Multi-factor                   tvl=  953235  apyBase=  34.575%
Delta Neutral Arbitrage            tvl= 2475647  apyBase=   1.505%
CTA - Systematic Alpha             tvl= 2124964  apyBase=  16.911%
CTA - Adaptive Alpha               tvl=   87088  apyBase= -29.599%
CTA - Longshort Alpha              tvl=  155371  apyBase=  12.005%
Neutral Autopilot                  tvl= 3011124  apyBase=   5.317%
Hyperliquid Funding Arb            tvl=  595455  apyBase=  11.732%
```

### Why apy7d is the right field

It is the realized return net of fees, which is what `apyBase` is meant to be. I checked it against each pool's own price per share, from the `daily-vault-snapshot` endpoint the adapter already calls:

| vault | pps 7d ago | pps now | implied APY | API apy7d |
|---|---|---|---|---|
| HFT Multi-factor (82) | 2.725121 | 2.740686 | +0.3458 | 0.34575 |
| Neutral Autopilot (76) | 1.375248 | 1.376615 | +0.0532 | 0.05317 |

The API also declares `rateUnit: "decimal"`, so the existing `* 100` is correct.

I checked two vaults this way, not all twelve. On vault 75 the price-per-share series implies about -0.005 while the API reports 0.15014, so those two do not line up. It is the protocol's own published figure either way, and the same number their app shows.

I also confirmed the `pricePerShare` values returned after the fix match the snapshot endpoint exactly for every vault, so the `snapshotVaultId` mapping in `vaultMetadata` is correct.

### Negative APYs

Several vaults currently report a negative 7d APY. Those are real drawdowns in the published price per share, not a units problem. `keepFinite` accepts them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Neutral Trade APY values now display the vault’s standard 7-day APY consistently for base and 7-day APY fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->