### PR TITLE
drop pools holding implausibly more tvl than their own protocol

### DIFF
--- a/src/handlers/triggerAdaptor.js
+++ b/src/handlers/triggerAdaptor.js
@@ -134,6 +134,21 @@ const main = async (body) => {
       p.tvlUsd <= exclude.boundaries.tvlUsdDB.ub
   );
 
+  // Filter pools holding implausibly more tvl than the protocol they belong to.
+  const protocolTvl = await exclude.getProtocolTvl(body.adaptor);
+  const { multiplier, minProtocolTvl } = exclude.boundaries.tvlUsdVsProtocol;
+  if (Number.isFinite(protocolTvl) && protocolTvl >= minProtocolTvl) {
+    const ceiling = protocolTvl * multiplier;
+    const implausible = data.filter((p) => p.tvlUsd > ceiling);
+    if (implausible.length) {
+      console.log(
+        `${body.adaptor}: dropping ${implausible.length} pool(s) over ${multiplier}x the protocol tvl of ${protocolTvl}: ` +
+          implausible.map((p) => `${p.symbol} ${p.tvlUsd}`).join(', ')
+      );
+      data = data.filter((p) => p.tvlUsd <= ceiling);
+    }
+  }
+
   // nullify NaN, undefined or Infinity apy values
   data = data.map((p) => ({
     ...p,

--- a/src/utils/exclude.js
+++ b/src/utils/exclude.js
@@ -2495,22 +2495,37 @@ const boundaries = {
   apy: { lb: 0, ub: 1e6 },
   // reading from database returns only pools which is max 7 days old
   age: 7,
+  // a pool cannot hold this many times its own protocol's tvl, only checked when
+  // that protocol is on api.llama.fi with a tvl of at least minProtocolTvl
+  tvlUsdVsProtocol: { multiplier: 50, minProtocolTvl: 1e6 },
+};
+
+let protocolsPromise = null;
+
+const fetchProtocols = async () => {
+  if (!protocolsPromise) {
+    protocolsPromise = (async () => {
+      const response = await fetch('https://api.llama.fi/protocols', {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      return Array.isArray(data) ? data : [];
+    })().catch((err) => {
+      protocolsPromise = null;
+      throw err;
+    });
+  }
+  return protocolsPromise;
 };
 
 const getProtocolExclusionsFromApi = async () => {
   try {
-    const response = await fetch('https://api.llama.fi/protocols', {
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-
-    const data = await response.json();
+    const data = await fetchProtocols();
     return new Set(
-      (Array.isArray(data) ? data : [])
-        .filter((p) => p.rugged || p.deprecated || p.deadFrom)
-        .map((p) => p.slug)
+      data.filter((p) => p.rugged || p.deprecated || p.deadFrom).map((p) => p.slug)
     );
   } catch (err) {
     console.log(
@@ -2518,6 +2533,20 @@ const getProtocolExclusionsFromApi = async () => {
       err?.message || err
     );
     return new Set();
+  }
+};
+
+const getProtocolTvl = async (slug) => {
+  try {
+    const data = await fetchProtocols();
+    const match = data.find((p) => p.slug === slug);
+    return Number.isFinite(match?.tvl) ? match.tvl : null;
+  } catch (err) {
+    console.log(
+      'Failed to fetch protocol tvl; skipping the pool tvl plausibility check',
+      err?.message || err
+    );
+    return null;
   }
 };
 
@@ -2532,4 +2561,5 @@ module.exports = {
   excludePools,
   boundaries,
   getExcludedAdaptors,
+  getProtocolTvl,
 };


### PR DESCRIPTION
Fixes #2950

`/pools` is currently serving `aerodrome-slipstream` `WETH-SAND` on Base at
`tvlUsd: 31,431,600,393`, which is 242x the entire protocol's tvl and 17.11% of the
$183,753,699,148 total across all 17,274 pools. the pool
(`0xa69cdf524d072c366fd050957880552916d29405`) holds 2.147927 WETH and 26.2t of a token
coins.llama.fi has no price for at all, so the real number is about $5,352 of weth plus whatever
the SAND side is worth. it read $121,012 on 08-21, $31.4b on 08-22, and has not updated since
while its sibling pools have.

`boundaries.tvlUsdUI` already has a `ub` of 2e10 for exactly this, and the comment above it says
"max ($20 billion)", but the value is never read anywhere in the repo, every reference to
`tvlUsdUI` is `.lb`. it also cannot be turned on as written: lido steth is $24,286,038,515
today against a lido protocol tvl of $24,208,098,312, so a $20b absolute cap deletes the
largest legitimate pool in the dataset.

what separates the two is the ratio to the pool's own protocol, not the absolute size:

```
lido stETH            pool $24.29b / protocol $24.21b  =   1.003
aerodrome WETH-SAND   pool $31.43b / protocol $0.13b   = 242.03
```

so this adds `boundaries.tvlUsdVsProtocol` and filters on it at insert time in
`triggerAdaptor.js`, next to the existing `tvlUsdDB` bounds.

the denominator comes from `api.llama.fi/protocols`, which `getProtocolExclusionsFromApi`
already fetches. i pulled that fetch into a shared `fetchProtocols` so the new lookup does not
add a request; that is the one behaviour change here beyond the filter, and it also means the
two callers no longer fetch the same payload twice. a rejected fetch clears the cached promise
so the next call retries.

the check is deliberately conservative:

- skipped entirely when the protocol is not on api.llama.fi, or its tvl is under `minProtocolTvl`
  ($1m), so a protocol we do not track and one whose tvl adapter is down never lose pools
- a failed fetch returns null and drops nothing
- `multiplier` is 50, which is far looser than needed

run against every pool `/pools` currently returns:

```
projects checked: 367   skipped (unknown/small protocol tvl): 135
pools dropped: 1

  DROP  aerodrome-slipstream | Base | WETH-SAND
        pool tvlUsd $31,431,600,393  vs protocol $129,865,242  = 242.0x

control lido stETH: pool $24,286,038,515 vs protocol $24,208,098,312 = 1.003x -> kept
```

for context on where the threshold could go, the distribution over the 16,733 pools whose
project matches a protocol slug (0 unmatched) is `>1.5: 29, >2: 23, >3: 15, >5: 9, >10: 5,
>50: 1`. 50 is the setting that changes exactly one pool today; anything tighter is a
one-line change to the boundary if you want it.

also verified: 502 `getProtocolTvl` calls issue 1 http request, an unknown slug returns null,
and a simulated fetch failure logs and drops nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool data quality by filtering out pools with implausibly high TVL compared with their protocol’s total TVL.
  * Added safeguards to apply this validation only when reliable protocol TVL data is available.
  * Improved efficiency and reliability when retrieving protocol TVL information by reusing cached data and handling invalid responses safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->