### PR TITLE
fix(strata-markets): read projected APR for nOPAL zero-projection mode

### DIFF
--- a/src/adaptors/strata-markets/index.js
+++ b/src/adaptors/strata-markets/index.js
@@ -47,6 +47,11 @@ const Addresses = {
     srNOPAL: '0x8a646Edc4633ADBA5Ec87DedaF3Af958e268FE96',
     jrNOPAL: '0x1b2b8cFEF0b7B1Fad216b55fefeEb0c3349Da141',
     underlying: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+    // nOPAL uses zero-projection mode: the AprPairFeed returns (0,0) for
+    // accounting, but the provider exposes the real projected APR via
+    // getAprPairProjected(). CDOLens only reads the feed, so we read the
+    // provider directly when CDOLens returns zeros.
+    provider: '0x1FE39BE01BA0AF9f8D61A8a581eb7Df29c0BCe97',
   },
 };
 
@@ -84,7 +89,7 @@ const getTotalAssets = async (tokenAddress, chain = 'ethereum') => {
   return output;
 };
 
-const getAprs = async (cdoAddress, chain = 'ethereum') => {
+const getAprs = async (cdoAddress, chain = 'ethereum', trancheConfig = {}) => {
   try {
     const { output } = await sdk.api.abi.call({
       target: Addresses.lens,
@@ -94,12 +99,63 @@ const getAprs = async (cdoAddress, chain = 'ethereum') => {
       block: 'latest',
     });
     let [base, target, jrt, srt] = output;
+
+    // If CDOLens returns all zeros and a provider is configured, read the
+    // projected APR directly from the provider's getAprPairProjected().
+    // This is needed for markets using zero-projection mode (e.g. nOPAL)
+    // where the feed intentionally returns (0,0) for accounting while the
+    // real base APR is exposed via the provider.
+    if (Number(jrt) === 0 && Number(srt) === 0 && trancheConfig.provider) {
+      const [{ output: projected }, { output: breakdown }, { output: reserveBpsRaw }] = await Promise.all([
+        sdk.api.abi.call({
+          target: trancheConfig.provider,
+          abi: 'function getAprPairProjected() external view returns (int64 aprTarget, int64 aprBase, uint64 updatedAt)',
+          chain,
+        }),
+        sdk.api.abi.call({
+          target: Addresses.lens,
+          abi: 'function getAPRsBreakdown(address cdo) external view returns (int64 base, int64 target, int64 jrt, int64 srt, uint256 tvlRatioSrt, uint256 riskPremium)',
+          params: [cdoAddress],
+          chain,
+        }),
+        sdk.api.abi.call({
+          target: trancheConfig.cdo,
+          abi: 'function accounting() view returns (address)',
+          chain,
+        }).then(({ output: acct }) =>
+          sdk.api.abi.call({
+            target: acct,
+            abi: 'function reserveBps() view returns (uint256)',
+            chain,
+          })
+        ),
+      ]);
+
+      const aprBase = Number(projected.aprBase) / 1e10;
+      const aprTarget = Number(projected.aprTarget) / 1e10;
+      const tvlRatioSrt = Number(breakdown.tvlRatioSrt) / 1e18;
+      const tvlRatioJrt = 1 - tvlRatioSrt;
+      const risk = Number(breakdown.riskPremium) / 1e18;
+      const reserveBps = Number(reserveBpsRaw) / 1e18;
+
+      // Replicate CDOLens formula: aprSrt = max(aprTarget, aprBase * (1 - risk))
+      const aprSrt = Math.max(aprTarget, aprBase * (1 - risk));
+      // Net base after performance fee
+      const netBase = aprBase > 0 && reserveBps > 0 ? aprBase * (1 - reserveBps) : aprBase;
+      // JRT gets the residual: aprJrt = netBase + (netBase - aprSrt) * ratioSrt / ratioJrt
+      const aprJrt = tvlRatioJrt > 0
+        ? netBase + (netBase - aprSrt) * tvlRatioSrt / tvlRatioJrt
+        : netBase;
+
+      return { jrt: aprJrt, srt: aprSrt };
+    }
+
     return {
       jrt: Number(jrt) / 1e10,
       srt: Number(srt) / 1e10,
     };
   } catch (error) {
-    console.error(`Error fetching total supply for ${cdoAddress}:`, error);
+    console.error(`Error fetching APRs for ${cdoAddress}:`, error);
     throw error;
   }
 };
@@ -112,7 +168,7 @@ async function loadPool(tranche, symbol, overrides = {}) {
   const [totalSupply, price, aprs, totalAssetsRaw, underlyingPrice] = await Promise.all([
     getTotalSupply(vault, 'ethereum'),
     getTokenPrice(vault),
-    getAprs(cdo),
+    getAprs(cdo, 'ethereum', Addresses[tranche]),
     getTotalAssets(vault, 'ethereum'),
     getTokenPrice(underlying),
   ]);


### PR DESCRIPTION
nOPAL uses zero-projection mode where the AprPairFeed returns `(0,0)` for accounting purposes, but the real base APR (~10.15%) is available via `provider.getAprPairProjected()`. CDOLens only reads the feed, so it returns 0% for nOPAL — causing both pools to show 0% APY on DeFiLlama.

**Fix**: When CDOLens returns all-zero APRs and a `provider` address is configured in the tranche config, fall back to reading `getAprPairProjected()` directly from the provider.

This only affects nOPAL. All other markets continue to use CDOLens as before.

**On-chain verification**:
```
provider.getAprPairProjected() → (aprTarget=0, aprBase=101514508505)
→ baseApr = 10.15% → expected APY ≈ 8-10%
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APR retrieval for configured markets when standard APR data is unavailable.
  * Added support for calculating senior and junior APRs using projected provider rates and tranche data.
  * Applied projected base APRs consistently across both tranches.
  * Improved reserve and APR breakdown accuracy for supported markets.
  * Improved error reporting when APR retrieval fails by identifying the affected APR calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->