### PR TITLE
termmax: dont let one failing chain discard the other three

### DIFF
--- a/src/adaptors/termmax/index.js
+++ b/src/adaptors/termmax/index.js
@@ -898,15 +898,23 @@ async function getVaultsOnChain(chain, chainId, alias) {
 async function apy() {
   const vaults = [];
   const tasks = [];
-  for (const key of Object.keys(VAULTS)) {
+  const keys = Object.keys(VAULTS);
+  const failed = [];
+  for (const key of keys) {
     const task = async () => {
       const { alias, chain, chainId } = VAULTS[key];
-      const vaultsOnChain = await getVaultsOnChain(chain, chainId, alias);
-      for (const vault of vaultsOnChain) vaults.push(vault);
+      try {
+        const vaultsOnChain = await getVaultsOnChain(chain, chainId, alias);
+        for (const vault of vaultsOnChain) vaults.push(vault);
+      } catch (error) {
+        failed.push(`${key}: ${error.message}`);
+      }
     };
     tasks.push(task());
   }
   await Promise.all(tasks);
+  if (failed.length === keys.length)
+    throw new Error(`termmax: every chain failed -> ${failed.join(' | ')}`);
   return vaults;
 }
 


### PR DESCRIPTION
Fixes #2900.

`apy()` awaited all four chains with `Promise.all` and no per-chain handling, so the first chain to throw discarded every vault already collected from the others. The protocol has $32.06M TVL updating daily but has never published a single pool.

Per chain, running the fan-out one at a time:

| chain | result |
|---|---|
| ethereum | 64 pools (incl. a $25.3M XAUt vault) |
| arbitrum | 7 pools |
| base | 1 pool |
| bsc | throws, `limit exceeded` / `log query range must not exceed 25 blocks` on public RPCs |

Catching per chain and throwing only when every chain fails, so a partial outage degrades to partial data while a total outage still surfaces as an error rather than an empty result, same shape as the `filterPools` guard in DefiLlama/dimension-adapters#8565.

Verified with all four chains enabled and BSC still failing locally:

```
$ npm run test --adapter=termmax
Tests:       438 passed, 438 total
Nb of pools: 72
```

Same on a repeat run. Forcing every chain to reject:

```
termmax: every chain failed -> ethereum: INJECTED | arbitrum: INJECTED | bsc: INJECTED | base: INJECTED
```

Worth flagging: the BSC failure I hit is on the public RPC pool and may not be what fails in your infrastructure. The fix does not depend on which chain it is; it only stops one chain from taking the rest down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when retrieving vault data across multiple chains.
  * Successful chain results are now returned even if another chain encounters an error.
  * An error is reported only when all configured chains fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->