### PR TITLE
Update phoenix-protocol staking address to PhlimboV3

### DIFF
--- a/src/adaptors/phoenix-protocol/index.js
+++ b/src/adaptors/phoenix-protocol/index.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 const { getPriceApiUrl } = require('../utils');
 
 const CHAIN = 'ethereum';
-const PHLIMBO = '0x6084a02c2ac0127ddf1e617de257c61480a2aee0';
+const PHLIMBO = '0x8D3A8E3ba43DEb8C7e2110DF437a92243523b6ca';
 const PHUSD = '0xf3B5B661b92B75C71fA5Aba8Fd95D7514A9CD605';
 const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const SUSDS = '0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD';


### PR DESCRIPTION
### Summary

The phUSD staking contract has been migrated from **PhlimboEA (V2)** `0x6084a02c2ac0127ddf1e617de257c61480a2aee0` to **PhlimboV3** `0x8D3A8E3ba43DEb8C7e2110DF437a92243523b6ca`.

This is a migration, not a new product: **all staked user positions were moved across to V3**. V2 still exists but is wound down and mint-revoked, so its `totalStaked` no longer reflects live staking and the adapter would report a decaying/incorrect TVL if left pointing at it.

### Changes

One line — the `PHLIMBO` address constant. V3 exposes the same `totalStaked` / `desiredAPYBps` / `rewardPerSecond` views, so no other adapter logic changes.

Branched from current `master`, so the `protocolId` export and `getPriceApiUrl` pro routing are preserved (this was the issue that got #2754 closed).

### Verification

Ran against mainnet on this base:

```json
{
  "pool": "0x8d3a8e3ba43deb8c7e2110df437a92243523b6ca-ethereum",
  "symbol": "phUSD",
  "tvlUsd": 11937.90,
  "apyReward": 25.94,
  "poolMeta": "Staking"
}
```

### Note on pool history

The pool ID is derived from the contract address, so this registers as a new pool and the V2 pool's chart history won't carry over. That's unavoidable given the contract migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the PHLIMBO contract address to ensure interactions target the correct on-chain contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->