### PR TITLE
feat(midas-rwa): mark mTokens as intrinsic APY sources

### DIFF
--- a/src/adaptors/midas-rwa/index.js
+++ b/src/adaptors/midas-rwa/index.js
@@ -5,6 +5,39 @@ const { fetchTokenData } = require('./fetchTokenData');
 const { formatUnits } = require('ethers/lib/utils');
 const utils = require('../utils');
 
+// Midas mTokens are yield-bearing RWA primitives: NAV accrues into the token,
+// and they are widely posted as collateral elsewhere (Morpho Blue and Aave
+// Horizon markets), where the venue pays nothing on collateral itself. Marking
+// them as intrinsic sources lets those downstream pools surface the yield the
+// depositor is still earning, as maple/usd-ai/spark-savings already do for
+// their own yield-bearing primitives.
+//
+// Per the adapter guidelines, when the same product is deployed on several
+// chains with the same intrinsic APY the flag belongs on the canonical
+// deployment only. Ethereum is canonical where a pool actually resolved there;
+// otherwise the largest pool for that product wins. Choosing among *emitted*
+// pools rather than from the static config matters: a configured deployment
+// can drop out on any given run (missing price data, a failed multicall), and
+// pinning the flag to config alone would leave that product with no intrinsic
+// source at all.
+const markIntrinsicSources = (pools) => {
+  const canonical = new Map();
+  for (const pool of pools) {
+    const product = pool.poolMeta;
+    const incumbent = canonical.get(product);
+    if (!incumbent) {
+      canonical.set(product, pool);
+      continue;
+    }
+    const isEth = (p) => p.chain === 'Ethereum';
+    if (isEth(pool) && !isEth(incumbent)) canonical.set(product, pool);
+    else if (isEth(pool) === isEth(incumbent) && pool.tvlUsd > incumbent.tvlUsd)
+      canonical.set(product, pool);
+  }
+  for (const pool of canonical.values()) pool.isIntrinsicSource = true;
+  return pools;
+};
+
 const poolsFunction = async () => {
   try {
     const baseAssetPrices = await fetchBaseAssetPrices();
@@ -42,7 +75,7 @@ const poolsFunction = async () => {
       }
     }
 
-    return results;
+    return markIntrinsicSources(results);
   } catch (error) {
     console.error('MidasRWA: Error in poolsFunction:', error);
     throw error;


### PR DESCRIPTION
Midas mTokens are yield-bearing RWA primitives — NAV accrues into the token — and they're widely posted as collateral on **Morpho Blue** and **Aave Horizon**. Those venues pay nothing on collateral itself and hardcode `apyBase: 0` for the market, so the yield a depositor is still earning on the posted mToken doesn't surface anywhere downstream.

This marks the mToken pools as intrinsic sources, the same way `maple`, `usd-ai` and `spark-savings` already do for their own yield-bearing primitives. Maple is the closest analogue — syrupUSDC is a yield-bearing credit token flagged as an intrinsic source, and it currently sits at ~$97M of Morpho collateral.

Live examples of the gap this closes:

| collateral | venue | TVL | market `apyBase` |
|---|---|---|---|
| MF-ONE | Morpho Blue | $31.6M | 0 |
| MGLO | Morpho Blue (Base + Robinhood Chain) | $50.9M | 0 |
| MGLOBAL | Aave Horizon | $30.5M | 0 |

### Canonical deployment selection

Per the guideline in the README — *"If an adapter lists multiple bridged versions with the same intrinsic APY, set this only on the canonical deployment"* — the flag lands once per product. Ethereum wins where a pool actually resolved there; otherwise the largest pool for that product.

The selection deliberately runs over **emitted pools rather than the static config**. A configured deployment can drop out on any given run (missing price data, a failed multicall), and pinning the flag to config alone would leave that product with no intrinsic source at all. That isn't hypothetical: `mRE7` is configured on `base`, but currently only emits pools on Etherlink and TAC — my first cut of this patch keyed off config and silently left mRE7 unflagged.

### Verification

```
45 pools; 24 marked isIntrinsicSource
distinct products: 24   flagged: 24
products flagged more than once: none
products present but NOT flagged: none
```

Non-Ethereum canonicals resolve as expected for the products with no Ethereum deployment (mRE7, mRE7SOL, mXRP, mRe7ETH).

No change to TVL, APY, or any existing field — this only adds the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Yield-bearing Midas mToken pools are now identified as intrinsic yield sources.
  * The system selects a canonical pool for each product, prioritizing Ethereum deployments or the pool with the highest TVL when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->