### PR TITLE
feat(arcadia-v2): add Robinhood lending pools

### DIFF
--- a/src/adaptors/arcadia-v2/index.js
+++ b/src/adaptors/arcadia-v2/index.js
@@ -44,6 +44,30 @@ const config = {
       },
     ],
   },
+  robinhood: {
+    chainId: 4663,
+    assets: {
+      // Robinhood's dollar market is USDG; the chain has no USDC.
+      USDG: '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168',
+      wETH: '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73',
+    },
+    pools: [
+      {
+        symbol: 'wETH',
+        address: '0x803ea69c7e87D1d6C86adeB40CB636cC0E6B98E2',
+        underlying: '0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73',
+        decimals: 18,
+        poolMeta: 'Arcadia V2 WETH Pool',
+      },
+      {
+        symbol: 'USDG',
+        address: '0xf37c0C5996503Fdd2b5CCCE36E659cD30393AE59',
+        underlying: '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168',
+        decimals: 6,
+        poolMeta: 'Arcadia V2 USDG Pool',
+      },
+    ],
+  },
   optimism: {
     chainId: 10,
     assets: {


### PR DESCRIPTION
Arcadia's lending markets are live on Robinhood Chain (4663): wETH and USDG. The chain has no USDC, so USDG is its dollar market and the assets map lists it under that name; the map only feeds getMaxCollFactor, which reads the highest collateral factor across a chain's assets.

Two values read zero today. apyBase is zero because nothing has been borrowed yet, so there is no interest to share with suppliers; getRiskFactors returns 0/0 because the margin risk parameters are not set on chain yet, so ltv is 0. Both will fix themselves when they get added and borrowing starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Robinhood chain in the Arcadia V2 integration.
  * Added USDG and wETH asset and pool configurations, including associated metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->