### PR TITLE
add CARRY APY calculation to vault-street and change methodology

### DIFF
--- a/src/adaptors/vault-street-primeusd/index.js
+++ b/src/adaptors/vault-street-primeusd/index.js
@@ -4,10 +4,8 @@ const utils = require('../utils');
 const CHAIN = 'ethereum';
 
 const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-const primeUSD = '0x7ea76108975ec0998b9bc2db04b4eca986400dd7';
-const priceOracle = '0x8cda03e2004c35e07963fb792c6b7511dabee369';
 
-// oracle price is scaled to 8 decimals (primeUSD/USDC)
+// oracle prices are scaled to 8 decimals (token/USDC)
 const PRICE_DECIMALS = 8n;
 const USDC_DECIMALS = 6n;
 const LAST_PRICE_ABI =
@@ -16,7 +14,23 @@ const LAST_PRICE_ABI =
 const DAY_IN_SECONDS = 24 * 60 * 60;
 const SECONDS_IN_YEAR = 365 * DAY_IN_SECONDS;
 
-const getLastPrice = async (block) => {
+const PRODUCTS = [
+  {
+    symbol: 'primeUSD',
+    token: '0x7ea76108975ec0998b9bc2db04b4eca986400dd7',
+    priceOracle: '0x8cda03e2004c35e07963fb792c6b7511dabee369',
+    url: 'https://app.vaultstreet.com/prime-usd',
+  },
+  {
+    symbol: 'CARRY',
+    token: '0xf05f7ab9b05d9dcf99b8e9bbae8e5e4a3201d004',
+    // updates once per ~7d (staleness period 169h)
+    priceOracle: '0xd610fabab31c6d76b50a49c337fc39d6559e0e87',
+    url: 'https://app.vaultstreet.com/carry',
+  },
+];
+
+const getLastPrice = async (priceOracle, block) => {
   const { output } = await sdk.api.abi.call({
     target: priceOracle,
     abi: LAST_PRICE_ABI,
@@ -26,56 +40,83 @@ const getLastPrice = async (block) => {
   return { value: BigInt(output.value), timestamp: Number(output.timestamp) };
 };
 
-const apy = async () => {
-  const currentBlock = await sdk.api.util.getLatestBlock(CHAIN);
-  const timestamp7dAgo = currentBlock.timestamp - 7 * DAY_IN_SECONDS;
-  const [block7dAgo] = await utils.getBlocksByTime([timestamp7dAgo], CHAIN);
+// elapsed time between oracle updates rounded to whole days
+const elapsedWholeDaysSeconds = (startTimestamp, endTimestamp) =>
+  Math.floor(
+    (endTimestamp - startTimestamp + DAY_IN_SECONDS / 2) / DAY_IN_SECONDS
+  ) * DAY_IN_SECONDS;
 
-  const [supplyRes, decimalsRes, endPrice, startPrice, usdcPrice] =
-    await Promise.all([
-      sdk.api.abi.call({ target: primeUSD, abi: 'erc20:totalSupply', chain: CHAIN }),
-      sdk.api.abi.call({ target: primeUSD, abi: 'erc20:decimals', chain: CHAIN }),
-      getLastPrice(),
-      getLastPrice(block7dAgo),
-      utils.getPriceApiData(`/prices/current/${CHAIN}:${USDC}`),
-    ]);
+// compounded annualized rate: (endRate / startRate) ^ (year / elapsed) - 1
+// null when not calculable (e.g. the oracle's first update has no predecessor)
+const calcApyPct = (startRate, endRate, startTimestamp, endTimestamp) => {
+  const elapsed = elapsedWholeDaysSeconds(startTimestamp, endTimestamp);
+  if (!(startRate > 0) || elapsed <= 0) return null;
+  return (
+    (Math.pow(endRate / startRate, SECONDS_IN_YEAR / elapsed) - 1) * 100
+  );
+};
+
+const getPool = async ({ symbol, token, priceOracle, url }, usdcPriceUsd) => {
+  const [supplyRes, decimalsRes, endPrice] = await Promise.all([
+    sdk.api.abi.call({ target: token, abi: 'erc20:totalSupply', chain: CHAIN }),
+    sdk.api.abi.call({ target: token, abi: 'erc20:decimals', chain: CHAIN }),
+    getLastPrice(priceOracle),
+  ]);
+
+  // sample just before the latest update landed; the oracle then reports the
+  // previous update, so the apy window is always exactly one publish interval
+  const [blockBeforeUpdate] = await utils.getBlocksByTime(
+    [endPrice.timestamp - 600],
+    CHAIN
+  );
+  const startPrice = await getLastPrice(priceOracle, blockBeforeUpdate).catch(
+    () => ({ value: 0n, timestamp: 0 })
+  );
 
   const supply = BigInt(supplyRes.output);
-  const primeDecimals = BigInt(decimalsRes.output);
-  const usdcPriceUsd = usdcPrice.coins[`${CHAIN}:${USDC}`]?.price ?? 1;
+  const tokenDecimals = BigInt(decimalsRes.output);
 
-  // value primeUSD in USDC terms, then express the balance in USDC's own decimals
-  const scale = 10n ** (primeDecimals + PRICE_DECIMALS - USDC_DECIMALS);
+  // value the token in USDC terms, then express the balance in USDC's own decimals
+  const scale = 10n ** (tokenDecimals + PRICE_DECIMALS - USDC_DECIMALS);
   const usdcBalance = (supply * endPrice.value) / scale;
   const tvlUsd = (Number(usdcBalance) / 10 ** Number(USDC_DECIMALS)) * usdcPriceUsd;
 
-  // primeUSD/USDC price per share (8 decimals) from the oracle
+  // token/USDC price per share (8 decimals) from the oracle
   const pricePerShare = Number(endPrice.value) / 10 ** Number(PRICE_DECIMALS);
   const startRate = Number(startPrice.value) / 10 ** Number(PRICE_DECIMALS);
 
+  const apyBase = calcApyPct(
+    startRate,
+    pricePerShare,
+    startPrice.timestamp,
+    endPrice.timestamp
+  );
+  if (apyBase === null) return null;
 
-  const elapsedSeconds = endPrice.timestamp - startPrice.timestamp;
-  const apyBase =
-    startRate > 0 && elapsedSeconds > 0
-      ? ((pricePerShare - startRate) / startRate) *
-        (SECONDS_IN_YEAR / elapsedSeconds) *
-        100
-      : 0;
+  return {
+    pool: `${token}-${CHAIN}`,
+    chain: 'Ethereum', // display name; handler normalizes via formatChain
+    project: 'vault-street-primeusd',
+    symbol,
+    tvlUsd,
+    apyBase,
+    pricePerShare,
+    underlyingTokens: [USDC],
+    token,
+    url,
+  };
+};
 
-  return [
-    {
-      pool: `${primeUSD}-${CHAIN}`,
-      chain: 'Ethereum', // display name; handler normalizes via formatChain
-      project: 'vault-street-primeusd',
-      symbol: 'primeUSD',
-      tvlUsd,
-      apyBase,
-      pricePerShare,
-      underlyingTokens: [USDC],
-      token: primeUSD,
-      url: 'https://app.vaultstreet.com/prime-usd'
-    },
-  ];
+const apy = async () => {
+  const usdcPrice = await utils.getPriceApiData(
+    `/prices/current/${CHAIN}:${USDC}`
+  );
+  const usdcPriceUsd = usdcPrice.coins[`${CHAIN}:${USDC}`]?.price ?? 1;
+
+  const pools = await Promise.all(
+    PRODUCTS.map((product) => getPool(product, usdcPriceUsd))
+  );
+  return pools.filter(Boolean);
 };
 
 module.exports = {

--- a/src/adaptors/vault-street-primeusd/index.js
+++ b/src/adaptors/vault-street-primeusd/index.js
@@ -120,12 +120,15 @@ const apy = async () => {
     console.log(
       `vault-street: ${failed.length}/${PRODUCTS.length} products failed -> ${failed.join(' | ')}`
     );
-  if (failed.length === PRODUCTS.length)
-    throw new Error(`vault-street: every product failed -> ${failed.join(' | ')}`);
-  return settled
+  const pools = settled
     .filter((r) => r.status === 'fulfilled')
     .map((r) => r.value)
     .filter(Boolean);
+  if (pools.length === 0)
+    throw new Error(
+      `vault-street: no valid product pool${failed.length ? ` -> ${failed.join(' | ')}` : ''}`
+    );
+  return pools;
 };
 
 module.exports = {

--- a/src/adaptors/vault-street-primeusd/index.js
+++ b/src/adaptors/vault-street-primeusd/index.js
@@ -13,6 +13,7 @@ const LAST_PRICE_ABI =
 
 const DAY_IN_SECONDS = 24 * 60 * 60;
 const SECONDS_IN_YEAR = 365 * DAY_IN_SECONDS;
+const MIN_WINDOW_DAYS = 7;
 
 const PRODUCTS = [
   {
@@ -24,7 +25,6 @@ const PRODUCTS = [
   {
     symbol: 'CARRY',
     token: '0xf05f7ab9b05d9dcf99b8e9bbae8e5e4a3201d004',
-    // updates once per ~7d (staleness period 169h)
     priceOracle: '0xd610fabab31c6d76b50a49c337fc39d6559e0e87',
     url: 'https://app.vaultstreet.com/carry',
   },
@@ -40,16 +40,10 @@ const getLastPrice = async (priceOracle, block) => {
   return { value: BigInt(output.value), timestamp: Number(output.timestamp) };
 };
 
-// elapsed time between oracle updates rounded to whole days
-const elapsedWholeDaysSeconds = (startTimestamp, endTimestamp) =>
-  Math.floor(
-    (endTimestamp - startTimestamp + DAY_IN_SECONDS / 2) / DAY_IN_SECONDS
-  ) * DAY_IN_SECONDS;
-
 // compounded annualized rate: (endRate / startRate) ^ (year / elapsed) - 1
 // null when not calculable (e.g. the oracle's first update has no predecessor)
 const calcApyPct = (startRate, endRate, startTimestamp, endTimestamp) => {
-  const elapsed = elapsedWholeDaysSeconds(startTimestamp, endTimestamp);
+  const elapsed = endTimestamp - startTimestamp;
   if (!(startRate > 0) || elapsed <= 0) return null;
   return (
     (Math.pow(endRate / startRate, SECONDS_IN_YEAR / elapsed) - 1) * 100
@@ -63,15 +57,16 @@ const getPool = async ({ symbol, token, priceOracle, url }, usdcPriceUsd) => {
     getLastPrice(priceOracle),
   ]);
 
-  // sample just before the latest update landed; the oracle then reports the
-  // previous update, so the apy window is always exactly one publish interval
-  const [blockBeforeUpdate] = await utils.getBlocksByTime(
-    [endPrice.timestamp - 600],
+  // anchor to the last publish at or before (latest - MIN_WINDOW), so the window
+  // never collapses when the publisher goes off-schedule
+  const [anchorBlock] = await utils.getBlocksByTime(
+    [endPrice.timestamp - MIN_WINDOW_DAYS * DAY_IN_SECONDS],
     CHAIN
   );
-  const startPrice = await getLastPrice(priceOracle, blockBeforeUpdate).catch(
-    () => ({ value: 0n, timestamp: 0 })
-  );
+  const startPrice = await getLastPrice(priceOracle, anchorBlock).catch((e) => {
+    if (/revert/i.test(e?.message ?? '')) return { value: 0n, timestamp: 0 };
+    throw e;
+  });
 
   const supply = BigInt(supplyRes.output);
   const tokenDecimals = BigInt(decimalsRes.output);
@@ -113,10 +108,24 @@ const apy = async () => {
   );
   const usdcPriceUsd = usdcPrice.coins[`${CHAIN}:${USDC}`]?.price ?? 1;
 
-  const pools = await Promise.all(
+  const settled = await Promise.allSettled(
     PRODUCTS.map((product) => getPool(product, usdcPriceUsd))
   );
-  return pools.filter(Boolean);
+  const failed = settled
+    .map((r, i) =>
+      r.status === 'rejected' ? `${PRODUCTS[i].symbol}: ${r.reason?.message}` : null
+    )
+    .filter(Boolean);
+  if (failed.length)
+    console.log(
+      `vault-street: ${failed.length}/${PRODUCTS.length} products failed -> ${failed.join(' | ')}`
+    );
+  if (failed.length === PRODUCTS.length)
+    throw new Error(`vault-street: every product failed -> ${failed.join(' | ')}`);
+  return settled
+    .filter((r) => r.status === 'fulfilled')
+    .map((r) => r.value)
+    .filter(Boolean);
 };
 
 module.exports = {
@@ -125,3 +134,4 @@ module.exports = {
   apy,
   url: 'https://www.vaultstreet.com/',
 };
+


### PR DESCRIPTION
Related TVL adapter PR: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20586

Note:
If it's possible, rename the current Vault Street primeUSD page (https://defillama.com/protocol/vault-street-primeusd) to Vault Street, and show the cumulative TVL on the main page and per token in the TVL breakdown section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking the CARRY product alongside primeUSD.
  * Improved retrieval across multiple products, allowing successful results when individual products fail.
* **Bug Fixes**
  * Improved APY accuracy using compounded annualized calculations over exact oracle intervals.
  * Preserved valid calculation windows for irregular oracle publishing schedules.
  * Restricted fallback data to unavailable oracle records while surfacing other errors.
  * Prevented results from being returned when no valid product data is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->