### PR TITLE
fix balancer-v2 apy spikes, fee apy

### DIFF
--- a/src/adaptors/balancer-v2/index.js
+++ b/src/adaptors/balancer-v2/index.js
@@ -78,47 +78,43 @@ const queryGauge = gql`
 `;
 
 const query = gql`
-  {
-    pools(
-      first: 200
-      orderBy: "totalLiquidity"
-      orderDirection: "desc"
-      where: { totalShares_gt: 0.01 }
-      skip: 0
-    ) {
-      id
-      tokensList
-      totalSwapFee
-      totalShares
-      tokens {
-        address
-        balance
-        symbol
-        weight
-      }
-      address
-    }
-  }
-`;
-
-const queryPrior = gql`
 {
   pools(
-    first: 1000
+    first: 200
     orderBy: "totalLiquidity"
     orderDirection: "desc"
     where: { totalShares_gt: 0.01 }
-    block: {number: <PLACEHOLDER>}
-  ) { 
-    id 
-    tokensList 
-    totalSwapFee 
-    tokens { 
-      address 
-      balance 
+    skip: 0
+    block: {number_gte: <BLOCK_NOW>}
+  ) {
+    id
+    tokensList
+    swapFee
+    totalShares
+    tokens {
+      address
+      balance
       symbol
       weight
-    } 
+    }
+    address
+  }
+}
+`;
+
+const querySwaps = gql`
+{
+  swaps(
+    first: 1000
+    orderBy: id
+    orderDirection: asc
+    where: { block_gt: <BLOCK_PRIOR>, block_lte: <BLOCK_NOW>, id_gt: "<CURSOR>" }
+  ) {
+    id
+    poolId {
+      id
+    }
+    valueUSD
   }
 }
 `;
@@ -210,6 +206,7 @@ const tvl = (entry, tokenPriceList, chainString) => {
     symbol: balanceDetails.map((tok) => tok.symbol).join('-'),
     tvl: 0,
     totalShares: entry.totalShares,
+    swapFee: entry.swapFee,
     tokensList: (entry.tokensList || []).filter(
       (token) => !isPoolToken(token, entry)
     ),
@@ -275,17 +272,23 @@ const aprLM = async (tvlData, urlLM, queryLM, chainString, gaugeABI) => {
             : chainString === 'xdai'
             ? 'gnosis'
             : chainString
-        )
+        ).catch(() => [])
       : Promise.resolve([]);
 
   const balKey = `ethereum:${BAL}`.toLowerCase();
+  // a dead gauge subgraph should cost the chain its reward apy, not every pool on it. base has
+  // been missing from the run because its gauge endpoint 404s and took the whole chain with it.
+  const liquidityGaugesPromise = request(urlLM, queryLM).catch((err) => {
+    console.log(`gauge subgraph unavailable for ${chainString}: ${err.message}`);
+    return { liquidityGauges: [] };
+  });
   const [
     { liquidityGauges },
     childChainRootGauges,
     inflationRateResult,
     balPriceResult,
   ] = await Promise.all([
-    request(urlLM, queryLM),
+    liquidityGaugesPromise,
     childChainRootGaugesPromise,
     // Global source of truth for the inflation rate. All mainnet gauges use the BalancerTokenAdmin contract to update their locally stored inflation rate during checkpoints.
     sdk.api.abi.call({
@@ -485,12 +488,62 @@ const aprLM = async (tvlData, urlLM, queryLM, chainString, gaugeABI) => {
   return data;
 };
 
-const aprFee = (el, dataNow, dataPrior, swapFeePercentage) => {
-  const swapFeeNow = dataNow.find((x) => x.id === el.id)?.totalSwapFee;
-  const swapFeePrior = dataPrior.find((x) => x.id === el.id)?.totalSwapFee;
-  const swapFee24h = Number(swapFeeNow) - Number(swapFeePrior);
+// a single mispriced swap can still put a small pool somewhere absurd, so keep a ceiling. the
+// fee apy of every balancer pool over $100k sits under 10% in practice.
+const maxFeeApy = 1000;
 
-  el.aprFee = ((swapFee24h * 365) / el.tvl) * 100 * swapFeePercentage;
+// busiest chain runs ~3k swaps a day, so this is far above what a healthy run needs
+const maxSwapPages = 25;
+
+const swapVolumeByPool = async (url, blockPrior, block) => {
+  const volumeByPool = new Map();
+  let cursor = '';
+
+  for (let page = 0; page < maxSwapPages; page++) {
+    const { swaps } = await request(
+      url,
+      querySwaps
+        .replace('<BLOCK_PRIOR>', blockPrior)
+        .replace('<BLOCK_NOW>', block)
+        .replace('<CURSOR>', cursor)
+    );
+
+    for (const swap of swaps) {
+      const id = swap.poolId.id;
+      volumeByPool.set(id, (volumeByPool.get(id) ?? 0) + Number(swap.valueUSD));
+    }
+
+    if (swaps.length < 1000) return volumeByPool;
+    cursor = swaps[swaps.length - 1].id;
+  }
+
+  console.log(`swap pagination hit ${maxSwapPages} pages, fee apy may be understated`);
+  return volumeByPool;
+};
+
+const aprFee = (el, volumeByPool, protocolFeePercentage) => {
+  if (!(el.tvl > 0)) {
+    el.aprFee = null;
+    return el;
+  }
+
+  const volume24h = volumeByPool.get(el.id) ?? 0;
+  // what the pool charged, minus the cut the protocol takes off the top, is what lps keep
+  const lpFees24h =
+    volume24h * Number(el.swapFee) * (1 - protocolFeePercentage);
+  const apr = ((lpFees24h * 365) / el.tvl) * 100;
+
+  if (!Number.isFinite(apr) || apr > maxFeeApy) {
+    console.log(
+      `dropping implausible aprFee for ${el.id}: ${apr.toFixed(
+        0
+      )}% from volume24h=${volume24h.toFixed(0)} tvl=${el.tvl.toFixed(0)}`
+    );
+    el.aprFee = null;
+    return el;
+  }
+
+  el.aprFee = apr;
   return el;
 };
 
@@ -498,23 +551,26 @@ const topLvl = async (
   chainString,
   url,
   query,
-  queryPrior,
   urlGauge,
   queryGauge,
   gaugeABI,
-  swapFeePercentage
+  protocolFeePercentage
 ) => {
-  const [_, blockPrior] = await utils.getBlocks(chainString, null, [url]);
-  // pull data
-  let dataNow = await request(url, query);
-  let dataPrior = await request(
-    url,
-    queryPrior.replace('<PLACEHOLDER>', blockPrior)
-  );
+  const [block, blockPrior] = await utils.getBlocks(chainString, null, [url]);
+
+  // getBlocks reads the head off a separate request, so it can name a block the indexer serving
+  // this one hasn't reached. that is worth a retry, not the loss of the chain — the pin is only
+  // a staleness guard on whichever indexer ends up answering.
+  const [data, volumeByPool] = await Promise.all([
+    request(url, query.replace('<BLOCK_NOW>', block)).catch((err) => {
+      console.log(`${chainString} retrying unpinned: ${err.message.slice(0, 120)}`);
+      return request(url, query.replace('<BLOCK_NOW>', blockPrior));
+    }),
+    swapVolumeByPool(url, blockPrior, block),
+  ]);
 
   // correct for missing maker symbol
-  dataNow = dataNow.pools.map((el) => correctMaker(el));
-  dataPrior = dataPrior.pools.map((el) => correctMaker(el));
+  const dataNow = data.pools.map((el) => correctMaker(el));
 
   // for tvl, we gonna pull token prices from our price api, which we use to calculate tvl
   // note: the subgraph already comes with usd tvl values, but sometimes they are inflated
@@ -552,7 +608,7 @@ const topLvl = async (
 
   // calculate fee apy
   tvlInfo = tvlInfo.map((el) =>
-    aprFee(el, dataNow, dataPrior, swapFeePercentage)
+    aprFee(el, volumeByPool, protocolFeePercentage)
   );
 
   // calculate reward apr
@@ -589,7 +645,7 @@ const topLvl = async (
 
 const main = async () => {
   // balancer splits off a pct cut of swap fees to the protocol, get pct value:
-  const swapFeePercentage =
+  const protocolFeePercentage =
     (
       await sdk.api.abi.call({
         target: protocolFeesCollector,
@@ -605,61 +661,55 @@ const main = async () => {
       'ethereum',
       urlEthereum,
       query,
-      queryPrior,
       urlGaugesEthereum,
       queryGauge,
       gaugeABIEthereum,
-      swapFeePercentage
+      protocolFeePercentage
     ),
     topLvl(
       'polygon',
       urlPolygon,
       query,
-      queryPrior,
       urlGaugesPolygon,
       queryGauge,
       gaugeABIPolygon,
-      swapFeePercentage
+      protocolFeePercentage
     ),
     topLvl(
       'arbitrum',
       urlArbitrum,
       query,
-      queryPrior,
       urlGaugesArbitrum,
       queryGauge,
       gaugeABIArbitrum,
-      swapFeePercentage
+      protocolFeePercentage
     ),
     topLvl(
       'xdai',
       urlGnosis,
       query,
-      queryPrior,
       urlGaugesGnosis,
       queryGauge,
       gaugeABIGnosis,
-      swapFeePercentage
+      protocolFeePercentage
     ),
     topLvl(
       'base',
       urlBaseChain,
       query,
-      queryPrior,
       urlGaugesBase,
       queryGauge,
       gaugeABIBase,
-      swapFeePercentage
+      protocolFeePercentage
     ),
     topLvl(
       'avax',
       urlAvalanche,
       query,
-      queryPrior,
       urlGaugesAvalanche,
       queryGauge,
       gaugeABIArbitrum,
-      swapFeePercentage
+      protocolFeePercentage
     ),
   ]);
 

--- a/src/adaptors/balancer-v2/index.js
+++ b/src/adaptors/balancer-v2/index.js
@@ -88,6 +88,7 @@ const query = gql`
     block: {number_gte: <BLOCK_NOW>}
   ) {
     id
+    name
     tokensList
     swapFee
     totalShares
@@ -204,6 +205,9 @@ const tvl = (entry, tokenPriceList, chainString) => {
   const d = {
     id: entry.id,
     symbol: balanceDetails.map((tok) => tok.symbol).join('-'),
+    // balancer's own name for the pool, which carries the weights our symbol drops
+    // (20wstETH-80AAVE vs wstETH-AAVE). some come back padded or empty
+    name: entry.name?.trim() || undefined,
     tvl: 0,
     totalShares: entry.totalShares,
     swapFee: entry.swapFee,
@@ -628,6 +632,7 @@ const topLvl = async (
       chain: utils.formatChain(chainString),
       project: 'balancer-v2',
       symbol: p.symbol,
+      poolMeta: p.name,
       token: p.id.slice(0, 42).toLowerCase(),
       tvlUsd: p.tvl,
       apyBase: p.aprFee,


### PR DESCRIPTION
resolves #2899 

# balancer-v2: apyBase spikes, two missing chains, and a 3x understated fee APY

## Summary

The 100,000%+ `apyBase` spikes came from differencing Balancer's cumulative `totalSwapFee`
counter across two subgraph reads. That counter is unusable for this purpose. The adapter no
longer touches it — fee revenue is now summed from the individual `Swap` entities, verified
against the Vault's on-chain `Swap` logs.

Investigating it turned up two unrelated failures that were silently dropping whole chains, and
a systematic ~3x understatement of `apyBase` on 42% of the adapter's TVL.

| | before | after |
|---|---|---|
| pools | 646 | 1,040 |
| tvlUsd | $25.57M | $26.37M |
| chains publishing | 4 | 6 |
| wstETH-AAVE apyBase | 0.141% | 0.432% (on-chain: 0.414%) |
| max apyBase observed | 822,315% | 29% |

---

## Root cause of the spikes

`aprFee` built the daily fee APR from the difference of a cumulative lifetime counter measured at
two points:

```js
const swapFeeNow = dataNow.find((x) => x.id === el.id)?.totalSwapFee;
const swapFeePrior = dataPrior.find((x) => x.id === el.id)?.totalSwapFee;
const swapFee24h = Number(swapFeeNow) - Number(swapFeePrior);
el.aprFee = ((swapFee24h * 365) / el.tvl) * 100 * swapFeePercentage;
```

Two independent things go wrong with that subtraction.

### 1. The two reads came from different indexers, which disagree on the counter

`dataNow` was **unpinned** (master's `query` has no `block:` argument — the validated `block` from
`getBlocks` was discarded into `_`). `dataPrior` was **pinned**. The Graph's gateway picks an
indexer per request, so the two sides regularly landed on different indexers — and indexers
disagree on `totalSwapFee` by a fixed per-pool offset.

Reproduced live with the old two-request shape, roughly 1 sample in 6:

```
0x3de27e (wstETH/AAVE): -173,163,418     ← normal delta ~150
0xa6f548 (WBTC/WETH):        -602,717     ← normal delta ~3
0x5c6ee3 (BAL/WETH):           +5,817     ← normal delta ~374
```

The sign flips depending on which indexer serves which read. A positive draw is the spike.

This matches the magnitude derived independently in the thread by inverting `aprFee` on the
2026-07-19 spike — implied delta $173,161,926 vs measured $173,163,418.

It also explains why WBTC-WETH's four spike days are a strict subset of wstETH-AAVE's sixteen:
each pool has its own offset, and only some indexer pairs disagree on a given pool. It was never
"shared per-run inputs" and never either pool's own data — it is *which indexer answers*.

### 2. The counter is corrupted in absolute terms and moves on its own

Same indexer, pinned blocks:

```
date          totalSwapFee($)     totalLiquidity($)
2025-11-12          6,034,576           102,939,543
2025-11-13     30,949,171,865     3,292,649,909,274,387   ← subgraph pricing blowup
2025-11-14     67,406,581,916            89,095,606
2025-11-30     72,819,139,106         2,706,280,448,708
2026-07-19     73,050,565,253            16,079,571
```

$73B of lifetime fees on a $12M pool. The counter also runs **backwards** across reindexes. Even
a perfect single-indexer read differencing this would produce garbage on jump days.

---

## Two chains were silently absent from every run

Both pre-existing, both masked by `Promise.allSettled` in `main`.

**Gnosis** — the `prior` query requested a full token payload for 1000 pools at a historical
block. Every Gnosis indexer timed out on it (0/4 success; master fails identically). Only `id`
and `totalSwapFee` were ever read from that side.

**Base** — its gauge subgraph (`api.studio.thegraph.com/query/24660/balancer-gauges-base`)
returns `deployment does not exist`. That rejection propagated out of `aprLM` and took every Base
pool with it.

---

## apyBase was understated ~3x on the largest pool

Chasing the counter on-chain showed it does not just spike — it under-accrues. For wstETH-AAVE
over 24h the counter moved **$156.87** while the pool actually earned **$428**.

The innocent explanations are ruled out:

- **Not missing swaps.** 141 on-chain Vault `Swap` logs, 141 subgraph `Swap` entities.
- **Not mispricing.** `sum(valueUSD)` matches on-chain `amountIn x price` within 5%.
- **Not a dynamic fee.** `getSwapFeePercentage()` is a constant 0.00292 on-chain across 12 blocks
  in the window, and the subgraph agrees.

The counter increments at 1x, 0.5x or 0.2x the pool's stated fee depending on the swap:

```
tokenIn      valueUSD    accrued   mult(of poolSwapFee)
AAVE -> wstETH  620.89     0.3626   0.200
AAVE -> wstETH  627.65     1.8327   1.000
wstETH -> AAVE  492.52     0.7191   0.500
```

Not direction-dependent, not time-ordered. Affects wstETH-AAVE (2.77x), WBTC-WETH (2.79x) and
BAL-WETH (1.36x); GNO-COW and WETH-LIT accrue exactly right.

---

## The fixes

**1. Stop differencing the cumulative counter.** Sum the individual `Swap` entities over the 24h
block window instead, paginated on `id`. This dissolves the original bug at its root — there is no
cumulative counter left to disagree about, jump, or run backwards. Costs 1–3k extra rows per
chain, under 2s; full run is 18s.

**2. Trim the prior read** — removed entirely along with the counter, which also removes the
Gnosis timeout.

**3. A dead gauge subgraph degrades to no reward APY** instead of killing the chain. Same guard on
`getChildChainRootGauge`, which was a single point of failure for all five non-Ethereum chains.

**4. `* swapFeePercentage` → `* (1 - protocolFeePercentage)`.** LPs keep the fee *minus* the
protocol's cut; the old code multiplied by the cut itself. A numerical no-op today because the cut
is exactly 0.5 (`getSwapFeePercentage()` on the ProtocolFeesCollector), but it would have silently
inverted every APY the day Balancer changed it.

**5. Pin the pools read** with `number_gte`, retrying unpinned rather than losing the chain — a
staleness guard on whichever indexer actually answers, which `getBlocks` cannot provide since it
reads the head in a separate request.

**6. A 1000% ceiling** stays as a backstop against a single mispriced swap on a small pool.

---

## Verification

`apyBase` recomputed from Vault `Swap` logs (`0xBA1222...2C8`, topic `0x2170c741...`), same block
window, all pools with activity in the top 5 by TVL per chain:

```
pool                      chain      subgraph apyBase   on-chain apyBase   ratio
wstETH/AAVE               ethereum          0.4335%           0.4144%   1.046
BAL/WETH                  ethereum          0.4333%           0.3972%   1.091
WBTC/WETH                 ethereum          0.2459%           0.2431%   1.012
WBTC/USDC/WETH            polygon           0.3964%           0.3971%   0.998
WBTC/TEL                  polygon           3.3377%           3.3743%   0.989
USDC/TEL                  polygon           4.5663%           4.6122%   0.990
WBTC/WETH/USDC            arbitrum          0.2822%           0.2827%   0.998
DAI/USDT/USDC             arbitrum          0.4760%           0.4759%   1.000
RDNT/WETH                 arbitrum          1.4010%           1.3957%   1.004
OLAS/USDC                 base              0.1913%           0.1912%   1.000
COW/GNO                   xdai              3.7856%           3.6525%   1.036
WETH/wstETH               xdai              0.1585%           0.1589%   0.998
```

Residual is subgraph-internal pricing vs the coins API.

Adapter TVL vs DefiLlama's protocol endpoint:

```
chain          pools        tvlUsd     defillama
Ethereum         196   $20,883,156   $20,539,500
Polygon          188    $3,535,193    $3,499,829
Arbitrum         193    $1,151,502      $930,754
Gnosis           199      $513,378      $263,617
Base             195      $270,962      $266,936
Avax              69       $19,522       $86,435
```

Tests: 7530 passed.

---

## Ruled out

- **Unvalidated `blockPrior`.** `getBlocks` validates `block` but not `blockPrior`. Real
  asymmetry, but harmless — an unreachable block returns
  `Unavailable(missing block: X, latest: Y)`, never a stale counter. It can only throw.
- **A zero or missing prior.** Against the counter's real magnitude that yields ~110,000,000%, not
  261,404% — it overshoots by 400x.
- **The missing-pool path.** `Number(undefined)` → `NaN`, and `triggerAdaptor.js:137-141`
  nullifies non-finite apy fields, so it publishes nothing rather than a spike.
- **`correctMaker`.** Only rewrites an MKR symbol, never touches `id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pool names, swap fees, and metadata to pool information.
  - Added 24-hour swap volume and fee APR calculations.
  - Improved consistency by using the same protocol fee percentage across chain data.

- **Bug Fixes**
  - Added fallback handling when block-specific data is unavailable.
  - Prevented invalid fee APR values and excluded pools without TVL.
  - Chain data now remains available when gauge reward data cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->