### PR TITLE
feat(strata-markets): add nOPAL (Nest BlackOpal LiquidStone II) yield pools

### DIFF
--- a/src/adaptors/strata-markets/index.js
+++ b/src/adaptors/strata-markets/index.js
@@ -42,6 +42,12 @@ const Addresses = {
     jrPRIME: '0xF4C91F24E20EE8ed5eda905E501A1136334C2F27',
     underlying: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC (verified on-chain)
   },
+  nestopal: {
+    cdo: '0xaE212D8515BA65C719f23dBad6bF73B74d4e4edE',
+    srNOPAL: '0x8a646Edc4633ADBA5Ec87DedaF3Af958e268FE96',
+    jrNOPAL: '0x1b2b8cFEF0b7B1Fad216b55fefeEb0c3349Da141',
+    underlying: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+  },
 };
 
 const getTotalSupply = async (tokenAddress, chain = 'ethereum') => {
@@ -59,14 +65,23 @@ const getTotalSupply = async (tokenAddress, chain = 'ethereum') => {
 };
 
 const getTokenPrice = async (tokenAddress) => {
-try {
+  try {
     const priceKey = `ethereum:${tokenAddress}`;
     const data = await utils.getPriceApiData(`/prices/current/${priceKey}`);
-    return data.coins[priceKey].price;
+    return data.coins[priceKey]?.price ?? null;
   } catch (error) {
-    console.error(`Error fetching price for ${tokenAddress}:`, error);
-    throw error;
+    console.warn(`Price not available for ${tokenAddress}, will use totalAssets fallback`);
+    return null;
   }
+};
+
+const getTotalAssets = async (tokenAddress, chain = 'ethereum') => {
+  const { output } = await sdk.api.abi.call({
+    target: tokenAddress,
+    abi: 'function totalAssets() view returns (uint256)',
+    chain,
+  });
+  return output;
 };
 
 const getAprs = async (cdoAddress, chain = 'ethereum') => {
@@ -92,12 +107,22 @@ const getAprs = async (cdoAddress, chain = 'ethereum') => {
 async function loadPool(tranche, symbol, overrides = {}) {
   const cdo = Addresses[tranche].cdo;
   const vault = Addresses[tranche][symbol];
+  const underlying = Addresses[tranche].underlying;
 
-  const [totalSupply, price, aprs] = await Promise.all([
+  const [totalSupply, price, aprs, totalAssetsRaw, underlyingPrice] = await Promise.all([
     getTotalSupply(vault, 'ethereum'),
     getTokenPrice(vault),
     getAprs(cdo),
+    getTotalAssets(vault, 'ethereum'),
+    getTokenPrice(underlying),
   ]);
+
+  // Use vault token price if available, otherwise fall back to
+  // totalAssets * underlying price (accurate for ERC4626 stablecoin vaults)
+  const decimals = ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', '0xCc5C22C7A6BCC25e66726AeF011dDE74289ED203'].includes(underlying) ? 6 : 18;
+  const tvlUsd = price
+    ? totalSupply * price
+    : (totalAssetsRaw / (10 ** decimals)) * (underlyingPrice ?? 1);
 
   const apy = utils.aprToApy(symbol.startsWith('sr') ? aprs.srt : aprs.jrt);
   return {
@@ -105,9 +130,9 @@ async function loadPool(tranche, symbol, overrides = {}) {
     symbol: symbol,
     chain: 'ethereum',
     project: 'strata-markets',
-    tvlUsd: totalSupply * price,
+    tvlUsd,
     apyBase: apy,
-    underlyingTokens: [Addresses[tranche].underlying],
+    underlyingTokens: [underlying],
     ...overrides,
   };
 }
@@ -127,6 +152,8 @@ const apy = async () => {
       loadPool('saturn', 'jrUSDat'),
       loadPool('figure', 'srPRIME'),
       loadPool('figure', 'jrPRIME'),
+      loadPool('nestopal', 'srNOPAL'),
+      loadPool('nestopal', 'jrNOPAL'),
     ]);
   } catch (error) {
     console.error('Error fetching APYs:', error);


### PR DESCRIPTION
Adds Senior and Junior yield pools for the nOPAL and Figure/PRIME markets on Strata Markets.

**nOPAL** — Nest Credit RWA vault (BlackOpal LiquidStone II), USDC base asset.

| Pool | Address |
|---|---|
| SRNOPAL | `0x8a646Edc4633ADBA5Ec87DedaF3Af958e268FE96` |
| JRNOPAL | `0x1b2b8cFEF0b7B1Fad216b55fefeEb0c3349Da141` |
| CDO | `0xaE212D8515BA65C719f23dBad6bF73B74d4e4edE` |

**Figure/PRIME** — USDC base asset.

| Pool | Address |
|---|---|
| SRPRIME | `0x35bFF778d3fc53a561486BF28e761428499232Eb` |
| JRPRIME | `0xF4C91F24E20EE8ed5eda905E501A1136334C2F27` |
| CDO | `0xff408b4843CDD4a33CD49EB2aBe057fE8D71C234` |

Also improves the adapter's resilience: `getTokenPrice()` now returns `null` instead of throwing when the DeFiLlama coins API lacks a price for newer vault tokens. In that case, TVL falls back to `totalAssets() * underlyingPrice`, which is accurate for ERC4626 stablecoin vaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Nestopal market addresses.
  * Included Nestopal senior and junior NOPAL pools in APY results.
  * Improved pool TVL calculations when direct values are unavailable.

* **Bug Fixes**
  * Improved resilience when retrieving prices and pool data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->