### PR TITLE
Add FWB (Finance Without Borders) yield adapter

### DIFF
--- a/src/adaptors/fwb/index.js
+++ b/src/adaptors/fwb/index.js
@@ -1,19 +1,18 @@
-// Адаптер доходности FWB для DeFiLlama (репозиторий DefiLlama/yield-server).
-// Путь в репозитории: src/adaptors/fwb/index.js
+// FWB yield adapter for DefiLlama (DefiLlama/yield-server).
 //
-// Протокол: фиксированная ставка на фиксированный срок (30, 90, 180, 360 дней).
-// Расписок ERC-20 за депозит нет — позиция живёт во внутреннем учёте контракта,
-// поэтому идентификатор пула строим из адреса хранилища и адреса актива.
+// Protocol: fixed rate for a fixed term (30, 90, 180 or 360 days).
+// There is no ERC-20 receipt token — a deposit lives in the vault's internal
+// accounting, so the pool id is built from the vault address and the asset address.
 //
-// Что откуда берём (всё — вызовы чтения в контракте, без внешних API):
-//   getSupportedTokens()                      список принимаемых активов
-//   activePrincipalByToken(token)             тело активных депозитов
-//   getTokenUsdValue18(token, amount)         оценка в долларах, 18 знаков
-//   currentAprBps(token, term)                ставка в базисных пунктах
+// Where the data comes from (all on-chain reads, no external APIs):
+//   getSupportedTokens()                accepted assets
+//   activePrincipalByToken(token)       principal of active deposits
+//   getTokenUsdValue18(token, amount)   USD value, 18 decimals
+//   currentAprBps(token, term)          rate in basis points
 //
-// APY подаём для срока 360 дней и указываем это в poolMeta: единой ставки
-// у пула нет, срок выбирает вкладчик. Тот же подход у рынков с фиксированной
-// доходностью до погашения.
+// APY is reported for the 360-day term and poolMeta says so: there is no single
+// rate for a pool, the term is chosen by the depositor. Same approach as other
+// fixed-maturity markets.
 
 const sdk = require('@defillama/sdk');
 const utils = require('../utils');
@@ -21,7 +20,7 @@ const utils = require('../utils');
 const PROJECT = 'fwb';
 const SITE = 'https://finwb.xyz';
 
-// Срок, ставку за который показываем.
+// The term whose rate we report.
 const TERM_DAYS = 360;
 
 const VAULTS = {
@@ -40,10 +39,10 @@ const abi = {
 };
 
 const WAD = 1e18;
-const BPS = 100; // базисные пункты -> проценты
+const BPS = 100; // basis points -> percent
 
-// В символе USD₮0 стоит знак ₮ (U+20AE), а не латинская T: фильтр символов
-// его вырезает и получается USD0. Приводим к обычному написанию.
+// The on-chain symbol USD₮0 uses ₮ (U+20AE), not a latin T. Normalise it so the
+// symbol stays readable and searchable.
 function normaliseSymbol(symbol) {
   return String(symbol).replace(/₮/g, 'T');
 }
@@ -80,7 +79,7 @@ async function poolsForChain(chain) {
     }),
   ]);
 
-  // Оценку в долларах контракт считает сам — своим оракулом цен.
+  // The vault values assets in USD itself, through its own price oracle.
   const values = await sdk.api.abi.multiCall({
     chain,
     abi: abi.getTokenUsdValue18,
@@ -98,14 +97,16 @@ async function poolsForChain(chain) {
       pool: `${target}-${token}-${chain}`.toLowerCase(),
       chain: utils.formatChain(chain),
       project: PROJECT,
-      symbol: utils.formatSymbol(normaliseSymbol(symbols.output[i].output)),
+      symbol: normaliseSymbol(symbols.output[i].output),
       tvlUsd,
       apyBase,
       underlyingTokens: [token],
-      // Единой ставки у пула нет — она зависит от выбранного вкладчиком срока.
-      // Показываем ставку за 360 дней и говорим об этом прямо.
-      poolMeta: `Fixed term 30/90/180/${TERM_DAYS}d, APY shown for ${TERM_DAYS}d`,
-      url: SITE,
+      // No receipt token: the position is tracked in the vault's internal accounting.
+      token: null,
+      poolMeta: `Fixed term ${TERM_DAYS}d`,
+      // The deposit page. Chain, asset and term are picked in the UI after the
+      // wallet is connected, so there is no per-pool URL to link to.
+      url: `${SITE}/cabinet`,
     };
   }).filter((pool) => Number.isFinite(pool.tvlUsd) && Number.isFinite(pool.apyBase));
 }
@@ -120,7 +121,7 @@ module.exports = {
   timetravel: false,
   apy,
   url: SITE,
-  // Номер протокола обязан стоять здесь цифрой: проверка yield-server читает
-  // файл как текст и константу подставить не может.
+  // The protocol id must be an inline literal: the yield-server test reads this
+  // file as text and cannot resolve a constant.
   protocolId: '8069',
 };

--- a/src/adaptors/fwb/index.js
+++ b/src/adaptors/fwb/index.js
@@ -18,7 +18,6 @@
 const sdk = require('@defillama/sdk');
 const utils = require('../utils');
 
-const PROTOCOL_ID = '8069';
 const PROJECT = 'fwb';
 const SITE = 'https://finwb.xyz';
 
@@ -121,5 +120,7 @@ module.exports = {
   timetravel: false,
   apy,
   url: SITE,
-  protocolId: PROTOCOL_ID,
+  // Номер протокола обязан стоять здесь цифрой: проверка yield-server читает
+  // файл как текст и константу подставить не может.
+  protocolId: '8069',
 };

--- a/src/adaptors/fwb/index.js
+++ b/src/adaptors/fwb/index.js
@@ -1,0 +1,125 @@
+// Адаптер доходности FWB для DeFiLlama (репозиторий DefiLlama/yield-server).
+// Путь в репозитории: src/adaptors/fwb/index.js
+//
+// Протокол: фиксированная ставка на фиксированный срок (30, 90, 180, 360 дней).
+// Расписок ERC-20 за депозит нет — позиция живёт во внутреннем учёте контракта,
+// поэтому идентификатор пула строим из адреса хранилища и адреса актива.
+//
+// Что откуда берём (всё — вызовы чтения в контракте, без внешних API):
+//   getSupportedTokens()                      список принимаемых активов
+//   activePrincipalByToken(token)             тело активных депозитов
+//   getTokenUsdValue18(token, amount)         оценка в долларах, 18 знаков
+//   currentAprBps(token, term)                ставка в базисных пунктах
+//
+// APY подаём для срока 360 дней и указываем это в poolMeta: единой ставки
+// у пула нет, срок выбирает вкладчик. Тот же подход у рынков с фиксированной
+// доходностью до погашения.
+
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+const PROTOCOL_ID = '8069';
+const PROJECT = 'fwb';
+const SITE = 'https://finwb.xyz';
+
+// Срок, ставку за который показываем.
+const TERM_DAYS = 360;
+
+const VAULTS = {
+  ethereum: '0x1Ef96B8fad9aE983E60610C4ba13536606B5c477',
+  bsc: '0x18A021d1c89Af87AaeD266B2C58dD16855Ad3702',
+  polygon: '0xd17127796D46c1588550Df783FCfE3D08ef8F6c0',
+  arbitrum: '0xF5d84413f2cd33d6d473BA9D0c665a73472d8fC7',
+  base: '0x199180dfbACEE5c204Db4E803A92a9D3A9Db4d1F',
+};
+
+const abi = {
+  getSupportedTokens: 'function getSupportedTokens() view returns (address[])',
+  activePrincipalByToken: 'function activePrincipalByToken(address) view returns (uint256)',
+  getTokenUsdValue18: 'function getTokenUsdValue18(address token, uint256 amount) view returns (uint256)',
+  currentAprBps: 'function currentAprBps(address, uint32) view returns (uint16)',
+};
+
+const WAD = 1e18;
+const BPS = 100; // базисные пункты -> проценты
+
+// В символе USD₮0 стоит знак ₮ (U+20AE), а не латинская T: фильтр символов
+// его вырезает и получается USD0. Приводим к обычному написанию.
+function normaliseSymbol(symbol) {
+  return String(symbol).replace(/₮/g, 'T');
+}
+
+async function poolsForChain(chain) {
+  const target = VAULTS[chain];
+
+  const tokens = (
+    await sdk.api.abi.call({ target, chain, abi: abi.getSupportedTokens })
+  ).output;
+
+  if (!tokens || tokens.length === 0) return [];
+
+  const [principals, symbols, decimals, aprs] = await Promise.all([
+    sdk.api.abi.multiCall({
+      chain,
+      abi: abi.activePrincipalByToken,
+      calls: tokens.map((token) => ({ target, params: [token] })),
+    }),
+    sdk.api.abi.multiCall({
+      chain,
+      abi: 'erc20:symbol',
+      calls: tokens.map((token) => ({ target: token })),
+    }),
+    sdk.api.abi.multiCall({
+      chain,
+      abi: 'erc20:decimals',
+      calls: tokens.map((token) => ({ target: token })),
+    }),
+    sdk.api.abi.multiCall({
+      chain,
+      abi: abi.currentAprBps,
+      calls: tokens.map((token) => ({ target, params: [token, TERM_DAYS] })),
+    }),
+  ]);
+
+  // Оценку в долларах контракт считает сам — своим оракулом цен.
+  const values = await sdk.api.abi.multiCall({
+    chain,
+    abi: abi.getTokenUsdValue18,
+    calls: tokens.map((token, i) => ({
+      target,
+      params: [token, principals.output[i].output],
+    })),
+  });
+
+  return tokens.map((token, i) => {
+    const tvlUsd = Number(values.output[i].output) / WAD;
+    const apyBase = Number(aprs.output[i].output) / BPS;
+
+    return {
+      pool: `${target}-${token}-${chain}`.toLowerCase(),
+      chain: utils.formatChain(chain),
+      project: PROJECT,
+      symbol: utils.formatSymbol(normaliseSymbol(symbols.output[i].output)),
+      tvlUsd,
+      apyBase,
+      underlyingTokens: [token],
+      // Единой ставки у пула нет — она зависит от выбранного вкладчиком срока.
+      // Показываем ставку за 360 дней и говорим об этом прямо.
+      poolMeta: `Fixed term 30/90/180/${TERM_DAYS}d, APY shown for ${TERM_DAYS}d`,
+      url: SITE,
+    };
+  }).filter((pool) => Number.isFinite(pool.tvlUsd) && Number.isFinite(pool.apyBase));
+}
+
+const apy = async () => {
+  const chains = Object.keys(VAULTS);
+  const results = await Promise.all(chains.map((chain) => poolsForChain(chain)));
+  return results.flat();
+};
+
+module.exports = {
+  timetravel: false,
+  apy,
+  url: SITE,
+  protocolId: PROTOCOL_ID,
+};


### PR DESCRIPTION
Adds a yield adapter for FWB (Finance Without Borders), protocolId 8069,
already listed on the TVL side as `fwb`.

1. What it is. A fixed-rate, fixed-term vault: users deposit USDT, WETH or a
   wrapped BTC asset for 30, 90, 180 or 360 days. The rate is locked at deposit
   time and does not float afterwards.

2. Pool identity. The protocol issues no ERC-20 receipt token — a position
   exists only as an entry in the vault's internal accounting. There is
   therefore no receipt address to build the pool id from, so we use
   `${vaultAddress}-${assetAddress}-${chain}`.

3. APY. A pool has no single rate: the rate depends on the term chosen by the
   depositor (currently 6/8/10/12% for USDT across 30/90/180/360 days). We
   report the 360-day rate and state this explicitly in `poolMeta`. This mirrors
   how fixed-maturity yield is displayed elsewhere on DefiLlama, where the rate
   held to maturity is shown even though exiting early through the market can
   return less.

4. Data sources. On-chain reads only, no APIs:
   - `getSupportedTokens()` — accepted assets
   - `activePrincipalByToken(token)` — active principal
   - `getTokenUsdValue18(token, amount)` — USD value, 18 decimals
   - `currentAprBps(token, term)` — rate in basis points

5. Deployments (same contract, five chains):
   - Ethereum  0x1Ef96B8fad9aE983E60610C4ba13536606B5c477
   - BNB Chain 0x18A021d1c89Af87AaeD266B2C58dD16855Ad3702
   - Polygon   0xd17127796D46c1588550Df783FCfE3D08ef8F6c0
   - Arbitrum  0xF5d84413f2cd33d6d473BA9D0c665a73472d8fC7
   - Base      0x199180dfbACEE5c204Db4E803A92a9D3A9Db4d1F

6. Output. 15 pools, aggregate TVL ~$52k, which matches the TVL currently
   reported for the protocol.

Site: https://finwb.xyz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking FWB fixed-term DeFi yield pools.
  * Added pool data across Ethereum, BSC, Polygon, Arbitrum, and Base.
  * Included normalized token details, TVL, APY, underlying assets, metadata, and protocol links.
  * Added clearer pool labeling for 360-day fixed-term products and improved links to pool details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->