### PR TITLE
Add Rujira staking yield adapter

### DIFF
--- a/src/adaptors/rujira-staking/common/index.js
+++ b/src/adaptors/rujira-staking/common/index.js
@@ -1,0 +1,186 @@
+const BigNumber = require('bignumber.js');
+const { request } = require('graphql-request');
+
+const MAIN_API = 'https://api.rujira.network/api/graphql';
+const CHAIN = 'Thorchain';
+const USD_DECIMALS = 8;
+const GRAPHQL_DECIMAL_PLACES = 12;
+const RATE_PERCENT_DECIMALS = GRAPHQL_DECIMAL_PLACES - 2;
+const REQUEST_TIMEOUT_MS = 30_000;
+const RETRY_DELAYS_MS = [1_000, 2_000, 4_000];
+const RATE_BUCKET_RETRY_DELAY_MS = 12_000;
+const MAX_CONNECTION_PAGES = 20;
+
+const SOURCE_CHAIN_LABELS = {
+  AVAX: 'Avalanche',
+  BASE: 'Base',
+  BSC: 'BSC',
+  TRON: 'Tron',
+};
+
+const CANONICAL_CHAINS = {
+  AAVE: 'ETH',
+  ATOM: 'GAIA',
+  BNB: 'BSC',
+  CBBTC: 'BASE',
+  DAI: 'ETH',
+  FOX: 'ETH',
+  GUSD: 'ETH',
+  LINK: 'ETH',
+  LUSD: 'ETH',
+  TGT: 'ETH',
+  THOR: 'ETH',
+  USDC: 'ETH',
+  USDT: 'ETH',
+  USDP: 'ETH',
+  VTHOR: 'ETH',
+  WBTC: 'ETH',
+  YFI: 'ETH',
+};
+
+const ETHEREUM_CANONICAL_SYMBOLS = new Set(['ETH', 'USDC', 'USDT']);
+
+const fromFixed = (value, decimals) => {
+  if (value === null || value === undefined) return null;
+
+  const result = new BigNumber(String(value)).shiftedBy(-decimals);
+  if (!result.isFinite()) return null;
+
+  const number = result.toNumber();
+  return Number.isFinite(number) ? number : null;
+};
+
+const tokenValueUsd = (amount, price, decimals) => {
+  if (amount === null || amount === undefined || price == null) return null;
+
+  const result = new BigNumber(String(amount))
+    .shiftedBy(-decimals)
+    .times(String(price))
+    .shiftedBy(-GRAPHQL_DECIMAL_PLACES);
+
+  if (!result.isFinite()) return null;
+  const number = result.toNumber();
+  return Number.isFinite(number) ? number : null;
+};
+
+const toPercent = (value) => fromFixed(value, RATE_PERCENT_DECIMALS);
+
+const isTransportError = (error) =>
+  !error?.response &&
+  ['AbortError', 'TimeoutError', 'TypeError', 'FetchError'].includes(
+    error?.name
+  );
+
+const requestGraphql = async (endpoint, query, variables) => {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await request({
+        url: endpoint,
+        document: query,
+        variables,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (error) {
+      const status = error?.response?.status;
+      const messages = (error?.response?.errors || [])
+        .map((entry) => entry?.message)
+        .filter(Boolean)
+        .join(' ');
+      const rateBucketFull = messages.includes('rate bucket full');
+      const retryable =
+        rateBucketFull ||
+        status === 429 ||
+        status >= 500 ||
+        isTransportError(error);
+
+      if (!retryable || attempt === RETRY_DELAYS_MS.length) throw error;
+      await new Promise((resolve) =>
+        setTimeout(
+          resolve,
+          rateBucketFull ? RATE_BUCKET_RETRY_DELAY_MS : RETRY_DELAYS_MS[attempt]
+        )
+      );
+    }
+  }
+};
+
+const assetUrlSegment = (asset) => {
+  const symbol = asset?.metadata?.symbol;
+  const chain = asset?.chain;
+  if (!symbol || !chain) return null;
+
+  const normalizedSymbol = symbol.toUpperCase();
+  const normalizedChain = chain.toUpperCase();
+  const canonicalChain = CANONICAL_CHAINS[normalizedSymbol] || normalizedSymbol;
+  return normalizedChain === 'THOR' || normalizedChain === canonicalChain
+    ? symbol
+    : `${symbol}.${normalizedChain}`;
+};
+
+const assetVariantMeta = (asset) => {
+  const symbol = asset?.metadata?.symbol;
+  const chain = asset?.chain;
+  if (
+    !symbol ||
+    !chain ||
+    !ETHEREUM_CANONICAL_SYMBOLS.has(symbol.toUpperCase()) ||
+    chain === 'ETH'
+  ) {
+    return null;
+  }
+
+  return {
+    chain: SOURCE_CHAIN_LABELS[chain] || chain,
+    asset: assetUrlSegment(asset),
+  };
+};
+
+const encodedAssetSegment = (asset) => {
+  const segment = assetUrlSegment(asset);
+  return segment ? encodeURIComponent(segment) : null;
+};
+
+const getConnectionNodes = async (query, connectionAt) => {
+  const nodes = [];
+  let after = null;
+  const seenCursors = new Set();
+
+  for (let page = 0; page < MAX_CONNECTION_PAGES; page++) {
+    const data = await requestGraphql(MAIN_API, query, { after });
+    const connection = connectionAt(data);
+    if (!connection?.edges || !connection.pageInfo) {
+      throw new Error('Rujira GraphQL returned a malformed connection');
+    }
+
+    nodes.push(...connection.edges.map((edge) => edge?.node).filter(Boolean));
+
+    if (!connection.pageInfo.hasNextPage) break;
+    if (page === MAX_CONNECTION_PAGES - 1) {
+      throw new Error('Rujira GraphQL exceeded the maximum page count');
+    }
+
+    after = connection.pageInfo.endCursor;
+    if (!after) {
+      throw new Error('Rujira GraphQL omitted the next page cursor');
+    }
+    if (seenCursors.has(after)) {
+      throw new Error('Rujira GraphQL returned a repeated page cursor');
+    }
+    seenCursors.add(after);
+  }
+
+  return nodes;
+};
+
+module.exports = {
+  CHAIN,
+  MAIN_API,
+  USD_DECIMALS,
+  assetVariantMeta,
+  encodedAssetSegment,
+  fromFixed,
+  getConnectionNodes,
+  requestGraphql,
+  toPercent,
+  tokenValueUsd,
+};

--- a/src/adaptors/rujira-staking/index.js
+++ b/src/adaptors/rujira-staking/index.js
@@ -1,0 +1,110 @@
+const { gql } = require('graphql-request');
+const {
+  CHAIN,
+  MAIN_API,
+  USD_DECIMALS,
+  encodedAssetSegment,
+  fromFixed,
+  requestGraphql,
+  toPercent,
+} = require('./common');
+
+const PROJECT = 'rujira-staking';
+const STAKING_SYMBOLS = new Set(['RUJI', 'BRUNE', 'TCY']);
+
+const STAKING_QUERY = gql`
+  query RujiraStakingYield {
+    staking {
+      pools {
+        address
+        bondAsset {
+          metadata {
+            symbol
+          }
+          variants {
+            native {
+              denom
+            }
+          }
+        }
+        receiptAsset {
+          variants {
+            native {
+              denom
+            }
+          }
+        }
+        status {
+          valueUsd
+        }
+        summary {
+          apy {
+            status
+            value
+          }
+        }
+      }
+    }
+  }
+`;
+
+const getStakingPools = async () => {
+  const data = await requestGraphql(MAIN_API, STAKING_QUERY);
+  const pools = data?.staking?.pools;
+  if (!Array.isArray(pools)) {
+    throw new Error('Rujira GraphQL returned malformed staking data');
+  }
+
+  return pools
+    .map((pool) => {
+      const symbol = pool?.bondAsset?.metadata?.symbol;
+      const normalizedSymbol = symbol?.toUpperCase();
+      if (!STAKING_SYMBOLS.has(normalizedSymbol)) return null;
+
+      const tvlUsd = fromFixed(pool?.status?.valueUsd, USD_DECIMALS);
+      const apyBase =
+        pool?.summary?.apy?.status === 'AVAILABLE'
+          ? toPercent(pool.summary.apy.value)
+          : null;
+      const underlying = pool?.bondAsset?.variants?.native?.denom;
+      const token = pool?.receiptAsset?.variants?.native?.denom;
+      const route = encodedAssetSegment({
+        chain: 'THOR',
+        metadata: { symbol },
+      });
+
+      if (
+        !pool?.address ||
+        !symbol ||
+        !underlying ||
+        !token ||
+        !route ||
+        tvlUsd === null ||
+        tvlUsd < 0 ||
+        apyBase === null
+      ) {
+        return null;
+      }
+
+      return {
+        pool: pool.address.toLowerCase(),
+        chain: CHAIN,
+        project: PROJECT,
+        symbol,
+        tvlUsd,
+        apyBase,
+        underlyingTokens: [underlying],
+        token,
+        poolMeta: 'Staking',
+        url: `https://rujira.network/stake/${route}`,
+      };
+    })
+    .filter(Boolean);
+};
+
+module.exports = {
+  protocolId: '8394',
+  timetravel: false,
+  apy: getStakingPools,
+  url: 'https://rujira.network/stake',
+};

--- a/src/adaptors/rujira-staking/index.js
+++ b/src/adaptors/rujira-staking/index.js
@@ -19,6 +19,7 @@ const STAKING_QUERY = gql`
         address
         bondAsset {
           metadata {
+            decimals
             symbol
           }
           variants {
@@ -28,6 +29,9 @@ const STAKING_QUERY = gql`
           }
         }
         receiptAsset {
+          metadata {
+            decimals
+          }
           variants {
             native {
               denom
@@ -35,6 +39,8 @@ const STAKING_QUERY = gql`
           }
         }
         status {
+          liquidBondShares
+          liquidBondSize
           valueUsd
         }
         summary {
@@ -68,6 +74,20 @@ const getStakingPools = async () => {
           : null;
       const underlying = pool?.bondAsset?.variants?.native?.denom;
       const token = pool?.receiptAsset?.variants?.native?.denom;
+      const bondDecimals = pool?.bondAsset?.metadata?.decimals;
+      const receiptDecimals = pool?.receiptAsset?.metadata?.decimals;
+      const liquidBondSize = Number.isInteger(bondDecimals)
+        ? fromFixed(pool?.status?.liquidBondSize, bondDecimals)
+        : null;
+      const liquidBondShares = Number.isInteger(receiptDecimals)
+        ? fromFixed(pool?.status?.liquidBondShares, receiptDecimals)
+        : null;
+      const pricePerShare =
+        liquidBondSize !== null &&
+        liquidBondShares !== null &&
+        liquidBondShares > 0
+          ? liquidBondSize / liquidBondShares
+          : null;
       const route = encodedAssetSegment({
         chain: 'THOR',
         metadata: { symbol },
@@ -93,6 +113,8 @@ const getStakingPools = async () => {
         symbol,
         tvlUsd,
         apyBase,
+        ...(Number.isFinite(pricePerShare) &&
+          pricePerShare > 0 && { pricePerShare }),
         underlyingTokens: [underlying],
         token,
         poolMeta: 'Staking',

--- a/src/adaptors/rujira-staking/index.js
+++ b/src/adaptors/rujira-staking/index.js
@@ -73,7 +73,6 @@ const getStakingPools = async () => {
           ? toPercent(pool.summary.apy.value)
           : null;
       const underlying = pool?.bondAsset?.variants?.native?.denom;
-      const token = pool?.receiptAsset?.variants?.native?.denom;
       const bondDecimals = pool?.bondAsset?.metadata?.decimals;
       const receiptDecimals = pool?.receiptAsset?.metadata?.decimals;
       const liquidBondSize = Number.isInteger(bondDecimals)
@@ -97,7 +96,6 @@ const getStakingPools = async () => {
         !pool?.address ||
         !symbol ||
         !underlying ||
-        !token ||
         !route ||
         tvlUsd === null ||
         tvlUsd < 0 ||
@@ -116,7 +114,6 @@ const getStakingPools = async () => {
         ...(Number.isFinite(pricePerShare) &&
           pricePerShare > 0 && { pricePerShare }),
         underlyingTokens: [underlying],
-        token,
         poolMeta: 'Staking',
         url: `https://rujira.network/stake/${route}`,
       };


### PR DESCRIPTION
## Summary

Adds the Rujira Staking yield adapter.

This PR is split out from the original combined Rujira adapter PR:
https://github.com/DefiLlama/yield-server/pull/2930

Per review feedback, the shared helper code has been moved out of the adapter root and into:

`src/adaptors/rujira-staking/common`

This keeps the implementation self-contained under the Rujira adapter folders while allowing follow-up Rujira adapters to reuse the same GraphQL/request/formatting helpers.

## Structure

- `src/adaptors/rujira-staking/index.js`
  - Staking-specific GraphQL query and pool mapping
  - Exports protocolId `8394`
  - Project slug: `rujira-staking`

- `src/adaptors/rujira-staking/common/index.js`
  - Shared Rujira GraphQL request helpers
  - Shared decimal/percent conversion helpers
  - Shared asset URL/metadata formatting helpers

## Testing

```bash
npm run test --adapter=rujira-staking --fast -- --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Rujira staking pools.
  * Added staking data for RUJI, BRUNE, and TCY assets.
  * Displays normalized total value locked (TVL), APY, asset routes, and metadata.
* **Reliability**
  * Added pagination, timeout, and retry handling for staking data retrieval.
* **Bug Fixes**
  * Added validation for incomplete or malformed staking pool responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->