### PR TITLE
Add Alandale V3 adaptor

### DIFF
--- a/src/adaptors/alandale-v3/index.js
+++ b/src/adaptors/alandale-v3/index.js
@@ -16,6 +16,10 @@ const LUTE = '0xD1e861CC5Eee7eA88649206b74504D78CCD7AEeA';
 const FEE_DENOMINATOR = 1e6;
 const COMMUNITY_FEE_DENOMINATOR = 1e3;
 
+// Algebra fees are dynamic, so this is the rate in force at read time rather than a
+// fixed tier. Trailing zeros are trimmed: 0.3%, 1.492%, 0.011%.
+const formatFee = (rate) => `${Number((rate * 100).toFixed(3))}%`;
+
 const HOUR = 3600;
 const EPOCH = 604800;
 const EPOCHS_PER_YEAR = 52;
@@ -205,6 +209,7 @@ const apy = async () => {
         chain: utils.formatChain(CHAIN),
         project: PROJECT,
         symbol: `${p.token0.symbol}-${p.token1.symbol}`,
+        poolMeta: formatFee(feeTier),
         tvlUsd,
         apyBase: Number.isFinite(apyBase) ? apyBase : 0,
         apyReward: Number.isFinite(apyReward) ? apyReward : null,

--- a/src/adaptors/alandale-v3/index.js
+++ b/src/adaptors/alandale-v3/index.js
@@ -84,8 +84,15 @@ const apy = async () => {
 
   // Whatever share of the swap fee a pool routes to its community fee leaves the pool
   // for veLUTE voters, so only the remainder ever reaches liquidity providers.
-  const [{ pricesByAddress }, globalStates, gauges, activePeriod, weeklyRaw] =
-    await Promise.all([
+  const [
+    { pricesByAddress },
+    globalStates,
+    gauges,
+    activePeriod,
+    weeklyRaw,
+    teamRateRaw,
+    precisionRaw,
+  ] = await Promise.all([
       utils.getPrices([...addresses, LUTE], CHAIN),
       sdk.api2.abi.multiCall({
         abi: 'function globalState() view returns (uint160 price, int24 tick, uint16 lastFee, uint8 pluginConfig, uint16 communityFee, bool unlocked)',
@@ -102,29 +109,50 @@ const apy = async () => {
       }),
       sdk.api2.abi.call({ target: MINTER, abi: 'uint256:active_period', chain: CHAIN }),
       sdk.api2.abi.call({ target: MINTER, abi: 'uint256:weekly', chain: CHAIN }),
+      sdk.api2.abi.call({ target: MINTER, abi: 'uint256:teamRate', chain: CHAIN }),
+      sdk.api2.abi.call({ target: MINTER, abi: 'uint256:PRECISION', chain: CHAIN }),
     ]);
 
-  // Emissions are voted on per epoch, so each gauge's share of the weekly mint is
-  // known from the vote weights before the epoch's distribution actually runs.
+  // The team takes its cut of the weekly mint before anything reaches a gauge.
+  const precision = Number(precisionRaw) || 1;
+  const weeklyLute = (Number(weeklyRaw) / 1e18) * (1 - Number(teamRateRaw) / precision);
+
+  // A week's emissions are split on the votes of the epoch that funded it, which is
+  // the one that just closed; the running epoch decides the week after.
   const epoch =
     BigInt(String(activePeriod)) - (BigInt(String(activePeriod)) % BigInt(EPOCH));
-  const weeklyLute = Number(weeklyRaw) / 1e18;
-  const [totalWeightRaw, poolWeights] = await Promise.all([
+  const readTotalWeight = (e) =>
     sdk.api2.abi.call({
       target: VOTER,
       abi: 'function totalWeightsPerEpoch(uint256) view returns (uint256)',
-      params: [epoch.toString()],
+      params: [e.toString()],
       chain: CHAIN,
-    }),
-    sdk.api2.abi.multiCall({
-      target: VOTER,
-      abi: 'function weightsPerEpoch(uint256, address) view returns (uint256)',
-      calls: pools.map((p) => ({ params: [epoch.toString(), p.id] })),
-      chain: CHAIN,
-      permitFailure: true,
-    }),
+    });
+  const [fundedRaw, runningRaw] = await Promise.all([
+    readTotalWeight(epoch - BigInt(EPOCH)),
+    readTotalWeight(epoch),
   ]);
-  const totalWeight = Number(totalWeightRaw) / 1e18;
+  const funded = Number(fundedRaw) / 1e18;
+  const voteEpoch = funded > 0 ? epoch - BigInt(EPOCH) : epoch;
+  const totalWeight = funded > 0 ? funded : Number(runningRaw) / 1e18;
+
+  const poolWeights = await sdk.api2.abi.multiCall({
+    target: VOTER,
+    abi: 'function weightsPerEpoch(uint256, address) view returns (uint256)',
+    calls: pools.map((p) => ({ params: [voteEpoch.toString(), p.id] })),
+    chain: CHAIN,
+    permitFailure: true,
+  });
+
+  // An unavailable read must stay unavailable: collapsing it to 0 would publish a
+  // verified no-reward pool, which downstream cannot tell apart from a real zero.
+  const lutePerYearFor = (gauge, weightRaw) => {
+    if (gauge == null) return null;
+    if (gauge === ZERO) return 0;
+    if (weightRaw == null) return null;
+    if (!(totalWeight > 0)) return 0;
+    return (Number(weightRaw) / 1e18 / totalWeight) * weeklyLute * EPOCHS_PER_YEAR;
+  };
 
   const lpShare = {};
   const feeRate = {};
@@ -140,9 +168,7 @@ const apy = async () => {
     // lastFee is the fee actually charged, unlike the subgraph's stored tier.
     const lastFee = Number(globalStates[i]?.lastFee ?? 0);
     feeRate[id] = lastFee > 0 ? lastFee / FEE_DENOMINATOR : Number(p.fee) / FEE_DENOMINATOR;
-    const votedShare = totalWeight > 0 ? Number(poolWeights[i] ?? 0) / 1e18 / totalWeight : 0;
-    emissions[id] =
-      gauges[i] && gauges[i] !== ZERO ? votedShare * weeklyLute * EPOCHS_PER_YEAR : 0;
+    emissions[id] = lutePerYearFor(gauges[i], poolWeights[i]);
   });
   const lutePrice = pricesByAddress[LUTE.toLowerCase()] ?? 0;
 
@@ -167,9 +193,12 @@ const apy = async () => {
       const lpFeeShare = lpShare[id] ?? 0;
       const apyBase = ((volumeUsd * feeTier * lpFeeShare * 365) / tvlUsd) * 100;
 
-      const lutePerYear = emissions[id] ?? 0;
-      const apyReward =
-        lutePerYear > 0 && lutePrice > 0 ? ((lutePerYear * lutePrice) / tvlUsd) * 100 : 0;
+      // Emissions that exist but cannot be priced are unknown, not zero.
+      const lutePerYear = emissions[id];
+      let apyReward = null;
+      if (lutePerYear === 0) apyReward = 0;
+      else if (lutePerYear > 0 && lutePrice > 0)
+        apyReward = ((lutePerYear * lutePrice) / tvlUsd) * 100;
 
       return {
         pool: `${p.id}-${CHAIN}`.toLowerCase(),
@@ -178,7 +207,7 @@ const apy = async () => {
         symbol: `${p.token0.symbol}-${p.token1.symbol}`,
         tvlUsd,
         apyBase: Number.isFinite(apyBase) ? apyBase : 0,
-        apyReward: Number.isFinite(apyReward) ? apyReward : 0,
+        apyReward: Number.isFinite(apyReward) ? apyReward : null,
         rewardTokens: [LUTE],
         underlyingTokens: [p.token0.id, p.token1.id],
         // Concentrated-liquidity positions are NFTs, not a fungible pool token.

--- a/src/adaptors/alandale-v3/index.js
+++ b/src/adaptors/alandale-v3/index.js
@@ -1,0 +1,109 @@
+const { request, gql } = require('graphql-request');
+const utils = require('../utils');
+
+const PROJECT = 'alandale-v3';
+const CHAIN = 'robinhood';
+const URL = 'https://app.alandale.xyz';
+const SUBGRAPH =
+  'https://api.goldsky.com/api/public/project_cms6oy9216bwr01wahoyxhk79/subgraphs/alandale-cl-mainnet/1.0.0/gn';
+
+const FEE_DENOMINATOR = 1e6;
+
+const poolsQuery = gql`
+  {
+    pools(first: 1000) {
+      id
+      fee
+      totalValueLockedToken0
+      totalValueLockedToken1
+      token0 {
+        id
+        symbol
+        decimals
+      }
+      token1 {
+        id
+        symbol
+        decimals
+      }
+    }
+  }
+`;
+
+const hourlyQuery = gql`
+  query Hourly($since: Int!) {
+    poolHourDatas(
+      first: 1000
+      where: { periodStartUnix_gte: $since }
+      orderBy: periodStartUnix
+      orderDirection: desc
+    ) {
+      pool {
+        id
+      }
+      volumeToken0
+      volumeToken1
+    }
+  }
+`;
+
+const apy = async () => {
+  const since = Math.floor(Date.now() / 1000) - 86400;
+  const [{ pools }, { poolHourDatas }] = await Promise.all([
+    request(SUBGRAPH, poolsQuery),
+    request(SUBGRAPH, hourlyQuery, { since }),
+  ]);
+
+  const volume = {};
+  poolHourDatas.forEach((h) => {
+    const id = h.pool.id.toLowerCase();
+    const cur = volume[id] ?? { token0: 0, token1: 0 };
+    cur.token0 += Number(h.volumeToken0) || 0;
+    cur.token1 += Number(h.volumeToken1) || 0;
+    volume[id] = cur;
+  });
+
+  const addresses = [
+    ...new Set(pools.flatMap((p) => [p.token0.id.toLowerCase(), p.token1.id.toLowerCase()])),
+  ];
+  const { pricesByAddress } = await utils.getPrices(addresses, CHAIN);
+
+  return pools
+    .map((p) => {
+      const t0 = p.token0.id.toLowerCase();
+      const t1 = p.token1.id.toLowerCase();
+      const price0 = pricesByAddress[t0];
+      const price1 = pricesByAddress[t1];
+      if (price0 === undefined || price1 === undefined) return null;
+
+      const tvlUsd =
+        Number(p.totalValueLockedToken0) * price0 +
+        Number(p.totalValueLockedToken1) * price1;
+      if (!(tvlUsd > 0)) return null;
+
+      const vol = volume[p.id.toLowerCase()] ?? { token0: 0, token1: 0 };
+      const volumeUsd = vol.token0 * price0;
+      const feeTier = Number(p.fee) / FEE_DENOMINATOR;
+      const apyBase = ((volumeUsd * feeTier * 365) / tvlUsd) * 100;
+
+      return {
+        pool: `${p.id}-${CHAIN}`.toLowerCase(),
+        chain: utils.formatChain(CHAIN),
+        project: PROJECT,
+        symbol: utils.formatSymbol(`${p.token0.symbol}-${p.token1.symbol}`),
+        tvlUsd,
+        apyBase,
+        underlyingTokens: [p.token0.id, p.token1.id],
+        token: p.id,
+        url: `${URL}/pools/${p.id}`,
+      };
+    })
+    .filter(Boolean);
+};
+
+module.exports = {
+  protocolId: '8400',
+  timetravel: false,
+  apy,
+  url: `${URL}/pools`,
+};

--- a/src/adaptors/alandale-v3/index.js
+++ b/src/adaptors/alandale-v3/index.js
@@ -1,4 +1,5 @@
 const { request, gql } = require('graphql-request');
+const sdk = require('@defillama/sdk');
 const utils = require('../utils');
 
 const PROJECT = 'alandale-v3';
@@ -7,7 +8,18 @@ const URL = 'https://app.alandale.xyz';
 const SUBGRAPH =
   'https://api.goldsky.com/api/public/project_cms6oy9216bwr01wahoyxhk79/subgraphs/alandale-cl-mainnet/1.0.0/gn';
 
+const VOTER = '0x4cF1c47B95031cD2bb1d102021D8Ede60392971C';
+const MINTER = '0x782355E7771A9Aa0834de4Ae981DCF3b7aeC11e6';
+const LUTE = '0xD1e861CC5Eee7eA88649206b74504D78CCD7AEeA';
+
+// Algebra Constants.sol: swap fees are in millionths, the community fee in thousandths.
 const FEE_DENOMINATOR = 1e6;
+const COMMUNITY_FEE_DENOMINATOR = 1e3;
+
+const HOUR = 3600;
+const EPOCH = 604800;
+const EPOCHS_PER_YEAR = 52;
+const ZERO = '0x0000000000000000000000000000000000000000';
 
 const poolsQuery = gql`
   {
@@ -31,10 +43,10 @@ const poolsQuery = gql`
 `;
 
 const hourlyQuery = gql`
-  query Hourly($since: Int!) {
+  query Hourly($since: Int!, $until: Int!) {
     poolHourDatas(
       first: 1000
-      where: { periodStartUnix_gte: $since }
+      where: { periodStartUnix_gte: $since, periodStartUnix_lt: $until }
       orderBy: periodStartUnix
       orderDirection: desc
     ) {
@@ -48,10 +60,13 @@ const hourlyQuery = gql`
 `;
 
 const apy = async () => {
-  const since = Math.floor(Date.now() / 1000) - 86400;
+  // Bound the window to whole hourly buckets so the result does not drift with the
+  // minute the adaptor happens to run at.
+  const until = Math.floor(Date.now() / 1000 / HOUR) * HOUR;
+  const since = until - 86400;
   const [{ pools }, { poolHourDatas }] = await Promise.all([
     request(SUBGRAPH, poolsQuery),
-    request(SUBGRAPH, hourlyQuery, { since }),
+    request(SUBGRAPH, hourlyQuery, { since, until }),
   ]);
 
   const volume = {};
@@ -66,7 +81,70 @@ const apy = async () => {
   const addresses = [
     ...new Set(pools.flatMap((p) => [p.token0.id.toLowerCase(), p.token1.id.toLowerCase()])),
   ];
-  const { pricesByAddress } = await utils.getPrices(addresses, CHAIN);
+
+  // Whatever share of the swap fee a pool routes to its community fee leaves the pool
+  // for veLUTE voters, so only the remainder ever reaches liquidity providers.
+  const [{ pricesByAddress }, globalStates, gauges, activePeriod, weeklyRaw] =
+    await Promise.all([
+      utils.getPrices([...addresses, LUTE], CHAIN),
+      sdk.api2.abi.multiCall({
+        abi: 'function globalState() view returns (uint160 price, int24 tick, uint16 lastFee, uint8 pluginConfig, uint16 communityFee, bool unlocked)',
+        calls: pools.map((p) => p.id),
+        chain: CHAIN,
+        permitFailure: true,
+      }),
+      sdk.api2.abi.multiCall({
+        target: VOTER,
+        abi: 'function poolToGauge(address) view returns (address)',
+        calls: pools.map((p) => p.id),
+        chain: CHAIN,
+        permitFailure: true,
+      }),
+      sdk.api2.abi.call({ target: MINTER, abi: 'uint256:active_period', chain: CHAIN }),
+      sdk.api2.abi.call({ target: MINTER, abi: 'uint256:weekly', chain: CHAIN }),
+    ]);
+
+  // Emissions are voted on per epoch, so each gauge's share of the weekly mint is
+  // known from the vote weights before the epoch's distribution actually runs.
+  const epoch =
+    BigInt(String(activePeriod)) - (BigInt(String(activePeriod)) % BigInt(EPOCH));
+  const weeklyLute = Number(weeklyRaw) / 1e18;
+  const [totalWeightRaw, poolWeights] = await Promise.all([
+    sdk.api2.abi.call({
+      target: VOTER,
+      abi: 'function totalWeightsPerEpoch(uint256) view returns (uint256)',
+      params: [epoch.toString()],
+      chain: CHAIN,
+    }),
+    sdk.api2.abi.multiCall({
+      target: VOTER,
+      abi: 'function weightsPerEpoch(uint256, address) view returns (uint256)',
+      calls: pools.map((p) => ({ params: [epoch.toString(), p.id] })),
+      chain: CHAIN,
+      permitFailure: true,
+    }),
+  ]);
+  const totalWeight = Number(totalWeightRaw) / 1e18;
+
+  const lpShare = {};
+  const feeRate = {};
+  const emissions = {};
+  pools.forEach((p, i) => {
+    const id = p.id.toLowerCase();
+    // A failed read must not fall back to "no community fee", which would credit
+    // liquidity providers with fees they do not receive.
+    const communityFee = Number(
+      globalStates[i]?.communityFee ?? COMMUNITY_FEE_DENOMINATOR
+    );
+    lpShare[id] = 1 - communityFee / COMMUNITY_FEE_DENOMINATOR;
+    // lastFee is the fee actually charged, unlike the subgraph's stored tier.
+    const lastFee = Number(globalStates[i]?.lastFee ?? 0);
+    feeRate[id] = lastFee > 0 ? lastFee / FEE_DENOMINATOR : Number(p.fee) / FEE_DENOMINATOR;
+    const votedShare = totalWeight > 0 ? Number(poolWeights[i] ?? 0) / 1e18 / totalWeight : 0;
+    emissions[id] =
+      gauges[i] && gauges[i] !== ZERO ? votedShare * weeklyLute * EPOCHS_PER_YEAR : 0;
+  });
+  const lutePrice = pricesByAddress[LUTE.toLowerCase()] ?? 0;
 
   return pools
     .map((p) => {
@@ -81,20 +159,30 @@ const apy = async () => {
         Number(p.totalValueLockedToken1) * price1;
       if (!(tvlUsd > 0)) return null;
 
-      const vol = volume[p.id.toLowerCase()] ?? { token0: 0, token1: 0 };
-      const volumeUsd = vol.token0 * price0;
-      const feeTier = Number(p.fee) / FEE_DENOMINATOR;
-      const apyBase = ((volumeUsd * feeTier * 365) / tvlUsd) * 100;
+      const id = p.id.toLowerCase();
+      const vol = volume[id] ?? { token0: 0, token1: 0 };
+      // Both legs describe the same trade, so volume is their average, not the sum.
+      const volumeUsd = (vol.token0 * price0 + vol.token1 * price1) / 2;
+      const feeTier = feeRate[id] ?? 0;
+      const lpFeeShare = lpShare[id] ?? 0;
+      const apyBase = ((volumeUsd * feeTier * lpFeeShare * 365) / tvlUsd) * 100;
+
+      const lutePerYear = emissions[id] ?? 0;
+      const apyReward =
+        lutePerYear > 0 && lutePrice > 0 ? ((lutePerYear * lutePrice) / tvlUsd) * 100 : 0;
 
       return {
         pool: `${p.id}-${CHAIN}`.toLowerCase(),
         chain: utils.formatChain(CHAIN),
         project: PROJECT,
-        symbol: utils.formatSymbol(`${p.token0.symbol}-${p.token1.symbol}`),
+        symbol: `${p.token0.symbol}-${p.token1.symbol}`,
         tvlUsd,
-        apyBase,
+        apyBase: Number.isFinite(apyBase) ? apyBase : 0,
+        apyReward: Number.isFinite(apyReward) ? apyReward : 0,
+        rewardTokens: [LUTE],
         underlyingTokens: [p.token0.id, p.token1.id],
-        token: p.id,
+        // Concentrated-liquidity positions are NFTs, not a fungible pool token.
+        token: null,
         url: `${URL}/pools/${p.id}`,
       };
     })


### PR DESCRIPTION
Alandale V3 (`alandale-v3`, protocolId `8400`), a ve(3,3) DEX on Robinhood Chain. One pool row per
Algebra Integral concentrated-liquidity pool, read from the protocol's subgraph with USD derived
from DefiLlama prices.

- `apyBase` — 24h fee APY from whole hourly volume buckets, times each pool's live `globalState`
  fee, times the share of that fee which actually stays with liquidity providers. Every pool
  currently routes its full community fee to veLUTE voters, so this is 0 across the board and the
  protocol's fees adapter reports `SupplySideRevenue` 0 to match. It becomes non-zero on its own if
  a pool's community fee is ever lowered.
- `apyReward` — LUTE emissions, from each gauge's vote-weighted share of the weekly mint, net of
  the minter's team rate. A week's emissions are funded by the votes of the epoch that just closed,
  so weights are read from that epoch and fall back to the running one only when it is empty.
- Inputs that cannot be read are published as `null` rather than 0, so an RPC failure or a missing
  LUTE price is never mistaken for a verified no-reward pool.
- `token` is `null`: concentrated-liquidity positions are NFTs, not a fungible pool token.
- veLUTE-gated yield (boosts, voter bribes) is excluded, per the unboosted-lower-bound rule.
- Pools with an unpriced token are skipped, so that valuing a pool on one leg cannot halve `tvlUsd`
  and thereby inflate the APY. All pools currently qualify.

The subgraph's own USD fields (`totalValueLockedUSD`, `volumeUSD`, `feesUSD`) all return 0, so only
raw token amounts are read and every USD value comes from the DefiLlama coins API.

**Validation:** `npm run test --adapter=alandale-v3` passes 111/111. 15 pools, total `tvlUsd`
~$399k, matching the TVL reported for this protocol. Reward APY cross-checks against the live
gauge distribution and the protocol's own frontend to within the difference in LUTE price source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Alandale V3 on the Robinhood chain.
  * Added pool metrics including TVL, 24-hour volume, LP fee APY, and LUTE reward APY.
  * Excludes pools without valid pricing or positive TVL for more reliable results.
  * Preserves distinctions between unavailable reward data and verified zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->