### PR TITLE
hrusd: add HRUSD/USDC Uniswap V3 staking pool

### DIFF
--- a/src/adaptors/hrusd/index.js
+++ b/src/adaptors/hrusd/index.js
@@ -25,7 +25,15 @@ const ABI = {
     'function previewAmounts(uint256 tokenId) view returns (uint256 amt0, uint256 amt1, uint256 principalHrusd)',
   observe:
     'function observe(uint32[] secondsAgos) view returns (int56[] tickCumulatives, uint160[] secondsPerLiquidityCumulativeX128)',
+  pendingRewards: 'function pendingRewards(uint256 tokenId) view returns (uint256)',
+  feeGrowth0: 'uint256:feeGrowthGlobal0X128',
+  feeGrowth1: 'uint256:feeGrowthGlobal1X128',
+  liquidity: 'uint128:liquidity',
 };
+
+// Base produces a block roughly every 2s.
+const BLOCKS_PER_DAY = 43200;
+const Q128 = 2n ** 128n;
 
 // Same window the staking contracts use for their own principal valuation
 // (`twapWindowSeconds() == 1800`).
@@ -37,7 +45,7 @@ const TWAP_WINDOW = 1800;
 // block cannot move the reported TVL. `observe` reverts if the pool's observation
 // cardinality does not cover the window, which fails the run rather than reporting a
 // manipulable number.
-const getHrusdPrice = async (api) => {
+const getPrices = async (api) => {
   const [observation, usdc] = await Promise.all([
     api.call({ abi: ABI.observe, target: POOL, params: [[TWAP_WINDOW, 0]] }),
     utils.getData(`https://coins.llama.fi/prices/current/${CHAIN}:${USDC}`),
@@ -51,12 +59,14 @@ const getHrusdPrice = async (api) => {
   if (!Number.isFinite(avgTick)) throw new Error('hrusd: invalid TWAP observation');
 
   // HRUSD is token0, USDC is token1, both 6 decimals, so the tick needs no decimal shift
-  return 1.0001 ** avgTick * usdcPrice;
+  return { hrusdPrice: 1.0001 ** avgTick * usdcPrice, usdcPrice };
 };
 
 // Rewards accrue linearly on `principalHrusd`, the HRUSD-denominated value of each
-// staked position, so the pool's TVL is the sum of those principals.
-const getStakedPrincipal = async (api) => {
+// staked position, so the pool's TVL is the sum of those principals. The same walk over
+// the staked positions yields `owed`, the rewards already accrued to stakers, which the
+// reward runway below has to net out of the contracts' balance.
+const getStakedPositions = async (api) => {
   const counts = await api.multiCall({
     abi: ABI.balanceOf,
     target: POSITION_MANAGER,
@@ -68,7 +78,7 @@ const getStakedPrincipal = async (api) => {
     for (let j = 0; j < Number(counts[i]); j += 1)
       idCalls.push({ owner, params: [owner, j] });
   });
-  if (!idCalls.length) return 0;
+  if (!idCalls.length) return { principal: 0, owed: 0 };
 
   const tokenIds = await api.multiCall({
     abi: ABI.tokenOfOwnerByIndex,
@@ -76,20 +86,73 @@ const getStakedPrincipal = async (api) => {
     calls: idCalls.map(({ params }) => ({ params })),
   });
 
-  const previews = await Promise.all(
-    STAKERS.map((staker) => {
-      const calls = idCalls
-        .map(({ owner }, k) => (owner === staker ? { params: [tokenIds[k]] } : null))
-        .filter(Boolean);
-      if (!calls.length) return [];
-      // No permitFailure: a missing preview would silently understate TVL
-      return api.multiCall({ abi: ABI.previewAmounts, target: staker, calls });
-    })
-  );
+  const perStaker = STAKERS.map((staker) => {
+    const calls = idCalls
+      .map(({ owner }, k) => (owner === staker ? { params: [tokenIds[k]] } : null))
+      .filter(Boolean);
+    return { staker, calls };
+  });
 
-  return previews
-    .flat()
-    .reduce((acc, p) => acc + Number(p.principalHrusd) / 1e6, 0);
+  // No permitFailure anywhere here: a missing result would silently understate TVL or
+  // overstate how much reward inventory is unspoken for.
+  const [previews, pending] = await Promise.all([
+    Promise.all(
+      perStaker.map(({ staker, calls }) =>
+        calls.length ? api.multiCall({ abi: ABI.previewAmounts, target: staker, calls }) : []
+      )
+    ),
+    Promise.all(
+      perStaker.map(({ staker, calls }) =>
+        calls.length ? api.multiCall({ abi: ABI.pendingRewards, target: staker, calls }) : []
+      )
+    ),
+  ]);
+
+  return {
+    principal: previews.flat().reduce((a, p) => a + Number(p.principalHrusd) / 1e6, 0),
+    owed: pending.flat().reduce((a, v) => a + Number(v) / 1e6, 0),
+  };
+};
+
+// Trading fees earned by the pool over the last day, from the change in the pool's
+// global fee growth accumulators. Uniswap V3 tracks fees per unit of in-range liquidity,
+// so the delta multiplied by liquidity is what the pool actually earned.
+const getFeeApyBase = async (api, hrusdPrice, usdcPrice) => {
+  const block = await api.getBlock();
+  const dayAgo = block - BLOCKS_PER_DAY;
+
+  const read = (b) =>
+    Promise.all([
+      api.call({ abi: ABI.feeGrowth0, target: POOL, block: b }),
+      api.call({ abi: ABI.feeGrowth1, target: POOL, block: b }),
+      api.call({ abi: ABI.liquidity, target: POOL, block: b }),
+    ]);
+
+  const [[f0, f1, liq], [p0, p1]] = await Promise.all([read(undefined), read(dayAgo)]);
+
+  // Accumulators only ever increase, but they are unsigned and wrap; clamp rather than
+  // report a negative fee take.
+  const grown = (now, then) => {
+    const d = BigInt(now) - BigInt(then);
+    return d > 0n ? d : 0n;
+  };
+  const feesOf = (now, then) =>
+    Number((grown(now, then) * BigInt(liq)) / Q128) / 1e6;
+
+  const feesUsd = feesOf(f0, p0) * hrusdPrice + feesOf(f1, p1) * usdcPrice;
+
+  // Denominated against the whole pool, which is what an LP in it earns.
+  const [bal0, bal1] = await api.multiCall({
+    abi: ABI.balanceOf,
+    calls: [
+      { target: HRUSD, params: [POOL] },
+      { target: USDC, params: [POOL] },
+    ],
+  });
+  const poolTvl = (Number(bal0) / 1e6) * hrusdPrice + (Number(bal1) / 1e6) * usdcPrice;
+  if (!poolTvl) return 0;
+
+  return (feesUsd / poolTvl) * 365 * 100;
 };
 
 const apy = async () => {
@@ -104,14 +167,30 @@ const apy = async () => {
   // is applied for early exit: the exit fee is set to zero, and no ExitFeesPaid event
   // has ever fired on the current deployment (the legacy one charged 0.98 HRUSD in
   // total over its lifetime). Unstaking is subject to a 24h delay, not a penalty.
-  const apyReward = Math.min(
+  const nominalApr = Math.min(
     ...aprBps.map((bps, i) => (Number(bps) / Number(denominators[i])) * 100)
   );
 
-  const [principalHrusd, hrusdPrice] = await Promise.all([
-    getStakedPrincipal(api),
-    getHrusdPrice(api),
+  const [{ principal, owed }, prices, balances] = await Promise.all([
+    getStakedPositions(api),
+    getPrices(api),
+    api.multiCall({
+      abi: ABI.balanceOf,
+      calls: STAKERS.map((staker) => ({ target: HRUSD, params: [staker] })),
+    }),
   ]);
+  const { hrusdPrice, usdcPrice } = prices;
+
+  // `aprBps` is an owner-set parameter, not a rate derived from emissions, so on its own
+  // it would keep advertising the same yield after the reward pool ran dry. Rewards are
+  // paid out of HRUSD held by the staking contracts, part of which is already accrued to
+  // stakers; only the remainder can fund future accrual. If nothing is left unspoken for,
+  // the advertised rate is not payable and no reward APY is reported.
+  const inventory = balances.reduce((acc, v) => acc + Number(v) / 1e6, 0);
+  const unspokenFor = Math.max(0, inventory - owed);
+  const apyReward = unspokenFor > 0 ? nominalApr : 0;
+
+  const apyBase = await getFeeApyBase(api, hrusdPrice, usdcPrice);
 
   return [
     {
@@ -119,7 +198,8 @@ const apy = async () => {
       chain: utils.formatChain(CHAIN),
       project: 'hrusd',
       symbol: utils.formatSymbol('HRUSD-USDC'),
-      tvlUsd: principalHrusd * hrusdPrice,
+      tvlUsd: principal * hrusdPrice,
+      apyBase,
       apyReward,
       rewardTokens: [HRUSD],
       underlyingTokens: [HRUSD, USDC],

--- a/src/adaptors/hrusd/index.js
+++ b/src/adaptors/hrusd/index.js
@@ -1,0 +1,130 @@
+const sdk = require('@defillama/sdk');
+
+const utils = require('../utils');
+
+const CHAIN = 'base';
+const HRUSD = '0x5587AD03F9565F1B86cfA51a3C744Bcc4039dAf0';
+const USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const POOL = '0xAE2E818A18e95212FAE482e2180bC89546393DC9';
+const POSITION_MANAGER = '0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1';
+
+// Both V3LPStakingRewards deployments escrow HRUSD/USDC position NFTs and accrue
+// rewards on the same terms. The legacy one still holds stakes, so it is included.
+const STAKERS = [
+  '0xb72f376ae7732a76F1C18e0547553A616a33a2bd',
+  '0xA61C08DeC414416E55de7b4510bA8Ef25C89886a',
+];
+
+const ABI = {
+  aprBps: 'uint256:aprBps',
+  bpsDenominator: 'uint256:BPS_DENOMINATOR',
+  balanceOf: 'erc20:balanceOf',
+  tokenOfOwnerByIndex:
+    'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
+  previewAmounts:
+    'function previewAmounts(uint256 tokenId) view returns (uint256 amt0, uint256 amt1, uint256 principalHrusd)',
+  slot0:
+    'function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16, uint16, uint16, uint8, bool)',
+};
+
+// HRUSD has no price feed on DefiLlama, so it is valued against USDC from its own
+// Uniswap V3 pool — the same source the staking contract reads for principal.
+const getHrusdPrice = async (api) => {
+  const [slot0, usdc] = await Promise.all([
+    api.call({ abi: ABI.slot0, target: POOL }),
+    utils.getData(`https://coins.llama.fi/prices/current/${CHAIN}:${USDC}`),
+  ]);
+  const usdcPrice = Object.values(usdc.coins)[0]?.price;
+  if (!usdcPrice) throw new Error('hrusd: missing USDC price');
+  // HRUSD is token0, USDC is token1, both 6 decimals
+  const hrusdInUsdc = (Number(slot0.sqrtPriceX96) / 2 ** 96) ** 2;
+  return hrusdInUsdc * usdcPrice;
+};
+
+// Rewards accrue linearly on `principalHrusd`, the HRUSD-denominated value of each
+// staked position, so the pool's TVL is the sum of those principals.
+const getStakedPrincipal = async (api) => {
+  const counts = await api.multiCall({
+    abi: ABI.balanceOf,
+    target: POSITION_MANAGER,
+    calls: STAKERS.map((owner) => ({ params: [owner] })),
+  });
+
+  const idCalls = [];
+  STAKERS.forEach((owner, i) => {
+    for (let j = 0; j < Number(counts[i]); j += 1)
+      idCalls.push({ owner, params: [owner, j] });
+  });
+  if (!idCalls.length) return 0;
+
+  const tokenIds = await api.multiCall({
+    abi: ABI.tokenOfOwnerByIndex,
+    target: POSITION_MANAGER,
+    calls: idCalls.map(({ params }) => ({ params })),
+  });
+
+  const previews = await Promise.all(
+    STAKERS.map((staker) => {
+      const calls = idCalls
+        .map(({ owner }, k) => (owner === staker ? { params: [tokenIds[k]] } : null))
+        .filter(Boolean);
+      if (!calls.length) return [];
+      return api.multiCall({
+        abi: ABI.previewAmounts,
+        target: staker,
+        calls,
+        permitFailure: true,
+      });
+    })
+  );
+
+  return previews
+    .flat()
+    .filter(Boolean)
+    .reduce((acc, p) => acc + Number(p.principalHrusd) / 1e6, 0);
+};
+
+const apy = async () => {
+  const api = new sdk.ChainApi({ chain: CHAIN });
+
+  const [aprBps, denominators] = await Promise.all([
+    api.multiCall({ abi: ABI.aprBps, calls: STAKERS.map((target) => ({ target })) }),
+    api.multiCall({ abi: ABI.bpsDenominator, calls: STAKERS.map((target) => ({ target })) }),
+  ]);
+
+  // Lower bound across deployments, per the repo's unboosted-value rule. No haircut
+  // is applied for early exit: the exit fee is set to zero, and no ExitFeesPaid event
+  // has ever fired on the current deployment (the legacy one charged 0.98 HRUSD in
+  // total over its lifetime). Unstaking is subject to a 24h delay, not a penalty.
+  const apyReward = Math.min(
+    ...aprBps.map((bps, i) => (Number(bps) / Number(denominators[i])) * 100)
+  );
+
+  const [principalHrusd, hrusdPrice] = await Promise.all([
+    getStakedPrincipal(api),
+    getHrusdPrice(api),
+  ]);
+
+  return [
+    {
+      pool: `${POOL}-${CHAIN}`.toLowerCase(),
+      chain: utils.formatChain(CHAIN),
+      project: 'hrusd',
+      symbol: utils.formatSymbol('HRUSD-USDC'),
+      tvlUsd: principalHrusd * hrusdPrice,
+      apyReward,
+      rewardTokens: [HRUSD],
+      underlyingTokens: [HRUSD, USDC],
+      token: POOL,
+      poolMeta: 'Uniswap V3 LP staking',
+      url: 'https://hyperoute.xyz/',
+    },
+  ];
+};
+
+module.exports = {
+  protocolId: '8458',
+  timetravel: false,
+  apy,
+  url: 'https://hyperoute.xyz/',
+};

--- a/src/adaptors/hrusd/index.js
+++ b/src/adaptors/hrusd/index.js
@@ -26,9 +26,9 @@ const ABI = {
   observe:
     'function observe(uint32[] secondsAgos) view returns (int56[] tickCumulatives, uint160[] secondsPerLiquidityCumulativeX128)',
   pendingRewards: 'function pendingRewards(uint256 tokenId) view returns (uint256)',
-  feeGrowth0: 'uint256:feeGrowthGlobal0X128',
-  feeGrowth1: 'uint256:feeGrowthGlobal1X128',
-  liquidity: 'uint128:liquidity',
+  fee: 'uint24:fee',
+  swap:
+    'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick)',
 };
 
 // Base produces a block roughly every 2s.
@@ -57,6 +57,19 @@ const getPrices = async (api) => {
   const [start, end] = observation.tickCumulatives;
   const avgTick = Number(BigInt(end) - BigInt(start)) / TWAP_WINDOW;
   if (!Number.isFinite(avgTick)) throw new Error('hrusd: invalid TWAP observation');
+
+  // `observe` proves the window exists, not that anything was backing the price during it.
+  // The harmonic mean of in-range liquidity over the window comes out of the seconds-per-
+  // liquidity accumulator; if it is degenerate the tick describes an empty pool and the
+  // price derived from it means nothing. No floor above zero is imposed: any figure would
+  // be arbitrary, and HRUSD has no second venue to fall back on, so rejecting on a guessed
+  // threshold would drop the pool rather than protect it.
+  const [splStart, splEnd] = observation.secondsPerLiquidityCumulativeX128;
+  const splDelta = BigInt(splEnd) - BigInt(splStart);
+  const harmonicLiquidity =
+    splDelta > 0n ? Number((BigInt(TWAP_WINDOW) * Q128) / splDelta) : 0;
+  if (!(harmonicLiquidity > 0))
+    throw new Error('hrusd: no liquidity backing the TWAP window');
 
   // HRUSD is token0, USDC is token1, both 6 decimals, so the tick needs no decimal shift
   return { hrusdPrice: 1.0001 ** avgTick * usdcPrice, usdcPrice };
@@ -114,34 +127,39 @@ const getStakedPositions = async (api) => {
   };
 };
 
-// Trading fees earned by the pool over the last day, from the change in the pool's
-// global fee growth accumulators. Uniswap V3 tracks fees per unit of in-range liquidity,
-// so the delta multiplied by liquidity is what the pool actually earned.
+// Trading fees earned by the pool over the last day. Taken from the Swap events
+// themselves rather than from the fee-growth accumulators: `feeGrowthGlobal` rises by
+// fee/liquidity at each swap, so multiplying its delta by any single liquidity reading is
+// only correct while liquidity is unchanged over the window. Summing the fee cut of each
+// swap's input amount is exact regardless of how liquidity moved.
 const getFeeApyBase = async (api, hrusdPrice, usdcPrice) => {
   const block = await api.getBlock();
-  const dayAgo = block - BLOCKS_PER_DAY;
+  const [feeTier, logs] = await Promise.all([
+    api.call({ abi: ABI.fee, target: POOL }),
+    sdk.getEventLogs({
+      target: POOL,
+      chain: CHAIN,
+      fromBlock: block - BLOCKS_PER_DAY,
+      toBlock: block,
+      eventAbi: ABI.swap,
+      onlyArgs: true,
+    }),
+  ]);
 
-  const read = (b) =>
-    Promise.all([
-      api.call({ abi: ABI.feeGrowth0, target: POOL, block: b }),
-      api.call({ abi: ABI.feeGrowth1, target: POOL, block: b }),
-      api.call({ abi: ABI.liquidity, target: POOL, block: b }),
-    ]);
+  // Uniswap V3 takes its fee from the input side, which is the amount the pool receives.
+  let fees0 = 0;
+  let fees1 = 0;
+  for (const { amount0, amount1 } of logs) {
+    const a0 = BigInt(amount0);
+    const a1 = BigInt(amount1);
+    if (a0 > 0n) fees0 += Number(a0) / 1e6;
+    if (a1 > 0n) fees1 += Number(a1) / 1e6;
+  }
+  const rate = Number(feeTier) / 1e6;
+  const feesUsd = (fees0 * hrusdPrice + fees1 * usdcPrice) * rate;
 
-  const [[f0, f1, liq], [p0, p1]] = await Promise.all([read(undefined), read(dayAgo)]);
-
-  // Accumulators only ever increase, but they are unsigned and wrap; clamp rather than
-  // report a negative fee take.
-  const grown = (now, then) => {
-    const d = BigInt(now) - BigInt(then);
-    return d > 0n ? d : 0n;
-  };
-  const feesOf = (now, then) =>
-    Number((grown(now, then) * BigInt(liq)) / Q128) / 1e6;
-
-  const feesUsd = feesOf(f0, p0) * hrusdPrice + feesOf(f1, p1) * usdcPrice;
-
-  // Denominated against the whole pool, which is what an LP in it earns.
+  // Fees accrue to every in-range position, not only the staked ones, so the yield is
+  // measured against the whole pool rather than against this entry's staked TVL.
   const [bal0, bal1] = await api.multiCall({
     abi: ABI.balanceOf,
     calls: [

--- a/src/adaptors/hrusd/index.js
+++ b/src/adaptors/hrusd/index.js
@@ -23,22 +23,35 @@ const ABI = {
     'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
   previewAmounts:
     'function previewAmounts(uint256 tokenId) view returns (uint256 amt0, uint256 amt1, uint256 principalHrusd)',
-  slot0:
-    'function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16, uint16, uint16, uint8, bool)',
+  observe:
+    'function observe(uint32[] secondsAgos) view returns (int56[] tickCumulatives, uint160[] secondsPerLiquidityCumulativeX128)',
 };
 
+// Same window the staking contracts use for their own principal valuation
+// (`twapWindowSeconds() == 1800`).
+const TWAP_WINDOW = 1800;
+
 // HRUSD has no price feed on DefiLlama, so it is valued against USDC from its own
-// Uniswap V3 pool — the same source the staking contract reads for principal.
+// Uniswap V3 pool, over the same TWAP window the staking contract reads for principal.
+// A time-averaged tick is used rather than the spot price so that a swap at the sampled
+// block cannot move the reported TVL. `observe` reverts if the pool's observation
+// cardinality does not cover the window, which fails the run rather than reporting a
+// manipulable number.
 const getHrusdPrice = async (api) => {
-  const [slot0, usdc] = await Promise.all([
-    api.call({ abi: ABI.slot0, target: POOL }),
+  const [observation, usdc] = await Promise.all([
+    api.call({ abi: ABI.observe, target: POOL, params: [[TWAP_WINDOW, 0]] }),
     utils.getData(`https://coins.llama.fi/prices/current/${CHAIN}:${USDC}`),
   ]);
+
   const usdcPrice = Object.values(usdc.coins)[0]?.price;
   if (!usdcPrice) throw new Error('hrusd: missing USDC price');
-  // HRUSD is token0, USDC is token1, both 6 decimals
-  const hrusdInUsdc = (Number(slot0.sqrtPriceX96) / 2 ** 96) ** 2;
-  return hrusdInUsdc * usdcPrice;
+
+  const [start, end] = observation.tickCumulatives;
+  const avgTick = Number(BigInt(end) - BigInt(start)) / TWAP_WINDOW;
+  if (!Number.isFinite(avgTick)) throw new Error('hrusd: invalid TWAP observation');
+
+  // HRUSD is token0, USDC is token1, both 6 decimals, so the tick needs no decimal shift
+  return 1.0001 ** avgTick * usdcPrice;
 };
 
 // Rewards accrue linearly on `principalHrusd`, the HRUSD-denominated value of each
@@ -69,18 +82,13 @@ const getStakedPrincipal = async (api) => {
         .map(({ owner }, k) => (owner === staker ? { params: [tokenIds[k]] } : null))
         .filter(Boolean);
       if (!calls.length) return [];
-      return api.multiCall({
-        abi: ABI.previewAmounts,
-        target: staker,
-        calls,
-        permitFailure: true,
-      });
+      // No permitFailure: a missing preview would silently understate TVL
+      return api.multiCall({ abi: ABI.previewAmounts, target: staker, calls });
     })
   );
 
   return previews
     .flat()
-    .filter(Boolean)
     .reduce((acc, p) => acc + Number(p.principalHrusd) / 1e6, 0);
 };
 


### PR DESCRIPTION
Adds the HRUSD/USDC Uniswap V3 staking pool. HRUSD is already listed on the TVL side
(`hrusd`, protocol id 8458) and as a pegged asset (id 433).

### Where the APY comes from

The reward rate is a single on-chain parameter, not an off-chain figure:
`aprBps()` returns `1200` on both V3LPStakingRewards deployments, against
`BPS_DENOMINATOR() = 10000` — a flat 12.00% APR accruing linearly on each stake's
`principalHrusd`. The adapter reads both deployments and takes the lower of the two, per
the unboosted-value rule.

No haircut is applied for early exit. The exit fee is set to zero: `ExitFeesPaid` has never
fired on the current deployment, and over the legacy deployment's entire lifetime it fired
24 times for 0.977958 HRUSD in total. Unstaking is gated by a 24h delay
(`unstakePeriod() = 86400`), not by a penalty on accrued rewards.

### How TVL is computed

Rewards accrue on `principalHrusd`, the HRUSD-denominated value of a staked position, so
that is what the pool's TVL measures. The adapter enumerates the position NFTs escrowed by
the two staking contracts through the Uniswap position manager, calls `previewAmounts` on
each, and sums the principals — currently 27 positions totalling 41,172.68 HRUSD.

HRUSD has no price feed on DefiLlama (`coins.llama.fi` returns an empty object for it), so
it is valued against USDC from the HRUSD/USDC pool itself, using a time-averaged tick from
`observe()` over 1800s — the same window the staking contracts use for their own principal
valuation (`twapWindowSeconds() == 1800`). A spot `slot0()` read would let a swap at the
sampled block move the reported TVL; `observe` reverts if the pool's observation cardinality
does not cover the window, which fails the run rather than publishing a manipulable number.

As a cross-check, the USDC leg of those same positions sums to 9,589.10, which matches the
`pool2` figure produced by the existing `hrusd` entry in DefiLlama-Adapters.

### Note on the TVL difference vs the protocol page

This pool reports ~$41.2k while `defillama.com/protocol/hrusd` shows ~$10.2k. That is
expected and not a discrepancy: the protocol-side config deliberately counts only the USDC
side, because the HRUSD it is paired against is backed by that same USDC and counting both
would double count. A yield pool's TVL is the full value of the staked position, so both
legs are included here.

### Note on the reward token

Rewards are paid in HRUSD, funded into the staking contracts up front via `fund()`. Flagging
this explicitly against the "omit any pre-mined rewards" rule: the rewards are pre-funded
inventory rather than emissions minted on claim. The same balance is excluded from HRUSD's
circulating supply in peggedassets-server (PR #901), on the grounds that it has not been
distributed to any holder — `totalOwed()` currently reads 0. If you would rather this pool
carry no `apyReward` on that basis, say so and I will drop it to a TVL-only entry.

HRUSD's only venue is the Uniswap V3 pool above; it is not listed on CoinGecko or CMC.

### Validation

```
$ npm run test --adapter=hrusd

Tests: 14 passed, 14 total
```

Output:

```json
{
  "pool": "0xae2e818a18e95212fae482e2180bc89546393dc9-base",
  "chain": "Base",
  "project": "hrusd",
  "symbol": "HRUSD-USDC",
  "tvlUsd": 41146.09,
  "apyReward": 12,
  "rewardTokens": ["0x5587AD03F9565F1B86cfA51a3C744Bcc4039dAf0"],
  "underlyingTokens": ["0x5587AD03F9565F1B86cfA51a3C744Bcc4039dAf0", "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"],
  "token": "0xAE2E818A18e95212FAE482e2180bC89546393DC9",
  "poolMeta": "Uniswap V3 LP staking"
}
```

One new file, no dependency or lockfile changes.

Both of CodeRabbit's findings are addressed in the second commit: the TWAP change above, and
dropping `permitFailure` from the `previewAmounts` multiCall so an incomplete set of position
previews fails the run instead of silently reporting partial TVL.

Unrelated, but worth flagging while I was here: `beforeTests.js` resolves the adapter path
with `cwd.includes('src/adaptors')`, which never matches on Windows because the path uses
backslashes, so the runner looks under `src/adaptors/src/adaptors/`. Happy to open a separate
PR for that if useful — this one leaves it untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for pending HRUSD staking rewards.
  * Added base APY calculations using recent trading fees and current pool value.
  * Added separate HRUSD and USDC pricing.
  * Improved position reporting to include staked principal and accrued rewards.
  * Added support for HRUSD staking positions across multiple deployments.
  * Added HRUSD pricing, total value locked, reward, and underlying token details.
  * Added unboosted APY calculations based on staking rewards.
  * Added protocol metadata and configuration for HRUSD staking.
* **Bug Fixes**
  * Improved valuation reliability by rejecting incomplete pricing data and unavailable liquidity windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->