### PR TITLE
fix(liminal-basis): decode indexed NAV events

### DIFF
--- a/src/adaptors/liminal-basis/apy.js
+++ b/src/adaptors/liminal-basis/apy.js
@@ -78,6 +78,7 @@ async function getNavUpdates(navOracleAddress, chain) {
     toBlock,
     eventAbi: abi.navUpdated,
     entireLog: true,
+    parseLog: true,
   });
 
   return parseNavUpdates(logs);


### PR DESCRIPTION
## Summary

  - explicitly decode NAVUpdated event logs returned through the DefiLlama SDK
  indexer
  - restore 7-day APY calculation for Liminal Basis pools

  ## Validation

  - `npm run test --adapter=liminal-basis -- --runInBand`
  - verified the adapter APYs match the backend values for xHYPE, xBTC, xLEND, and
  limUSD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation update processing by using structured event log data, resulting in more reliable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->