### PR TITLE
fix(satsuma): replace deleted subgraph with on-chain data source

### DIFF
--- a/src/adaptors/satsuma/index.js
+++ b/src/adaptors/satsuma/index.js
@@ -8,6 +8,11 @@ const CHAIN = 'citrea';
 // Satsuma's analytics subgraph was deleted upstream, which silently dropped
 // every Satsuma pool from this adapter. Both sources below are on-chain or
 // derived from on-chain logs, so there is no indexer to go stale again.
+//
+// /pool-stats returns, per Algebra pool: tvlUSD, volumeUSD24h, feesUSD24h,
+// token0/token1 + decimals, and a `prices` map (USD per token) that is the
+// same one used to compute tvlUSD, so vault holdings valued with it are
+// consistent with the pool TVL.
 const POOL_STATS = 'https://s33-epoch-cron.tiagopratas69.workers.dev/pool-stats';
 const RPC = 'https://rpc.mainnet.citrea.xyz';
 // Axios defaults to no timeout; bound every upstream call so apy() rejects
@@ -15,27 +20,29 @@ const RPC = 'https://rpc.mainnet.citrea.xyz';
 const TIMEOUT_MS = 30_000;
 
 // s33 gauge system. The Voter streams weekly xSATS (symbol veSUMA, 1:1 with
-// SUMA) emissions to one IchiVaultGauge per Algebra pool; depositors of that
-// pool's ICHI vaults earn them. Booked under the period that just ended.
+// SUMA) emissions to one IchiVaultGauge per Algebra pool. Only depositors of
+// that gauge's two ICHI vaults earn them, so emissions are published on
+// separate vault records rather than on the AMM pool.
 const VOTER = '0x451d2305a819b6bdb43a104b2d9cf46603135332';
 const XSATS = '0x732bcf02bccb77dbe64cb64935c897eddf6805ac';
 const SUMA = '0x60bf948001e7b7ea03ddaaddae048af7402e7b74';
-const CTUSD = '0x8d82c4e3c936c7b5724a382a9c5a4e6eb7ab6d5d';
-// SUMA/ctUSD Algebra pool, used to price SUMA (not on the coins API).
-const SUMA_CTUSD_POOL = '0x298a4e0ec1af98066b79836ea99dcc2dd5437f67';
+const ZERO = '0x0000000000000000000000000000000000000000';
 
 const SELECTORS = {
   token0: '0x0dfe1681',
   token1: '0xd21220a7',
   symbol: '0x95d89b41',
-  globalState: '0xe76c01e4',
   // Voter
   getAllGauges: '0xc946c5cc',
   ammPoolForGauge: '0xb8eba276',
   isAlive: '0x1703e5f9',
   getPeriod: '0x1ed24195',
   // IchiVaultGauge
+  ichiVault0: '0xd2a047b7',
+  ichiVault1: '0xe85b4d7b',
   totalRewardByPeriod: '0xf4ae3d66',
+  // ICHI vault
+  getTotalAmounts: '0xc4a7761e',
 };
 
 const pad = (hex) => hex.replace(/^0x/, '').padStart(64, '0');
@@ -77,6 +84,11 @@ const toAddress = (word) =>
 
 const toBigInt = (word) => (word && word !== '0x' ? BigInt(word) : 0n);
 
+const toWord = (word, index) =>
+  word && word.length >= 2 + (index + 1) * 64
+    ? BigInt(`0x${word.slice(2 + index * 64, 2 + (index + 1) * 64)}`)
+    : 0n;
+
 /** Minimal ABI-decode of a dynamic address[] return. */
 const toAddressArray = (word) => {
   if (!word || word === '0x') return [];
@@ -105,51 +117,29 @@ const toSymbol = (word) => {
   }
 };
 
-/** SUMA in USD from the SUMA/ctUSD pool's sqrtPrice (ctUSD priced by the coins API). */
-const getSumaPriceUsd = async () => {
-  const [globalState, token0] = await ethCallBatch([
-    { to: SUMA_CTUSD_POOL, data: SELECTORS.globalState },
-    { to: SUMA_CTUSD_POOL, data: SELECTORS.token0 },
-  ]);
-  if (!globalState || globalState === '0x') return null;
-  const sqrtPriceX96 = BigInt(`0x${globalState.slice(2, 66)}`);
-  const ratio = (Number(sqrtPriceX96) / 2 ** 96) ** 2; // token1 raw per token0 raw
-  // SUMA has 18 decimals, ctUSD has 6.
-  const sumaInCtUsd =
-    toAddress(token0) === SUMA ? ratio * 1e12 : 1 / (ratio * 1e-12);
-
-  let ctUsdPrice = 1;
-  try {
-    const { data } = await axios.get(
-      `https://coins.llama.fi/prices/current/${CHAIN}:${CTUSD}`,
-      { timeout: TIMEOUT_MS }
-    );
-    ctUsdPrice = data?.coins?.[`${CHAIN}:${CTUSD}`]?.price ?? 1;
-  } catch {
-    // ctUSD is a stablecoin; fall back to parity.
-  }
-  const price = sumaInCtUsd * ctUsdPrice;
-  return Number.isFinite(price) && price > 0 ? price : null;
-};
+const toUnits = (raw, decimals) => Number(raw) / 10 ** decimals;
 
 /**
- * Weekly xSATS emissions per Algebra pool, keyed by pool address.
- * Uses the latest fully distributed period (current - 1), i.e. the amount the
- * gauge actually received for last week, which is the live reward rate.
+ * One record per live IchiVaultGauge: the gauge's two ICHI vaults, their
+ * combined TVL (valued with the same prices as the pool TVL), and the xSATS
+ * the gauge received for the latest fully distributed period (current - 1),
+ * which is the live reward rate for vault depositors.
  */
-const getWeeklyEmissions = async () => {
+const getVaultRecords = async (poolEntries, prices) => {
   const [gaugesWord, periodWord] = await ethCallBatch([
     { to: VOTER, data: SELECTORS.getAllGauges },
     { to: VOTER, data: SELECTORS.getPeriod },
   ]);
   const gauges = toAddressArray(gaugesWord);
   const period = toBigInt(periodWord);
-  if (!gauges.length || period === 0n) return {};
+  if (!gauges.length || period === 0n) return [];
   const rewardPeriod = period - 1n;
 
-  const [pools, alive, rewards] = await Promise.all([
+  const [pools, alive, vault0s, vault1s, rewards] = await Promise.all([
     ethCallBatch(gauges.map((g) => ({ to: VOTER, data: encodeAddress(SELECTORS.ammPoolForGauge, g) }))),
     ethCallBatch(gauges.map((g) => ({ to: VOTER, data: encodeAddress(SELECTORS.isAlive, g) }))),
+    ethCallBatch(gauges.map((g) => ({ to: g, data: SELECTORS.ichiVault0 }))),
+    ethCallBatch(gauges.map((g) => ({ to: g, data: SELECTORS.ichiVault1 }))),
     ethCallBatch(
       gauges.map((g) => ({
         to: g,
@@ -158,31 +148,59 @@ const getWeeklyEmissions = async () => {
     ),
   ]);
 
-  const byPool = {};
-  gauges.forEach((_, i) => {
-    const pool = toAddress(pools[i]);
-    if (!pool || pool === '0x0000000000000000000000000000000000000000') return;
-    if (toBigInt(alive[i]) === 0n) return;
-    const weekly = Number(toBigInt(rewards[i])) / 1e18;
-    byPool[pool] = (byPool[pool] ?? 0) + weekly;
+  const live = gauges
+    .map((gauge, i) => ({
+      gauge,
+      pool: toAddress(pools[i]),
+      vaults: [toAddress(vault0s[i]), toAddress(vault1s[i])].filter((v) => v && v !== ZERO),
+      weeklySuma: toUnits(toBigInt(rewards[i]), 18),
+    }))
+    .filter((g) => toBigInt(alive[gauges.indexOf(g.gauge)]) !== 0n)
+    .filter((g) => g.pool && g.pool !== ZERO && poolEntries[g.pool] && g.vaults.length);
+
+  const vaultCalls = live.flatMap((g) => g.vaults.map((v) => ({ to: v, data: SELECTORS.getTotalAmounts })));
+  const totals = await ethCallBatch(vaultCalls);
+
+  const sumaPrice = prices[SUMA];
+  let cursor = 0;
+  return live.map((g) => {
+    const entry = poolEntries[g.pool];
+    const p0 = prices[entry.token0] ?? 0;
+    const p1 = prices[entry.token1] ?? 0;
+    let tvlUsd = 0;
+    for (let k = 0; k < g.vaults.length; k++) {
+      const word = totals[cursor++];
+      tvlUsd +=
+        toUnits(toWord(word, 0), entry.decimals0) * p0 +
+        toUnits(toWord(word, 1), entry.decimals1) * p1;
+    }
+    const rewardUsdPerYear = sumaPrice && g.weeklySuma > 0 ? g.weeklySuma * sumaPrice * 52 : 0;
+    return {
+      gauge: g.gauge,
+      pool: g.pool,
+      tvlUsd,
+      apyReward: tvlUsd > 0 && rewardUsdPerYear > 0 ? (rewardUsdPerYear / tvlUsd) * 100 : 0,
+    };
   });
-  return byPool;
 };
 
 const apy = async () => {
   const { data: stats } = await axios.get(POOL_STATS, { timeout: TIMEOUT_MS });
-  const pools = Object.entries(stats?.pools ?? {}).filter(
-    ([, s]) => Number(s.tvlUSD) > 0
+  const prices = Object.fromEntries(
+    Object.entries(stats?.prices ?? {}).map(([k, v]) => [k.toLowerCase(), Number(v)])
   );
-  if (!pools.length) return [];
+  const poolEntries = Object.fromEntries(
+    Object.entries(stats?.pools ?? {})
+      .filter(([, s]) => Number(s.tvlUSD) > 0)
+      .map(([address, s]) => [address.toLowerCase(), s])
+  );
+  const addresses = Object.keys(poolEntries);
+  if (!addresses.length) return [];
 
-  const addresses = pools.map(([address]) => address.toLowerCase());
-
-  const [token0s, token1s, weeklyEmissions, sumaPriceUsd] = await Promise.all([
+  const [token0s, token1s, vaultRecords] = await Promise.all([
     ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.token0 }))),
     ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.token1 }))),
-    getWeeklyEmissions().catch(() => ({})),
-    getSumaPriceUsd().catch(() => null),
+    getVaultRecords(poolEntries, prices),
   ]);
 
   const tokens = addresses.flatMap((_, i) => [toAddress(token0s[i]), toAddress(token1s[i])]);
@@ -194,44 +212,54 @@ const apy = async () => {
     uniqueTokens.map((token, i) => [token, toSymbol(symbolResults[i])])
   );
 
-  const result = pools
-    .map(([, stat], i) => {
-      const address = addresses[i];
-      const token0 = toAddress(token0s[i]);
-      const token1 = toAddress(token1s[i]);
-      const symbol0 = symbolByToken[token0];
-      const symbol1 = symbolByToken[token1];
-      if (!token0 || !token1 || !symbol0 || !symbol1) return null;
+  const poolRecords = {};
+  addresses.forEach((address, i) => {
+    const stat = poolEntries[address];
+    const token0 = toAddress(token0s[i]);
+    const token1 = toAddress(token1s[i]);
+    const symbol0 = symbolByToken[token0];
+    const symbol1 = symbolByToken[token1];
+    if (!token0 || !token1 || !symbol0 || !symbol1) return;
 
-      const tvlUsd = Number(stat.tvlUSD);
-      const volumeUsd24h = Number(stat.volumeUSD24h) || 0;
-      // Fees are accumulated per swap at the fee in force at the time (Algebra
-      // pools have a dynamic fee), so use the endpoint's 24h total rather than
-      // volume * current fee.
-      const fees24h = Number(stat.feesUSD24h);
-      if (!Number.isFinite(fees24h) || fees24h < 0) return null;
+    const tvlUsd = Number(stat.tvlUSD);
+    const volumeUsd24h = Number(stat.volumeUSD24h) || 0;
+    // Fees are accumulated per swap at the fee in force at the time (Algebra
+    // pools have a dynamic fee), so use the endpoint's 24h total rather than
+    // volume * current fee.
+    const fees24h = Number(stat.feesUSD24h);
+    if (!Number.isFinite(fees24h) || fees24h < 0) return;
 
-      // Gauge emissions go to the pool's ICHI vault depositors. Measured
-      // against the whole pool TVL this is a floor on what vault LPs earn.
-      const weeklySuma = weeklyEmissions[address] ?? 0;
-      const rewardUsdPerYear =
-        sumaPriceUsd && weeklySuma > 0 ? weeklySuma * sumaPriceUsd * 52 : 0;
-      const apyReward = tvlUsd > 0 && rewardUsdPerYear > 0 ? (rewardUsdPerYear / tvlUsd) * 100 : 0;
+    poolRecords[address] = {
+      pool: `${address}-${CHAIN}`,
+      chain: utils.formatChain(CHAIN),
+      project: PROJECT,
+      symbol: utils.formatSymbol(`${symbol0}-${symbol1}`),
+      tvlUsd,
+      apyBase: tvlUsd > 0 ? (fees24h / tvlUsd) * 365 * 100 : 0,
+      underlyingTokens: [token0, token1],
+      volumeUsd1d: volumeUsd24h,
+      url: `https://www.satsuma.exchange/pool/${address}`,
+    };
+  });
 
+  // ICHI vault records. The vaults hold concentrated positions in the pool,
+  // so they earn the pool's swap-fee rate on their liquidity (apyBase carried
+  // over) plus the gauge's xSATS emissions (apyReward, vault-only).
+  const ichiRecords = vaultRecords
+    .map((v) => {
+      const base = poolRecords[v.pool];
+      if (!base) return null;
       return {
-        pool: `${address}-${CHAIN}`,
-        chain: utils.formatChain(CHAIN),
-        project: PROJECT,
-        symbol: utils.formatSymbol(`${symbol0}-${symbol1}`),
-        tvlUsd,
-        apyBase: tvlUsd > 0 ? (fees24h / tvlUsd) * 365 * 100 : 0,
-        ...(apyReward > 0 ? { apyReward, rewardTokens: [XSATS] } : {}),
-        underlyingTokens: [token0, token1],
-        volumeUsd1d: volumeUsd24h,
-        url: `https://www.satsuma.exchange/pool/${address}`,
+        ...base,
+        pool: `${v.gauge}-${CHAIN}`,
+        poolMeta: 'ICHI vault',
+        tvlUsd: v.tvlUsd,
+        ...(v.apyReward > 0 ? { apyReward: v.apyReward, rewardTokens: [XSATS] } : {}),
       };
     })
-    .filter(Boolean)
+    .filter(Boolean);
+
+  const result = [...Object.values(poolRecords), ...ichiRecords]
     .filter((p) => Number.isFinite(p.tvlUsd) && p.tvlUsd > 0)
     .filter((p) => utils.keepFinite(p));
 

--- a/src/adaptors/satsuma/index.js
+++ b/src/adaptors/satsuma/index.js
@@ -11,6 +11,16 @@ const CHAIN = 'citrea';
 const POOL_STATS = 'https://s33-epoch-cron.tiagopratas69.workers.dev/pool-stats';
 const RPC = 'https://rpc.mainnet.citrea.xyz';
 
+// s33 gauge system. The Voter streams weekly xSATS (symbol veSUMA, 1:1 with
+// SUMA) emissions to one IchiVaultGauge per Algebra pool; depositors of that
+// pool's ICHI vaults earn them. Booked under the period that just ended.
+const VOTER = '0x451d2305a819b6bdb43a104b2d9cf46603135332';
+const XSATS = '0x732bcf02bccb77dbe64cb64935c897eddf6805ac';
+const SUMA = '0x60bf948001e7b7ea03ddaaddae048af7402e7b74';
+const CTUSD = '0x8d82c4e3c936c7b5724a382a9c5a4e6eb7ab6d5d';
+// SUMA/ctUSD Algebra pool, used to price SUMA (not on the coins API).
+const SUMA_CTUSD_POOL = '0x298a4e0ec1af98066b79836ea99dcc2dd5437f67';
+
 // Algebra pools carry a dynamic fee. globalState.lastFee is not usable here (it
 // reads a constant across pools), so take the live value from fee().
 const SELECTORS = {
@@ -18,10 +28,24 @@ const SELECTORS = {
   token1: '0xd21220a7',
   fee: '0xddca3f43',
   symbol: '0x95d89b41',
+  globalState: '0xe76c01e4',
+  // Voter
+  getAllGauges: '0xc946c5cc',
+  ammPoolForGauge: '0xb8eba276',
+  isAlive: '0x1703e5f9',
+  getPeriod: '0x1ed24195',
+  // IchiVaultGauge
+  totalRewardByPeriod: '0xf4ae3d66',
 };
+
+const pad = (hex) => hex.replace(/^0x/, '').padStart(64, '0');
+const encodeAddress = (selector, address) => `${selector}${pad(address)}`;
+const encodeUintAddress = (selector, n, address) =>
+  `${selector}${pad(BigInt(n).toString(16))}${pad(address)}`;
 
 /** One JSON-RPC batch instead of a request per call. */
 const ethCallBatch = async (calls) => {
+  if (!calls.length) return [];
   const { data } = await axios.post(
     RPC,
     calls.map((c, i) => ({
@@ -40,6 +64,22 @@ const toAddress = (word) =>
 
 const toNumber = (word) => (word && word !== '0x' ? Number(BigInt(word)) : null);
 
+const toBigInt = (word) => (word && word !== '0x' ? BigInt(word) : 0n);
+
+/** Minimal ABI-decode of a dynamic address[] return. */
+const toAddressArray = (word) => {
+  if (!word || word === '0x') return [];
+  const body = word.slice(2);
+  const offset = Number(BigInt(`0x${body.slice(0, 64)}`)) * 2;
+  const len = Number(BigInt(`0x${body.slice(offset, offset + 64)}`));
+  const out = [];
+  for (let i = 0; i < len; i++) {
+    const start = offset + 64 + i * 64;
+    out.push(`0x${body.slice(start + 24, start + 64)}`.toLowerCase());
+  }
+  return out;
+};
+
 /** Minimal ABI-decode of a dynamic string return. */
 const toSymbol = (word) => {
   if (!word || word === '0x') return null;
@@ -54,6 +94,69 @@ const toSymbol = (word) => {
   }
 };
 
+/** SUMA in USD from the SUMA/ctUSD pool's sqrtPrice (ctUSD priced by the coins API). */
+const getSumaPriceUsd = async () => {
+  const [globalState, token0] = await ethCallBatch([
+    { to: SUMA_CTUSD_POOL, data: SELECTORS.globalState },
+    { to: SUMA_CTUSD_POOL, data: SELECTORS.token0 },
+  ]);
+  if (!globalState || globalState === '0x') return null;
+  const sqrtPriceX96 = BigInt(`0x${globalState.slice(2, 66)}`);
+  const ratio = (Number(sqrtPriceX96) / 2 ** 96) ** 2; // token1 raw per token0 raw
+  // SUMA has 18 decimals, ctUSD has 6.
+  const sumaInCtUsd =
+    toAddress(token0) === SUMA ? ratio * 1e12 : 1 / (ratio * 1e-12);
+
+  let ctUsdPrice = 1;
+  try {
+    const { data } = await axios.get(
+      `https://coins.llama.fi/prices/current/${CHAIN}:${CTUSD}`
+    );
+    ctUsdPrice = data?.coins?.[`${CHAIN}:${CTUSD}`]?.price ?? 1;
+  } catch {
+    // ctUSD is a stablecoin; fall back to parity.
+  }
+  const price = sumaInCtUsd * ctUsdPrice;
+  return Number.isFinite(price) && price > 0 ? price : null;
+};
+
+/**
+ * Weekly xSATS emissions per Algebra pool, keyed by pool address.
+ * Uses the latest fully distributed period (current - 1), i.e. the amount the
+ * gauge actually received for last week, which is the live reward rate.
+ */
+const getWeeklyEmissions = async () => {
+  const [gaugesWord, periodWord] = await ethCallBatch([
+    { to: VOTER, data: SELECTORS.getAllGauges },
+    { to: VOTER, data: SELECTORS.getPeriod },
+  ]);
+  const gauges = toAddressArray(gaugesWord);
+  const period = toBigInt(periodWord);
+  if (!gauges.length || period === 0n) return {};
+  const rewardPeriod = period - 1n;
+
+  const [pools, alive, rewards] = await Promise.all([
+    ethCallBatch(gauges.map((g) => ({ to: VOTER, data: encodeAddress(SELECTORS.ammPoolForGauge, g) }))),
+    ethCallBatch(gauges.map((g) => ({ to: VOTER, data: encodeAddress(SELECTORS.isAlive, g) }))),
+    ethCallBatch(
+      gauges.map((g) => ({
+        to: g,
+        data: encodeUintAddress(SELECTORS.totalRewardByPeriod, rewardPeriod, XSATS),
+      }))
+    ),
+  ]);
+
+  const byPool = {};
+  gauges.forEach((_, i) => {
+    const pool = toAddress(pools[i]);
+    if (!pool || pool === '0x0000000000000000000000000000000000000000') return;
+    if (toBigInt(alive[i]) === 0n) return;
+    const weekly = Number(toBigInt(rewards[i])) / 1e18;
+    byPool[pool] = (byPool[pool] ?? 0) + weekly;
+  });
+  return byPool;
+};
+
 const apy = async () => {
   const { data: stats } = await axios.get(POOL_STATS);
   const pools = Object.entries(stats?.pools ?? {}).filter(
@@ -61,12 +164,14 @@ const apy = async () => {
   );
   if (!pools.length) return [];
 
-  const addresses = pools.map(([address]) => address);
+  const addresses = pools.map(([address]) => address.toLowerCase());
 
-  const [token0s, token1s, fees] = await Promise.all([
+  const [token0s, token1s, fees, weeklyEmissions, sumaPriceUsd] = await Promise.all([
     ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.token0 }))),
     ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.token1 }))),
     ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.fee }))),
+    getWeeklyEmissions().catch(() => ({})),
+    getSumaPriceUsd().catch(() => null),
   ]);
 
   const tokens = addresses.flatMap((_, i) => [toAddress(token0s[i]), toAddress(token1s[i])]);
@@ -79,7 +184,8 @@ const apy = async () => {
   );
 
   const result = pools
-    .map(([address, stat], i) => {
+    .map(([, stat], i) => {
+      const address = addresses[i];
       const token0 = toAddress(token0s[i]);
       const token1 = toAddress(token1s[i]);
       const symbol0 = symbolByToken[token0];
@@ -92,6 +198,13 @@ const apy = async () => {
       const feeRate = (toNumber(fees[i]) ?? 0) / 1e6;
       const fees24h = volumeUsd24h * feeRate;
 
+      // Gauge emissions go to the pool's ICHI vault depositors. Measured
+      // against the whole pool TVL this is a floor on what vault LPs earn.
+      const weeklySuma = weeklyEmissions[address] ?? 0;
+      const rewardUsdPerYear =
+        sumaPriceUsd && weeklySuma > 0 ? weeklySuma * sumaPriceUsd * 52 : 0;
+      const apyReward = tvlUsd > 0 && rewardUsdPerYear > 0 ? (rewardUsdPerYear / tvlUsd) * 100 : 0;
+
       return {
         pool: `${address}-${CHAIN}`,
         chain: utils.formatChain(CHAIN),
@@ -99,6 +212,7 @@ const apy = async () => {
         symbol: utils.formatSymbol(`${symbol0}-${symbol1}`),
         tvlUsd,
         apyBase: tvlUsd > 0 ? (fees24h / tvlUsd) * 365 * 100 : 0,
+        ...(apyReward > 0 ? { apyReward, rewardTokens: [XSATS] } : {}),
         underlyingTokens: [token0, token1],
         volumeUsd1d: volumeUsd24h,
         url: `https://www.satsuma.exchange/pool/${address}`,

--- a/src/adaptors/satsuma/index.js
+++ b/src/adaptors/satsuma/index.js
@@ -1,91 +1,114 @@
-const { request, gql } = require('graphql-request');
+const axios = require('axios');
 const utils = require('../utils');
 const { addMerklRewardApy } = require('../merkl/merkl-additional-reward');
 
 const PROJECT = 'satsuma';
 const CHAIN = 'citrea';
-const SUBGRAPH =
-  'https://api.goldsky.com/api/public/project_cmamb6kkls0v2010932jjhxj4/subgraphs/analytics-mainnet/v1.0.3/gn';
 
-// Current snapshot: TVL + cumulative fees for APY calculation
-const query = gql`
-  {
-    pools(first: 1000, orderBy: totalValueLockedUSD, orderDirection: desc, block: {number: <PLACEHOLDER>}) {
-      id
-      totalValueLockedUSD
-      feesUSD
-      token0 {
-        id
-        symbol
-      }
-      token1 {
-        id
-        symbol
-      }
-    }
+// Satsuma's analytics subgraph was deleted upstream, which silently dropped
+// every Satsuma pool from this adapter. Both sources below are on-chain or
+// derived from on-chain logs, so there is no indexer to go stale again.
+const POOL_STATS = 'https://s33-epoch-cron.tiagopratas69.workers.dev/pool-stats';
+const RPC = 'https://rpc.mainnet.citrea.xyz';
+
+// Algebra pools carry a dynamic fee. globalState.lastFee is not usable here (it
+// reads a constant across pools), so take the live value from fee().
+const SELECTORS = {
+  token0: '0x0dfe1681',
+  token1: '0xd21220a7',
+  fee: '0xddca3f43',
+  symbol: '0x95d89b41',
+};
+
+/** One JSON-RPC batch instead of a request per call. */
+const ethCallBatch = async (calls) => {
+  const { data } = await axios.post(
+    RPC,
+    calls.map((c, i) => ({
+      jsonrpc: '2.0',
+      id: i,
+      method: 'eth_call',
+      params: [{ to: c.to, data: c.data }, 'latest'],
+    }))
+  );
+  const byId = new Map((Array.isArray(data) ? data : []).map((r) => [r.id, r.result]));
+  return calls.map((_, i) => byId.get(i) ?? null);
+};
+
+const toAddress = (word) =>
+  word && word.length >= 66 ? `0x${word.slice(26, 66)}`.toLowerCase() : null;
+
+const toNumber = (word) => (word && word !== '0x' ? Number(BigInt(word)) : null);
+
+/** Minimal ABI-decode of a dynamic string return. */
+const toSymbol = (word) => {
+  if (!word || word === '0x') return null;
+  const body = word.slice(2);
+  try {
+    const len = Number(BigInt(`0x${body.slice(64, 128)}`));
+    if (!len || len > 64) return null;
+    const hex = body.slice(128, 128 + len * 2);
+    return Buffer.from(hex, 'hex').toString('utf8').replace(/\0/g, '') || null;
+  } catch {
+    return null;
   }
-`;
+};
 
-// Prior snapshots: only cumulative fees needed to compute the delta
-const queryPrior = gql`
-  {
-    pools(first: 1000, orderBy: totalValueLockedUSD, orderDirection: desc, block: {number: <PLACEHOLDER>}) {
-      id
-      feesUSD
-    }
-  }
-`;
+const apy = async () => {
+  const { data: stats } = await axios.get(POOL_STATS);
+  const pools = Object.entries(stats?.pools ?? {}).filter(
+    ([, s]) => Number(s.tvlUSD) > 0
+  );
+  if (!pools.length) return [];
 
-const apy = async (timestamp = null) => {
-  // Get block numbers: current, 24h ago, 7d ago
-  const [block, blockPrior24h] = await utils.getBlocks(CHAIN, timestamp, [SUBGRAPH]);
-  const [, blockPrior7d] = await utils.getBlocks(CHAIN, timestamp, [SUBGRAPH], 604800);
+  const addresses = pools.map(([address]) => address);
 
-  const [dataNow, dataPrior24h, dataPrior7d] = await Promise.all([
-    request(SUBGRAPH, query.replace('<PLACEHOLDER>', block)),
-    request(SUBGRAPH, queryPrior.replace('<PLACEHOLDER>', blockPrior24h)),
-    request(SUBGRAPH, queryPrior.replace('<PLACEHOLDER>', blockPrior7d)),
+  const [token0s, token1s, fees] = await Promise.all([
+    ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.token0 }))),
+    ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.token1 }))),
+    ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.fee }))),
   ]);
 
-  const prior24hMap = Object.fromEntries(
-    dataPrior24h.pools.map((p) => [p.id, Number(p.feesUSD)])
+  const tokens = addresses.flatMap((_, i) => [toAddress(token0s[i]), toAddress(token1s[i])]);
+  const uniqueTokens = [...new Set(tokens.filter(Boolean))];
+  const symbolResults = await ethCallBatch(
+    uniqueTokens.map((to) => ({ to, data: SELECTORS.symbol }))
   );
-  const prior7dMap = Object.fromEntries(
-    dataPrior7d.pools.map((p) => [p.id, Number(p.feesUSD)])
+  const symbolByToken = Object.fromEntries(
+    uniqueTokens.map((token, i) => [token, toSymbol(symbolResults[i])])
   );
 
-  const result = dataNow.pools
-    .map((pool) => {
-      const tvlUsd = Number(pool.totalValueLockedUSD);
-      const feesNow = Number(pool.feesUSD);
+  const result = pools
+    .map(([address, stat], i) => {
+      const token0 = toAddress(token0s[i]);
+      const token1 = toAddress(token1s[i]);
+      const symbol0 = symbolByToken[token0];
+      const symbol1 = symbolByToken[token1];
+      if (!token0 || !token1 || !symbol0 || !symbol1) return null;
 
-      const fees24h = Math.max(0, feesNow - (prior24hMap[pool.id] ?? feesNow));
-      const fees7d = Math.max(0, feesNow - (prior7dMap[pool.id] ?? feesNow));
-
-      const apyBase = tvlUsd > 0 ? (fees24h / tvlUsd) * 365 * 100 : 0;
-      const apyBase7d =
-        tvlUsd > 0 ? ((fees7d / 7) / tvlUsd) * 365 * 100 : 0;
+      const tvlUsd = Number(stat.tvlUSD);
+      const volumeUsd24h = Number(stat.volumeUSD24h) || 0;
+      // fee() is in hundredths of a bip (1e6 == 100%).
+      const feeRate = (toNumber(fees[i]) ?? 0) / 1e6;
+      const fees24h = volumeUsd24h * feeRate;
 
       return {
-        pool: `${pool.id}-${CHAIN}`,
+        pool: `${address}-${CHAIN}`,
         chain: utils.formatChain(CHAIN),
         project: PROJECT,
-        symbol: `${pool.token0.symbol}-${pool.token1.symbol}`,
+        symbol: utils.formatSymbol(`${symbol0}-${symbol1}`),
         tvlUsd,
-        apyBase,
-        apyBase7d,
-        underlyingTokens: [pool.token0.id, pool.token1.id],
-        url: `https://www.satsuma.exchange/pool/${pool.id}`,
+        apyBase: tvlUsd > 0 ? (fees24h / tvlUsd) * 365 * 100 : 0,
+        underlyingTokens: [token0, token1],
+        volumeUsd1d: volumeUsd24h,
+        url: `https://www.satsuma.exchange/pool/${address}`,
       };
     })
+    .filter(Boolean)
     .filter((p) => Number.isFinite(p.tvlUsd) && p.tvlUsd > 0)
     .filter((p) => utils.keepFinite(p));
 
-  return addMerklRewardApy(
-    result,
-    'satsuma',
-    (pool) => pool.pool.split(`-${CHAIN}`)[0]
-  );
+  return addMerklRewardApy(result, PROJECT, (pool) => pool.pool.split(`-${CHAIN}`)[0]);
 };
 
 module.exports = {

--- a/src/adaptors/satsuma/index.js
+++ b/src/adaptors/satsuma/index.js
@@ -10,6 +10,9 @@ const CHAIN = 'citrea';
 // derived from on-chain logs, so there is no indexer to go stale again.
 const POOL_STATS = 'https://s33-epoch-cron.tiagopratas69.workers.dev/pool-stats';
 const RPC = 'https://rpc.mainnet.citrea.xyz';
+// Axios defaults to no timeout; bound every upstream call so apy() rejects
+// instead of hanging on a stalled endpoint.
+const TIMEOUT_MS = 30_000;
 
 // s33 gauge system. The Voter streams weekly xSATS (symbol veSUMA, 1:1 with
 // SUMA) emissions to one IchiVaultGauge per Algebra pool; depositors of that
@@ -21,12 +24,9 @@ const CTUSD = '0x8d82c4e3c936c7b5724a382a9c5a4e6eb7ab6d5d';
 // SUMA/ctUSD Algebra pool, used to price SUMA (not on the coins API).
 const SUMA_CTUSD_POOL = '0x298a4e0ec1af98066b79836ea99dcc2dd5437f67';
 
-// Algebra pools carry a dynamic fee. globalState.lastFee is not usable here (it
-// reads a constant across pools), so take the live value from fee().
 const SELECTORS = {
   token0: '0x0dfe1681',
   token1: '0xd21220a7',
-  fee: '0xddca3f43',
   symbol: '0x95d89b41',
   globalState: '0xe76c01e4',
   // Voter
@@ -53,16 +53,27 @@ const ethCallBatch = async (calls) => {
       id: i,
       method: 'eth_call',
       params: [{ to: c.to, data: c.data }, 'latest'],
-    }))
+    })),
+    { timeout: TIMEOUT_MS }
   );
-  const byId = new Map((Array.isArray(data) ? data : []).map((r) => [r.id, r.result]));
-  return calls.map((_, i) => byId.get(i) ?? null);
+  // A JSON-RPC item can carry `error` instead of `result`. Fail loudly rather
+  // than publishing a pool with partial data.
+  const byId = new Map((Array.isArray(data) ? data : []).map((r) => [r.id, r]));
+  return calls.map((_, i) => {
+    const response = byId.get(i);
+    if (!response || response.error || typeof response.result !== 'string') {
+      throw new Error(
+        `eth_call failed for ${calls[i].to} (${calls[i].data.slice(0, 10)}): ${
+          response?.error?.message ?? 'no result'
+        }`
+      );
+    }
+    return response.result;
+  });
 };
 
 const toAddress = (word) =>
   word && word.length >= 66 ? `0x${word.slice(26, 66)}`.toLowerCase() : null;
-
-const toNumber = (word) => (word && word !== '0x' ? Number(BigInt(word)) : null);
 
 const toBigInt = (word) => (word && word !== '0x' ? BigInt(word) : 0n);
 
@@ -110,7 +121,8 @@ const getSumaPriceUsd = async () => {
   let ctUsdPrice = 1;
   try {
     const { data } = await axios.get(
-      `https://coins.llama.fi/prices/current/${CHAIN}:${CTUSD}`
+      `https://coins.llama.fi/prices/current/${CHAIN}:${CTUSD}`,
+      { timeout: TIMEOUT_MS }
     );
     ctUsdPrice = data?.coins?.[`${CHAIN}:${CTUSD}`]?.price ?? 1;
   } catch {
@@ -158,7 +170,7 @@ const getWeeklyEmissions = async () => {
 };
 
 const apy = async () => {
-  const { data: stats } = await axios.get(POOL_STATS);
+  const { data: stats } = await axios.get(POOL_STATS, { timeout: TIMEOUT_MS });
   const pools = Object.entries(stats?.pools ?? {}).filter(
     ([, s]) => Number(s.tvlUSD) > 0
   );
@@ -166,10 +178,9 @@ const apy = async () => {
 
   const addresses = pools.map(([address]) => address.toLowerCase());
 
-  const [token0s, token1s, fees, weeklyEmissions, sumaPriceUsd] = await Promise.all([
+  const [token0s, token1s, weeklyEmissions, sumaPriceUsd] = await Promise.all([
     ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.token0 }))),
     ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.token1 }))),
-    ethCallBatch(addresses.map((to) => ({ to, data: SELECTORS.fee }))),
     getWeeklyEmissions().catch(() => ({})),
     getSumaPriceUsd().catch(() => null),
   ]);
@@ -194,9 +205,11 @@ const apy = async () => {
 
       const tvlUsd = Number(stat.tvlUSD);
       const volumeUsd24h = Number(stat.volumeUSD24h) || 0;
-      // fee() is in hundredths of a bip (1e6 == 100%).
-      const feeRate = (toNumber(fees[i]) ?? 0) / 1e6;
-      const fees24h = volumeUsd24h * feeRate;
+      // Fees are accumulated per swap at the fee in force at the time (Algebra
+      // pools have a dynamic fee), so use the endpoint's 24h total rather than
+      // volume * current fee.
+      const fees24h = Number(stat.feesUSD24h);
+      if (!Number.isFinite(fees24h) || fees24h < 0) return null;
 
       // Gauge emissions go to the pool's ICHI vault depositors. Measured
       // against the whole pool TVL this is a floor on what vault LPs earn.


### PR DESCRIPTION
Resubmission of #2966 with a clean diff (that PR was opened from a non-fork repo and carried the whole tree; closed by me).

Satsuma's adapter queries Goldsky `analytics-mainnet/v1.0.3`, which was **deleted upstream**. Every request 404s, so Satsuma has been silently missing from yields despite the adapter being merged in #2704.

This rebuilds it on sources that can't go stale the same way:

- **TVL and 24h volume** from Satsuma's own public `/pool-stats` endpoint (built by scanning Swap logs over RPC).
- **token0/token1, symbols and the pool fee** read directly from the pools via batched `eth_call` on Citrea mainnet.

Algebra pools use a **dynamic fee**, so the fee is read from `fee()` per pool rather than assumed. Live values range from 0.01% to 1.5% across Satsuma pools.

Total TVL agrees with the existing DefiLlama Satsuma TVL listing (~$780k). 14 pools exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szi7Q56pDzLiweiCZKrhZV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Satsuma pool statistics now include TVL and 24-hour trading volume.
  - Pool details now use on-chain data for token addresses, fees, and symbols.
  - APY is calculated from 24-hour volume and fee rates.
  - Pool results now include eligible gauge reward APY and reward token information.
  - SUMA pricing is derived from pool data and coin pricing, with a parity fallback.

- **Updates**
  - The 7-day APY metric is no longer included in Satsuma pool information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->