### PR TITLE
neutral-trade: use 30d APY

### DIFF
--- a/src/adaptors/neutral-trade/index.js
+++ b/src/adaptors/neutral-trade/index.js
@@ -93,8 +93,7 @@ const getApy = async () => {
       underlyingTokens: [vault.asset.mint],
       token: null,
       tvlUsd: vault.tvlUsd,
-      apyBase: toPct(vault.apy7d),
-      apyBase7d: toPct(vault.apy7d),
+      apyBase: toPct(vault.apy30d),
       pricePerShare: pricesPerShare[index],
       url: `${APP_URL}/strategies/${vaultMetadata[vault.bundleKey].strategySlug}`,
     }))


### PR DESCRIPTION
Some Neutral Trade vaults refresh NAV every 14 days, so a 7-day APY can cover an incomplete or stale NAV interval. Using the 30-day APY spans at least two refresh cycles and gives a more representative annualised rate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Neutral Trade APY reporting now uses the vault’s 30-day APY as the base APY.
  * Removed the separate 7-day APY field from reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->