### PR TITLE
feat: add GILDer yield adapter

### DIFF
--- a/src/adaptors/gilder/index.js
+++ b/src/adaptors/gilder/index.js
@@ -36,7 +36,7 @@ const apy = async () => {
       apyBase,
       underlyingTokens: [USDC],
       poolMeta: 'Standard 3yr Fixed',
-      url: 'https://gilderfinance.com',
+      url: 'https://gilderfinance.com/deposit',
       token: null,
     },
   ];

--- a/src/adaptors/gilder/index.js
+++ b/src/adaptors/gilder/index.js
@@ -27,6 +27,7 @@ const apy = async () => {
       apyBase: 20,
       underlyingTokens: [USDC],
       poolMeta: 'Standard — 3yr fixed, full principal returned at maturity',
+      token: null,
     },
     {
       pool: `${BOND_CONTRACT}-base-leverage`.toLowerCase(),
@@ -37,6 +38,7 @@ const apy = async () => {
       apyBase: 11,
       underlyingTokens: [USDC],
       poolMeta: 'Leverage — 3yr fixed, up to 75% of principal drawn on day 1',
+      token: null,
     },
     {
       pool: `${BOND_CONTRACT}-base-turbo`.toLowerCase(),
@@ -47,6 +49,7 @@ const apy = async () => {
       apyBase: 27.5,
       underlyingTokens: [USDC],
       poolMeta: 'Turbo — 3yr fixed, leveraged loop up to 2.485× multiplier',
+      token: null,
     },
   ];
 };

--- a/src/adaptors/gilder/index.js
+++ b/src/adaptors/gilder/index.js
@@ -1,0 +1,59 @@
+const sdk = require('@defillama/sdk');
+
+const CHAIN = 'base';
+const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const SAFE_VAULT = '0x9b937b72172c0706b51984a09992bB8007771E67';
+const BOND_CONTRACT = '0x5d25cFc927F95Cb519c0Fef438aFAa64cb374e10';
+
+const BALANCE_OF_ABI = 'function balanceOf(address) view returns (uint256)';
+
+const apy = async () => {
+  const safeVaultBal = await sdk.api.abi.call({
+    target: USDC,
+    abi: BALANCE_OF_ABI,
+    params: [SAFE_VAULT],
+    chain: CHAIN,
+  });
+
+  const tvlUsd = Number(safeVaultBal.output) / 1e6;
+
+  return [
+    {
+      pool: `${BOND_CONTRACT}-base-standard`.toLowerCase(),
+      chain: 'Base',
+      project: 'gilder',
+      symbol: 'USDC',
+      tvlUsd,
+      apyBase: 20,
+      underlyingTokens: [USDC],
+      poolMeta: 'Standard — 3yr fixed, full principal returned at maturity',
+    },
+    {
+      pool: `${BOND_CONTRACT}-base-leverage`.toLowerCase(),
+      chain: 'Base',
+      project: 'gilder',
+      symbol: 'USDC',
+      tvlUsd,
+      apyBase: 11,
+      underlyingTokens: [USDC],
+      poolMeta: 'Leverage — 3yr fixed, up to 75% of principal drawn on day 1',
+    },
+    {
+      pool: `${BOND_CONTRACT}-base-turbo`.toLowerCase(),
+      chain: 'Base',
+      project: 'gilder',
+      symbol: 'USDC',
+      tvlUsd,
+      apyBase: 27.5,
+      underlyingTokens: [USDC],
+      poolMeta: 'Turbo — 3yr fixed, leveraged loop up to 2.485× multiplier',
+    },
+  ];
+};
+
+module.exports = {
+  protocolId: '8424',
+  timetravel: false,
+  apy,
+  url: 'https://gilderfinance.com',
+};

--- a/src/adaptors/gilder/index.js
+++ b/src/adaptors/gilder/index.js
@@ -6,16 +6,25 @@ const SAFE_VAULT = '0x9b937b72172c0706b51984a09992bB8007771E67';
 const BOND_CONTRACT = '0x5d25cFc927F95Cb519c0Fef438aFAa64cb374e10';
 
 const BALANCE_OF_ABI = 'function balanceOf(address) view returns (uint256)';
+const ANNUAL_RATE_ABI = 'uint256:SIMPLE_ANNUAL_RATE_BPS';
 
 const apy = async () => {
-  const safeVaultBal = await sdk.api.abi.call({
-    target: USDC,
-    abi: BALANCE_OF_ABI,
-    params: [SAFE_VAULT],
-    chain: CHAIN,
-  });
+  const [safeVaultBal, annualRateBps] = await Promise.all([
+    sdk.api.abi.call({
+      target: USDC,
+      abi: BALANCE_OF_ABI,
+      params: [SAFE_VAULT],
+      chain: CHAIN,
+    }),
+    sdk.api.abi.call({
+      target: BOND_CONTRACT,
+      abi: ANNUAL_RATE_ABI,
+      chain: CHAIN,
+    }),
+  ]);
 
   const tvlUsd = Number(safeVaultBal.output) / 1e6;
+  const apyBase = Number(annualRateBps.output) / 100;
 
   return [
     {
@@ -24,31 +33,10 @@ const apy = async () => {
       project: 'gilder',
       symbol: 'USDC',
       tvlUsd,
-      apyBase: 20,
+      apyBase,
       underlyingTokens: [USDC],
-      poolMeta: 'Standard — 3yr fixed, full principal returned at maturity',
-      token: null,
-    },
-    {
-      pool: `${BOND_CONTRACT}-base-leverage`.toLowerCase(),
-      chain: 'Base',
-      project: 'gilder',
-      symbol: 'USDC',
-      tvlUsd,
-      apyBase: 11,
-      underlyingTokens: [USDC],
-      poolMeta: 'Leverage — 3yr fixed, up to 75% of principal drawn on day 1',
-      token: null,
-    },
-    {
-      pool: `${BOND_CONTRACT}-base-turbo`.toLowerCase(),
-      chain: 'Base',
-      project: 'gilder',
-      symbol: 'USDC',
-      tvlUsd,
-      apyBase: 27.5,
-      underlyingTokens: [USDC],
-      poolMeta: 'Turbo — 3yr fixed, leveraged loop up to 2.485× multiplier',
+      poolMeta: 'Standard 3yr Fixed',
+      url: 'https://gilderfinance.com',
       token: null,
     },
   ];


### PR DESCRIPTION
## Add GILDer yield adapter

Adds the yield adapter for GILDer (slug: `gilder`), already listed on the TVL page.

### What is GILDer

GILDer is a fixed-term deposit protocol on Base. Users deposit USDC into 3-year Term Deposits (ERC-721C NFTs). 80% of each deposit sits in a per-user Safe Vault untouched until maturity; the remaining 20% funds the yield engine. Yield is paid in USDC from treasury operations, not token inflation.

### Pools

Three pools, one per product:

| Pool | `apyBase` | Notes |
|------|-----------|-------|
| Standard | 20% | Full principal returned at maturity |
| Leverage | 11% | Up to 75% of Safe drawn as day-1 liquidity; loan forgiven at maturity |
| Turbo | 27.5% | Automated leveraged loop, ~2.485x multiplier per $1 deposited |

APY values are fixed, immutable contract parameters. 20% is the minimum attainable yield (unboosted, no locked rewards).

### TVL

Sourced from a USDC `balanceOf` call on the Safe Vault (`0x9b937b72172c0706b51984a09992bB8007771E67`) on Base. Protocol-owned reserves are excluded. Data is on-chain only.

### Tests

All 24 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking USDC yield through Gilder’s three-year fixed-term pool.
  * Added visibility into the pool’s annual percentage yield (APY).
  * Added USD total value locked (TVL) tracking based on USDC held in the vault.
  * Added access to Gilder’s project website and protocol information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->