### PR TITLE
add earn-grid yield adapter (ERC-4626 USDC vault on Base)

### DIFF
--- a/src/adaptors/earngrid/index.js
+++ b/src/adaptors/earngrid/index.js
@@ -1,0 +1,150 @@
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+const CHAIN = 'base';
+
+// EarnGrid BlendedVault on Base
+const VAULT = '0x8694D7D44309665D51Cb5002fceC0454f1c233dE';
+const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const BVUSDC = '0x8694D7D44309665D51Cb5002fceC0454f1c233dE'; // vault itself = receipt token
+
+// Underlying MetaMorpho strategies & their Morpho Blue vault addresses
+const STRATEGIES = [
+  {
+    name: 'Gauntlet USDC Prime',
+    morphoVault: '0xeE8F4eC5672F09119b96Ab6fB59C27E1b7e44b61',
+  },
+  {
+    name: 'Steakhouse Prime USDC',
+    morphoVault: '0xBEEFE94c8aD530842bfE7d8B397938fFc1cb83b2',
+  },
+  {
+    name: 'Moonwell Flagship USDC',
+    morphoVault: '0xc1256Ae5FF1cf2719D4937adb3bbCCab2E00A2Ca',
+  },
+  {
+    name: 'Gauntlet USDC Frontier',
+    morphoVault: '0x236919F11ff9eA9550A4287696C2FC9e18E6e890',
+  },
+  {
+    name: 'Steakhouse High Yield USDC v1.1',
+    morphoVault: '0xBEEFA7B88064FeEF0cEe02AAeBBd95D30df3878F',
+  },
+];
+
+/**
+ * Fetch MetaMorpho vault APYs from Morpho Blue GraphQL.
+ * Returns a map of vault address → netApy (as decimal, e.g. 0.05 = 5%).
+ */
+async function getMorphoApyMap() {
+  const query = `
+    query {
+      vaults(where: {
+        chainId_in: [8453],
+        address_in: ${JSON.stringify(STRATEGIES.map((s) => s.morphoVault))}
+      }, first: 10) {
+        items {
+          address
+          state { netApy }
+        }
+      }
+    }
+  `;
+
+  try {
+    const resp = await utils.fetchURL('https://blue-api.morpho.org/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query }),
+    });
+
+    const items = resp?.data?.vaults?.items ?? [];
+    const map = {};
+    for (const item of items) {
+      map[item.address.toLowerCase()] = item.state?.netApy ?? 0;
+    }
+    return map;
+  } catch (e) {
+    console.error('EarnGrid: Morpho GraphQL failed, falling back to 0 APY', e.message);
+    return {};
+  }
+}
+
+const abiTotalAssets = 'function totalAssets() view returns (uint256)';
+const abiBalanceOf = 'function balanceOf(address) view returns (uint256)';
+
+const getApy = async () => {
+  // 1. Fetch totalAssets from the vault
+  const totalAssetsCall = sdk.api.abi.call({
+    chain: CHAIN,
+    target: VAULT,
+    abi: abiTotalAssets,
+  });
+
+  // 2. Fetch vault's balance in each MetaMorpho strategy
+  const strategyBalanceCalls = STRATEGIES.map((s) =>
+    sdk.api.abi.call({
+      chain: CHAIN,
+      target: s.morphoVault,
+      abi: abiBalanceOf,
+      params: [VAULT],
+    })
+  );
+
+  // 3. Fetch Morpho APY data
+  const apyMapPromise = getMorphoApyMap();
+
+  const [totalAssetsRes, ...balanceResults] = await Promise.all([
+    totalAssetsCall,
+    ...strategyBalanceCalls,
+  ]);
+  const apyMap = await apyMapPromise;
+
+  const totalAssets = totalAssetsRes.output / 1e6; // USDC has 6 decimals
+  const usdcPrice = 1; // stablecoin
+
+  // Build strategy allocation + compute weighted APY
+  let totalBalance = 0;
+  const allocations = STRATEGIES.map((s, i) => {
+    const bal = balanceResults[i].output / 1e6;
+    totalBalance += bal;
+    const apy = (apyMap[s.morphoVault.toLowerCase()] ?? 0) * 100; // decimal → percentage
+    return { ...s, balance: bal, apy };
+  });
+
+  // Weighted average APY across strategies (only count strategies with balance > 0)
+  let weightedApy = 0;
+  if (totalBalance > 0) {
+    weightedApy = allocations.reduce((sum, a) => sum + a.balance * a.apy, 0) / totalBalance;
+  }
+
+  // Fallback: if GraphQL failed, estimate from totalAssets growth (rough)
+  // For now, just report 0 if no data
+  const apyBase = weightedApy > 0 ? weightedApy : 0;
+
+  // Compute idle (unallocated) portion
+  const idle = totalAssets - totalBalance;
+
+  // Build pool output
+  const pool = {
+    pool: `${VAULT}-${CHAIN}`,
+    chain: utils.formatChain(CHAIN),
+    project: 'earngrid',
+    symbol: 'USDC',
+    tvlUsd: totalAssets * usdcPrice,
+    apyBase,
+    apyReward: 0,
+    underlyingTokens: [USDC],
+    url: 'https://earngrid.site',
+    poolMeta: idle > 0.01 ? `${allocations.filter((a) => a.balance > 0).length} strategies + idle` : `${allocations.filter((a) => a.balance > 0).length} strategies`,
+  };
+
+  return [pool];
+};
+
+module.exports = {
+  protocolId: 'earngrid',
+  timetravel: false,
+  apy: getApy,
+  url: 'https://earngrid.site',
+};

--- a/src/adaptors/earngrid/index.js
+++ b/src/adaptors/earngrid/index.js
@@ -112,10 +112,10 @@ const getApy = async () => {
     return { ...s, balance: bal, apy };
   });
 
-  // Weighted average APY across strategies (only count strategies with balance > 0)
+  // Weighted average APY across all vault assets (idle USDC earns 0%)
   let weightedApy = 0;
-  if (totalBalance > 0) {
-    weightedApy = allocations.reduce((sum, a) => sum + a.balance * a.apy, 0) / totalBalance;
+  if (totalAssets > 0) {
+    weightedApy = allocations.reduce((sum, a) => sum + a.balance * a.apy, 0) / totalAssets;
   }
 
   // Fallback: if GraphQL failed, estimate from totalAssets growth (rough)
@@ -143,7 +143,7 @@ const getApy = async () => {
 };
 
 module.exports = {
-  protocolId: 'earngrid',
+  protocolId: '8384',
   timetravel: false,
   apy: getApy,
   url: 'https://earngrid.site',

--- a/src/adaptors/earngrid/index.js
+++ b/src/adaptors/earngrid/index.js
@@ -3,10 +3,10 @@ const utils = require('../utils');
 
 const CHAIN = 'base';
 
-// EarnGrid BlendedVault on Base
-const VAULT = '0x8694D7D44309665D51Cb5002fceC0454f1c233dE';
+// EarnGrid BlendedVault v2.0.0 on Base (v1.0.4 0x8694D7D4… retired 2026-08-15)
+const VAULT = '0xbDacA8B7782C66cc0ee32Cf70F835EBe86cb20D3';
 const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
-const BVUSDC = '0x8694D7D44309665D51Cb5002fceC0454f1c233dE'; // vault itself = receipt token
+const BVUSDC = '0xbDacA8B7782C66cc0ee32Cf70F835EBe86cb20D3'; // vault itself = receipt token
 
 // Underlying MetaMorpho strategies & their Morpho Blue vault addresses
 const STRATEGIES = [
@@ -113,13 +113,13 @@ const getApy = async () => {
   ]);
 
   const totalAssets = Number(totalAssetsRes.output) / 1e6;
-  const totalSupply = Number(totalSupplyRes.output) / 1e6;
+  const totalSupply = Number(totalSupplyRes.output) / 1e12; // bvUSDC shares: 12 decimals
   const usdcPrice = pricesByAddress[USDC.toLowerCase()] || 1;
 
   // Build strategy allocation + compute weighted APY
   let totalBalance = 0;
   const allocations = STRATEGIES.map((s, i) => {
-    const bal = balanceResults[i].output / 1e6;
+    const bal = balanceResults[i].output / 1e18; // MetaMorpho shares: 18 decimals
     totalBalance += bal;
     const apy = (apyMap[s.morphoVault.toLowerCase()] ?? 0) * 100; // decimal → percentage
     return { ...s, balance: bal, apy };

--- a/src/adaptors/earngrid/index.js
+++ b/src/adaptors/earngrid/index.js
@@ -52,11 +52,11 @@ async function getMorphoApyMap() {
   `;
 
   try {
-    const resp = await utils.fetchURL('https://blue-api.morpho.org/graphql', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query }),
-    });
+    const resp = await utils.getData(
+      'https://blue-api.morpho.org/graphql',
+      { query },
+      { 'Content-Type': 'application/json' }
+    );
 
     const items = resp?.data?.vaults?.items ?? [];
     const map = {};
@@ -65,43 +65,56 @@ async function getMorphoApyMap() {
     }
     return map;
   } catch (e) {
-    console.error('EarnGrid: Morpho GraphQL failed, falling back to 0 APY', e.message);
+    console.error('EarnGrid: Morpho GraphQL failed, falling back to 0 APY', String(e));
     return {};
   }
 }
 
 const abiTotalAssets = 'function totalAssets() view returns (uint256)';
 const abiBalanceOf = 'function balanceOf(address) view returns (uint256)';
+const abiTotalSupply = 'erc20:totalSupply';
 
 const getApy = async () => {
-  // 1. Fetch totalAssets from the vault
+  // 1. Fetch totalAssets & totalSupply from the vault
   const totalAssetsCall = sdk.api.abi.call({
     chain: CHAIN,
     target: VAULT,
     abi: abiTotalAssets,
   });
 
-  // 2. Fetch vault's balance in each MetaMorpho strategy
+  const totalSupplyCall = sdk.api.abi.call({
+    chain: CHAIN,
+    target: BVUSDC,
+    abi: abiTotalSupply,
+  });
+
+  // 2. Fetch vault's balance in each MetaMorpho strategy (graceful: 0 on error)
   const strategyBalanceCalls = STRATEGIES.map((s) =>
     sdk.api.abi.call({
       chain: CHAIN,
       target: s.morphoVault,
       abi: abiBalanceOf,
       params: [VAULT],
-    })
+    }).catch(() => ({ output: '0' }))
   );
 
-  // 3. Fetch Morpho APY data
+  // 3. Fetch Morpho APY data + USDC price
   const apyMapPromise = getMorphoApyMap();
+  const pricesPromise = utils.getPrices([USDC], CHAIN);
 
-  const [totalAssetsRes, ...balanceResults] = await Promise.all([
+  const [totalAssetsRes, totalSupplyRes, ...balanceResults] = await Promise.all([
     totalAssetsCall,
+    totalSupplyCall,
     ...strategyBalanceCalls,
   ]);
-  const apyMap = await apyMapPromise;
+  const [apyMap, { pricesByAddress }] = await Promise.all([
+    apyMapPromise,
+    pricesPromise,
+  ]);
 
-  const totalAssets = totalAssetsRes.output / 1e6; // USDC has 6 decimals
-  const usdcPrice = 1; // stablecoin
+  const totalAssets = Number(totalAssetsRes.output) / 1e6;
+  const totalSupply = Number(totalSupplyRes.output) / 1e6;
+  const usdcPrice = pricesByAddress[USDC.toLowerCase()] || 1;
 
   // Build strategy allocation + compute weighted APY
   let totalBalance = 0;
@@ -125,6 +138,11 @@ const getApy = async () => {
   // Compute idle (unallocated) portion
   const idle = totalAssets - totalBalance;
 
+  // Compute pricePerShare (ERC-4626 convertToAssets rate)
+  const pricePerShare = totalSupply > 0 ? totalAssets / totalSupply : 1;
+
+  const activeStrategyCount = allocations.filter((a) => a.balance > 0).length;
+
   // Build pool output
   const pool = {
     pool: `${VAULT}-${CHAIN}`,
@@ -136,7 +154,11 @@ const getApy = async () => {
     apyReward: 0,
     underlyingTokens: [USDC],
     url: 'https://earngrid.site',
-    poolMeta: idle > 0.01 ? `${allocations.filter((a) => a.balance > 0).length} strategies + idle` : `${allocations.filter((a) => a.balance > 0).length} strategies`,
+    poolMeta: idle > 0.01
+      ? `${activeStrategyCount} strategies + idle`
+      : `${activeStrategyCount} strategies`,
+    token: BVUSDC,
+    pricePerShare,
   };
 
   return [pool];


### PR DESCRIPTION
## Description

Adds EarnGrid yield adapter. EarnGrid is a USDC yield vault on Base (ERC-4626) that aggregates MetaMorpho strategies.

- **Vault:** 0x8694D7D44309665D51Cb5002fceC0454f1c233dE
- **Chain:** Base (8453)
- **Asset:** USDC
- **TVL:** ~\20 (growing)
- **APY source:** Morpho Blue GraphQL API — weighted average of underlying MetaMorpho strategy APYs
- **Website:** https://earngrid.site

The adapter reads:
1. `totalAssets()` from the vault for TVL
2. Vault balance in each MetaMorpho strategy via `balanceOf()`
3. Strategy APYs from Morpho Blue GraphQL
4. Computes weighted average APY

Already listed in DeFiLlama TVL via ERC-4626 registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for tracking the Base BlendedVault through EarnGrid.
  - Added USDC pool details, including total assets, strategy allocations, idle funds, active strategies, and price per share.
  - Added combined yield visibility with weighted APY and MetaMorpho strategy rates.
  - Added reliable fallback values when strategy or yield data is temporarily unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->