### PR TITLE
ci: restore the pool table in adapter PR comments

### DIFF
--- a/.github/workflows/commentResult.js
+++ b/.github/workflows/commentResult.js
@@ -25,18 +25,39 @@ function main() {
   const failed = /FAIL\s+.*test\.js/.test(file);
 
   const MAX_FAILURE_DETAIL_CHARS = 20000;
+  const MAX_POOL_DETAIL_CHARS = 20000;
 
-  // On success: everything from "Test Suites:" onward (includes pool output from
-  // afterTests.js). On failure: the jest failure blocks too, capped, so the
-  // reason is visible in the comment and not just the counts.
+  // On success: everything from "Test Suites:" onward. On failure: the jest
+  // failure blocks too, capped, so the reason is visible in the comment and
+  // not just the counts.
   const summaryIndex = file.indexOf('Test Suites:');
   if (summaryIndex === -1) return;
+
+  // afterTests.js (a jest globalTeardown) writes the pool summary to stdout
+  // while jest buffers its reporter output and writes it to stderr, so on
+  // Node 24 the pool block lands BEFORE the jest summary and slicing from
+  // "Test Suites:" drops it. Take the block explicitly and stitch it on,
+  // skipping the per-test lines in between: including them pushed the comment
+  // past GitHub's 65536-character limit, so it failed to post at all.
+  const poolIndex = file.indexOf('Nb of pools:');
+  let poolDetail = '';
+  if (poolIndex !== -1 && poolIndex < summaryIndex) {
+    const rest = file.slice(poolIndex);
+    const reporterStart = rest.match(/\n\s*(?:✓|✗|✕|PASS|FAIL|Test Suites:)/);
+    poolDetail = (reporterStart ? rest.slice(0, reporterStart.index) : rest).trimEnd();
+    if (poolDetail.length > MAX_POOL_DETAIL_CHARS) {
+      poolDetail =
+        poolDetail.substring(0, MAX_POOL_DETAIL_CHARS) +
+        '\n\n... pool output truncated ...';
+    }
+    poolDetail += '\n\n';
+  }
 
   const failureIndex = file.indexOf('●');
   const hasFailureDetail =
     failed && failureIndex !== -1 && failureIndex < summaryIndex;
 
-  let output = file.substring(summaryIndex);
+  let output = poolDetail + file.substring(summaryIndex);
   if (hasFailureDetail) {
     let detail = trimFailureDetail(file.substring(failureIndex, summaryIndex));
     if (detail.length > MAX_FAILURE_DETAIL_CHARS) {


### PR DESCRIPTION
Split out of #2753 at reviewer request, so the CI change can be tested on its own.

### The bug

Every adapter PR comment since CI was pinned to Node 24 (8e1fecb1) shows the test counts with an empty pool list.

`commentResult.js` slices the log from `Test Suites:` onward, assuming the pool output from `afterTests.js` follows the jest summary. It does not. `afterTests.js` is a jest `globalTeardown` writing to **stdout**, while jest buffers its reporter output and writes it to **stderr**. The interleaving is not guaranteed, and on Node 24 the pool block is flushed first, so the slice drops it.

### Why anchoring on `Nb of pools:` is not enough

Between that line and the summary sits jest's per-test output: 685 lines and 97KB on this adapter. Including it pushes the comment past GitHub's 65536-character limit and it fails to post at all.

So the pool block is cut at the first reporter marker, stitched onto the summary, and capped the same way the failure detail already is.

### Verification

Real `xoxno-lending` log, replayed through both the current script and this one, in both stream orderings:

| log ordering | script | pool table | comment bytes |
|---|---|---|---|
| summary first (Node 22) | master | yes | 8175 |
| summary first (Node 22) | this PR | yes | 8175 |
| pool first (Node 24) | master | **missing** | 223 |
| pool first (Node 24) | this PR | yes | 8239 |

Byte-identical to master on the ordering that already worked, so no regression there. Both outputs sit well under the 65536 limit.

The failure path is unchanged: on a failing log the two scripts are byte-identical in the previously-working ordering, the failure message is still surfaced in both, and source-excerpt and stack-trace noise is still stripped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test result comments now reliably include pool summaries when output ordering varies.
  * Comment content is capped to prevent exceeding GitHub’s maximum comment length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->