### PR TITLE
Add sapien-vault adapter

### DIFF
--- a/src/adaptors/sapien-vault/index.js
+++ b/src/adaptors/sapien-vault/index.js
@@ -1,0 +1,47 @@
+const { formatChain, getERC4626Info, getPrices } = require('../utils');
+
+const PROJECT = 'sapien-vault';
+
+// Sapien PoQ Vault — single-sided SAPIEN staking on Base (ERC-4626).
+// SAPIEN streams into the vault from an on-chain YieldController
+// (0x55Ce7717Bc8c8F1b59AdB9e0CE7abc332391BF18, keeper-driven drip capped at
+// min(rate cap, 10M SAPIEN/yr); slashed validator collateral also
+// redistributes into the vault). Rewards accrue into the vSAPIEN share
+// price with no claim step, so 24h share-price growth via convertToAssets
+// is the realized net yield.
+const VAULT = '0x60Bf63729f688287a450299962b36Cef0aFfaa42';
+const SAPIEN = '0xc729777d0470f30612b1564fd96e8dd26f5814e3';
+const CHAIN = 'base';
+const URL = 'https://vault.sapien.io';
+
+const apy = async (timestamp) => {
+  const { tvl, apyBase, pricePerShare } = await getERC4626Info(
+    VAULT,
+    CHAIN,
+    timestamp
+  );
+  const { pricesByAddress } = await getPrices([`${CHAIN}:${SAPIEN}`]);
+  const price = pricesByAddress[SAPIEN.toLowerCase()];
+
+  return [
+    {
+      pool: `${VAULT}-${CHAIN}`.toLowerCase(),
+      chain: formatChain(CHAIN),
+      project: PROJECT,
+      symbol: 'SAPIEN',
+      tvlUsd: (Number(tvl) / 1e18) * price,
+      apyBase,
+      pricePerShare,
+      underlyingTokens: [SAPIEN],
+      url: URL,
+    },
+  ];
+};
+
+module.exports = {
+  protocolId: '8465',
+  // getPrices returns current prices only, so historical runs would misprice TVL.
+  timetravel: false,
+  apy,
+  url: URL,
+};


### PR DESCRIPTION
Adds a yield adapter for **Sapien Vault** (`sapien-vault`, protocolId 8465, already listed for TVL) — single-sided SAPIEN staking on Base via an ERC-4626 vault.

**Methodology**: uses `utils.getERC4626Info` — apyBase from 24h `convertToAssets` share-price growth, annualized; TVL from `totalAssets()` priced via `utils.getPrices`. Rewards stream on-chain from a keeper-driven YieldController (`0x55Ce7717Bc8c8F1b59AdB9e0CE7abc332391BF18`) and accrue into the share price with no claim step, so share-price growth is the realized net yield. No centralized APIs.

**Test output** (`npm run test --adapter=sapien-vault`, 14/14 pass):

```
{
  pool: '0x60bf63729f688287a450299962b36cef0affaa42-base',
  chain: 'Base',
  project: 'sapien-vault',
  symbol: 'SAPIEN',
  tvlUsd: 37830.07535802567,
  apyBase: 20.892405749494586,
  pricePerShare: 1.05596130780506,
  underlyingTokens: [ '0xc729777d0470f30612b1564fd96e8dd26f5814e3' ],
  url: 'https://vault.sapien.io'
}
```

Note: the rewards program started 2026-08-20 01:30 UTC, so the 24h apyBase reading settles at ~22% (the compounded form of the on-chain 20% APR drip rate) as the window fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking single-sided SAPIEN staking on Base.
  * Displays the vault’s TVL, APY, share price, underlying token, and current SAPIEN price.
  * Added a direct link to the SAPIEN Vault.
  * Historical performance data is unavailable because only current pricing is supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->