### PR TITLE
Add Phase Delegation (pdSOL) and Phase Stake (YIELD) yield adapters

### DIFF
--- a/src/adaptors/phase-delegation/index.js
+++ b/src/adaptors/phase-delegation/index.js
@@ -1,0 +1,52 @@
+const axios = require('axios');
+const {
+  getStakePoolInfo,
+  calcSolanaLstApy,
+  solanaLstPricePerShare,
+  getPriceApiUrl,
+} = require('../utils');
+
+const PDSOL_MINT = 'aeroXvCT6tjGVNyTvZy86tFDwE4sYsKCh7FbNDcrcxF';
+const STAKE_POOL = 'aero2ePURjuEgLKTzcUmF6RypBncBGd7pMUYCoSsVJ6';
+const SOL = 'So11111111111111111111111111111111111111112';
+
+const solKey = `solana:${SOL}`;
+
+const apy = async () => {
+  const [stakePool, priceRes] = await Promise.all([
+    getStakePoolInfo(STAKE_POOL),
+    axios.get(getPriceApiUrl(`/prices/current/${solKey}`)),
+  ]);
+
+  const solPrice = priceRes.data.coins[solKey]?.price;
+  if (!solPrice) throw new Error('Unable to fetch SOL price');
+
+  const apyBase = calcSolanaLstApy(stakePool);
+  const pricePerShare = solanaLstPricePerShare(stakePool);
+
+  const feePct = stakePool.epochFee
+    ? `${((stakePool.epochFee.numerator / stakePool.epochFee.denominator) * 100).toFixed(0)}% epoch fee`
+    : null;
+
+  return [
+    {
+      pool: PDSOL_MINT,
+      chain: 'Solana',
+      project: 'phase-delegation',
+      symbol: 'pdSOL',
+      tvlUsd: stakePool.tvlSol * solPrice,
+      apyBase,
+      ...(pricePerShare > 0 && { pricePerShare }),
+      underlyingTokens: [SOL],
+      poolMeta: feePct,
+      isIntrinsicSource: true,
+    },
+  ];
+};
+
+module.exports = {
+  protocolId: '8520',
+  timetravel: false,
+  apy,
+  url: 'https://phase.cc/delegation',
+};

--- a/src/adaptors/phase-delegation/index.js
+++ b/src/adaptors/phase-delegation/index.js
@@ -18,8 +18,9 @@ const apy = async () => {
     axios.get(getPriceApiUrl(`/prices/current/${solKey}`)),
   ]);
 
-  const solPrice = priceRes.data.coins[solKey]?.price;
-  if (!solPrice) throw new Error('Unable to fetch SOL price');
+  const solPrice = priceRes?.data?.coins?.[solKey]?.price;
+  if (!Number.isFinite(solPrice) || solPrice <= 0)
+    throw new Error('Unable to fetch SOL price');
 
   const apyBase = calcSolanaLstApy(stakePool);
   const pricePerShare = solanaLstPricePerShare(stakePool);

--- a/src/adaptors/phase-stake/index.js
+++ b/src/adaptors/phase-stake/index.js
@@ -18,8 +18,9 @@ const apy = async () => {
     axios.get(getPriceApiUrl(`/prices/current/${solKey}`)),
   ]);
 
-  const solPrice = priceRes.data.coins[solKey]?.price;
-  if (!solPrice) throw new Error('Unable to fetch SOL price');
+  const solPrice = priceRes?.data?.coins?.[solKey]?.price;
+  if (!Number.isFinite(solPrice) || solPrice <= 0)
+    throw new Error('Unable to fetch SOL price');
 
   const apyBase = calcSolanaLstApy(stakePool);
   const pricePerShare = solanaLstPricePerShare(stakePool);

--- a/src/adaptors/phase-stake/index.js
+++ b/src/adaptors/phase-stake/index.js
@@ -1,0 +1,52 @@
+const axios = require('axios');
+const {
+  getStakePoolInfo,
+  calcSolanaLstApy,
+  solanaLstPricePerShare,
+  getPriceApiUrl,
+} = require('../utils');
+
+const YIELD_MINT = 'phaseZSfPxTDBpiVb96H4XFSD8xHeHxZre5HerehBJG';
+const STAKE_POOL = 'phasejkG1akKgqkLvfWzWY17evnH6mSWznnUspmpyeG';
+const SOL = 'So11111111111111111111111111111111111111112';
+
+const solKey = `solana:${SOL}`;
+
+const apy = async () => {
+  const [stakePool, priceRes] = await Promise.all([
+    getStakePoolInfo(STAKE_POOL),
+    axios.get(getPriceApiUrl(`/prices/current/${solKey}`)),
+  ]);
+
+  const solPrice = priceRes.data.coins[solKey]?.price;
+  if (!solPrice) throw new Error('Unable to fetch SOL price');
+
+  const apyBase = calcSolanaLstApy(stakePool);
+  const pricePerShare = solanaLstPricePerShare(stakePool);
+
+  const feePct = stakePool.epochFee
+    ? `${((stakePool.epochFee.numerator / stakePool.epochFee.denominator) * 100).toFixed(0)}% epoch fee`
+    : null;
+
+  return [
+    {
+      pool: YIELD_MINT,
+      chain: 'Solana',
+      project: 'phase-stake',
+      symbol: 'YIELD',
+      tvlUsd: stakePool.tvlSol * solPrice,
+      apyBase,
+      ...(pricePerShare > 0 && { pricePerShare }),
+      underlyingTokens: [SOL],
+      poolMeta: feePct,
+      isIntrinsicSource: true,
+    },
+  ];
+};
+
+module.exports = {
+  protocolId: '8527',
+  timetravel: false,
+  apy,
+  url: 'https://phase.cc/stake',
+};


### PR DESCRIPTION
Adds yield adapters for Phase's two Solana liquid staking tokens. Both protocols were listed on the TVL side earlier today (#20720 and #20739) and are live under `parent#phase`.

| | project | protocolId | mint | stake pool |
|---|---|---|---|---|
| pdSOL | `phase-delegation` | 8520 | `aeroXvCT6tjGVNyTvZy86tFDwE4sYsKCh7FbNDcrcxF` | `aero2ePURjuEgLKTzcUmF6RypBncBGd7pMUYCoSsVJ6` |
| YIELD | `phase-stake` | 8527 | `phaseZSfPxTDBpiVb96H4XFSD8xHeHxZre5HerehBJG` | `phasejkG1akKgqkLvfWzWY17evnH6mSWznnUspmpyeG` |

**Methodology**

Both follow the existing `jagpool-staked-sol` adapter: `getStakePoolInfo` reads the stake pool account, `calcSolanaLstApy` derives single-epoch APY from the account's own `lastEpochTotalLamports` / `lastEpochPoolTokenSupply` snapshots, and `solanaLstPricePerShare` supplies the exchange rate. TVL is `tvlSol * SOL price`.

Deliberately not using `getSanctumLstApy`, so neither adapter depends on a third-party API or key. Everything is read from chain.

**Verification**

Decoded all three pools with `StakePoolLayout` from `@solana/spl-stake-pool` at epoch 1024:

```
jagpool (control)  prevRate 1.11053617 -> 1.11079950   apy 3.83%
pdSOL              prevRate 1.14902804 -> 1.14929753   apy 3.79%
YIELD              prevRate 1.18482057 -> 1.18518416   apy 4.99%
```

The control reproduces jagSOL's currently published 3.83% exactly, which is what gave me confidence the same path is correct for these two.

Note that YIELD's pool runs on the Sanctum multi-validator stake pool program (`SPMBzsVUuoHA4Jm6KunbsotaahvVikZs1JyTW6iJvbn`, the same program jupSOL uses) rather than the standard SPL program. `StakePoolLayout` decodes it identically, 611-byte account, and the snapshot fields are populated.

TVL at time of writing: pdSOL ~$114.5M, YIELD ~$1.9M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added yield tracking for Phase’s Solana stake and delegation products.
  * Displays APY, total value locked, token pricing, and applicable epoch fees.
  * Includes links to the Phase staking and delegation pages.
  * Added validation to ensure reliable SOL pricing data before displaying metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->