### PR TITLE
accountable: add robinhood chain (4663)

### DIFF
--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -2,7 +2,7 @@ const sdk = require('@defillama/sdk');
 const utils = require('../utils');
 
 const API_URL = 'https://yield.accountable.capital/api/loan';
-const chainIdToName = { 1: 'ethereum', 143: 'monad', 4114: 'citrea' };
+const chainIdToName = { 1: 'ethereum', 143: 'monad', 4114: 'citrea', 4663: 'robinhood' };
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const abis = {


### PR DESCRIPTION
## Summary
- Adds Robinhood Chain (id `4663`) to the `accountable` adaptor's `chainIdToName` map, matching the mapping already used by other adaptors in this repo (e.g. `merkl/config.js`).
- The Accountable Meridian Liquidity Provider vault is deployed on Robinhood Chain and was previously dropped by this adaptor since its chain id wasn't recognized.

## Test plan
- [x] `npm run test --adapter=accountable` passes locally (216/216 tests), including the new pool `0xf62c201e9a28f6a57c4262004dd2e8b8e95bb1ec-robinhood`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing the Robinhood chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->