### PR TITLE
Add sapien-vault adapter

### DIFF
--- a/src/adaptors/sapien-vault/index.js
+++ b/src/adaptors/sapien-vault/index.js
@@ -1,0 +1,57 @@
+const sdk = require('@defillama/sdk');
+const { aprToApy, formatChain, getERC4626Info, getPrices } = require('../utils');
+
+const PROJECT = 'sapien-vault';
+const CHAIN = 'base';
+const VAULT = '0x60Bf63729f688287a450299962b36Cef0aFfaa42';
+const SAPIEN = '0xC729777d0470F30612B1564Fd96E8Dd26f5814E3';
+const REWARDS_CONTROLLER = '0x55Ce7717Bc8c8F1b59AdB9e0CE7abc332391BF18';
+const URL = 'https://vault.sapien.io';
+const WAD = 1e18;
+
+// Sapien PoQ Vault — single-sided SAPIEN staking on Base (ERC-4626).
+// RewardsController drips SAPIEN into the vault (no claim step) at
+// currentRateWad() = min(cap(t), yearlyBudget / TVL), a WAD APR.
+// Share-price growth is that drip net of slashed-validator redistribution,
+// so we report apyReward from the on-chain rate and leave any residual
+// (typically slashing) on apyBase.
+const apy = async (timestamp) => {
+  const [{ tvl, apyBase: shareApy, pricePerShare }, rateRes, { pricesByAddress }] =
+    await Promise.all([
+      getERC4626Info(VAULT, CHAIN, timestamp),
+      sdk.api.abi.call({
+        target: REWARDS_CONTROLLER,
+        abi: 'uint256:currentRateWad',
+        chain: CHAIN,
+      }),
+      getPrices([`${CHAIN}:${SAPIEN}`]),
+    ]);
+
+  const price = pricesByAddress[SAPIEN.toLowerCase()];
+  const apyReward = aprToApy((Number(rateRes.output) / WAD) * 100);
+  const apyBase = Math.max(0, shareApy - apyReward);
+
+  return [
+    {
+      pool: `${VAULT}-${CHAIN}`.toLowerCase(),
+      chain: formatChain(CHAIN),
+      project: PROJECT,
+      symbol: 'SAPIEN',
+      tvlUsd: (Number(tvl) / 1e18) * price,
+      apyBase,
+      apyReward,
+      pricePerShare,
+      rewardTokens: [SAPIEN],
+      underlyingTokens: [SAPIEN],
+      url: URL,
+    },
+  ];
+};
+
+module.exports = {
+  protocolId: '8465',
+  // currentRateWad and getPrices are live-only; historical runs would misprice TVL.
+  timetravel: false,
+  apy,
+  url: URL,
+};


### PR DESCRIPTION
## Summary
- Adds a yield adapter for the Sapien PoQ Vault on Base (`sapien-vault`, protocolId `8465`) — single-sided ERC-4626 SAPIEN staking at `https://vault.sapien.io`.
- Splits yield for @0xkr3p's review on #2929: `apyReward` from `RewardsController.currentRateWad()` (WAD APR → APY via `aprToApy`, `rewardTokens: [SAPIEN]`); `apyBase = max(0, 24h share-price APY − apyReward)` as the slashing residual.
- TVL from `getERC4626Info` × `getPrices`; `timetravel: false`.

This is meant to replace #2929 so that PR can be closed.

## Test plan
- [x] `npm run test --adapter=sapien-vault` — 15/15 pass

```
{
  pool: '0x60bf63729f688287a450299962b36cef0affaa42-base',
  chain: 'Base',
  project: 'sapien-vault',
  symbol: 'SAPIEN',
  tvlUsd: 78640.12193644264,
  apyBase: 0.0065970379339113094,
  apyReward: 22.133585825176727,
  pricePerShare: 1.0585145183495202,
  rewardTokens: [ '0xC729777d0470F30612B1564Fd96E8Dd26f5814E3' ],
  underlyingTokens: [ '0xC729777d0470F30612B1564Fd96E8Dd26f5814E3' ],
  url: 'https://vault.sapien.io'
}
```


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Sapien PoQ Vault on Base.
  * Displays vault TVL, share price, SAPIEN token pricing, reward APY, base APY, and vault URL.
  * Supports single-sided SAPIEN staking information.
  * Historical performance data is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->