### PR TITLE
accountable: report deposited principal as tvlUsd, not market value

### DIFF
--- a/src/adaptors/accountable/index.js
+++ b/src/adaptors/accountable/index.js
@@ -221,10 +221,8 @@ const apy = async() => {
                 chain: utils.formatChain(chainName),
                 project: 'accountable',
                 symbol: item.asset_symbol,
-                // Vault size (total deposited), straight from the API. These
-                // credit vaults run ~fully lent, so the on-chain idle-liquidity
-                // figure is ~$0 and would hide them below DefiLlama's thresholds.
-                tvlUsd: item.tvl_in_usd ?? null,
+                // Deposited principal, not share-price market value.
+                tvlUsd: toUsd(item.tvl) ?? item.tvl_in_usd ?? null,
                 ...(supplyCapUsd != null && { supplyCapUsd }),
                 apyBase: baseApy,
                 apyReward,


### PR DESCRIPTION
## Summary
- `tvlUsd` was sourced from `tvl_in_usd` (share-price market value, including accrued yield), which can exceed the vault's own deposit cap.
- Switched to the API's `tvl` field (capacity-clamped deposited principal), converted to USD via the same price lookup as `totalSupplyUsd`. Falls back to `tvl_in_usd` if `tvl` is unavailable.

## Test plan
- `npm run test --adapter=accountable`: 266/266 passing.