### PR TITLE
exclude goldfinch, protocol is winding down

### DIFF
--- a/src/utils/exclude.js
+++ b/src/utils/exclude.js
@@ -515,6 +515,7 @@ const excludedProtocols = [
   { id: '5214', slug: 'metrom' },
   { id: '435', slug: 'hop-protocol' },
   { id: '2228', slug: 'aries-markets' },
+  { id: '703', slug: 'goldfinch' }, // winding down, senior pool tvl is book value of defaulted loans
 ];
 
 const excludeAdaptors = excludedProtocols.map((protocol) => protocol.slug);


### PR DESCRIPTION
Fixes #2957

the senior pool publishes $35,957,023 at 10.15% apy. the pool contract holds $1,529,232 of usdc, and our own tvl adapter has returned `{}` for goldfinch's `borrowed` since 2026-06-25 with the comment `protocol is insolvant/ winding down`. the yields adapter reads `seniorPools[0].assets` from the subgraph, which is book value: $52.7m of loans outstanding, marked down only 5.6% by sharePrice, against $1.53m of cash. `estimatedApy` is the nominal rate on loans nobody is repaying, so it has printed the same 10.15347 for four days.

same treatment as `comb-financial`. adapter left in place, matching friktion/hedge/optifi.

not reachable by the new tvlDominance gate: it is dexs-only and goldfinch has a single pool, so the cliff scan never runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded the winding-down Goldfinch protocol from activation and enriched dataset results.
  * Prevented defaulted-loan book value from affecting protocol data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->