### PR TITLE
fix(peer): read yields from OrchestratorV3

### DIFF
--- a/src/adaptors/peer/index.js
+++ b/src/adaptors/peer/index.js
@@ -15,7 +15,7 @@ const WAD_DECIMALS = 18;
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const ESCROW_V2 = '0x777777779d229cdF3110e9de47943791c26300Ef';
-const ORCHESTRATOR_V2 = '0x888888359E981B5225CA48fbCdCeff702FC3b888';
+const ORCHESTRATOR_V3 = '0x014025fDE093f8701d86e9f38e2C3a9b779cb5c7';
 const BASE_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 
 const EVENTS = {
@@ -459,13 +459,13 @@ async function fetchWindowStats(
   const [signalLogs, fulfillmentLogs, transferLogs, marketRates] =
     await Promise.all([
       getEventLogsInChunks({
-        target: ORCHESTRATOR_V2,
+        target: ORCHESTRATOR_V3,
         eventAbi: EVENTS.IntentSignaled,
         fromBlock: signalFromBlock,
         toBlock: latestBlockNumber,
       }),
       getEventLogsInChunks({
-        target: ORCHESTRATOR_V2,
+        target: ORCHESTRATOR_V3,
         eventAbi: EVENTS.IntentFulfilled,
         fromBlock: windowFromBlock,
         toBlock: latestBlockNumber,


### PR DESCRIPTION
## Summary

- hard-cut Peer intent event reads from the retired Base OrchestratorV2 to the canonical OrchestratorV3 at 0x014025fDE093f8701d86e9f38e2C3a9b779cb5c7
- keep liquidity and transfer reads on the shared EscrowV2

## Why

Peer production fills moved to OrchestratorV3, but the yield adapter still read IntentSignaled and IntentFulfilled exclusively from OrchestratorV2. As V2 fills aged out of the seven-day window, platform volume defaulted to zero and the reported APRs decayed to zero despite active V3 fills.

OrchestratorV3 preserves the event signatures used by the adapter, so no compatibility path or decoding change is required.

## Validation

- node --check src/adaptors/peer/index.js
- npm run test --adapter=peer -- --runInBand --watchman=false
- 54 tests passed; adapter returned 8 pools with live V3-derived APRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated event tracking to use the latest orchestrator version, improving detection of intent-signaled and intent-fulfilled events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->