### PR TITLE
Add Lodestar Protocol (Flare) - lodUSDT0 lending pool

### DIFF
--- a/src/adaptors/lodestar-protocol/index.js
+++ b/src/adaptors/lodestar-protocol/index.js
@@ -1,8 +1,7 @@
 // Lodestar (Flare): no-liquidation, fixed-term lending. Lenders supply USDT0 to an ERC-4626 pool
 // (lodUSDT0) and earn the one-time fees borrowers pay up front; nothing is emitted, so the only yield
 // is the share price rising. The APY below is therefore the realised share-price change, annualised
-// over a trailing window, which is exactly what a depositor would have earned. It reads 0 while the
-// book is empty rather than quoting a projection.
+// over a trailing window, which is exactly what a depositor would have earned.
 //
 // NOT the same protocol as `lodestar` / `lodestar-v1` (Lodestar Finance on Arbitrum). Slug
 // `lodestar-protocol`, after lodestarprotocol.xyz.
@@ -13,9 +12,14 @@ const CHAIN = 'flare';
 const POOL = '0x87b09bE7A253C2af187c9af17cDEDcEAf4A9780E'; // LodestarPool, ERC-4626, genesis 2026-08-29
 const USDT0 = '0xe7cd86e13AC4309349F30B3435a9d337750fC82D'; // 6 decimals
 const GENESIS_BLOCK = 68517390; // the pool did not exist before this; the window never reaches back past it
-const GENESIS_TS = 1756425600; // 2026-08-29 00:00 UTC
+const GENESIS_TS = 1787961600; // 2026-08-29 00:00 UTC
 const ONE_SHARE = '1000000000000'; // lodUSDT0 is 12 dp (6 dp asset + 6 dp virtual offset)
 const WINDOW_DAYS = 30;
+// Borrowers pay their whole fee up front and it vests into the share price over 7 days, so the
+// share price moves in steps, not a smooth curve. Annualising a window shorter than one vesting
+// period turns a single loan into a headline APY of several hundred percent. Below this age the
+// pool reports no APY rather than a number that would be arithmetic rather than yield.
+const MIN_WINDOW_DAYS = 7;
 
 const abi = {
   totalAssets: 'function totalAssets() view returns (uint256)',
@@ -36,16 +40,23 @@ const apy = async () => {
 
   // share price at the start of the window, or at genesis if the pool is younger than the window
   const windowStart = Math.max(now - WINDOW_DAYS * 86400, GENESIS_TS);
+  const days = (now - windowStart) / 86400;
+  // The schema requires a finite APY field, so "not enough history yet" has to be expressed as a
+  // number. 0 is the one that cannot mislead: it under-claims instead of annualising a step.
   let apyBase = 0;
-  try {
-    const [blockThen] = await utils.getBlocksByTime([windowStart], CHAIN);
-    const block = Math.max(Number(blockThen), GENESIS_BLOCK);
-    const spThen = await call(POOL, abi.convertToAssets, [ONE_SHARE], block);
-    const days = Math.max(1, (now - windowStart) / 86400);
-    if (Number(spThen) > 0) apyBase = (Number(spNow) / Number(spThen) - 1) * (365 / days) * 100;
-  } catch (e) {
-    // a failed historical read must not fake a number; the pool is simply reported with apyBase 0
-    apyBase = 0;
+  if (days >= MIN_WINDOW_DAYS) {
+    try {
+      const [blockThen] = await utils.getBlocksByTime([windowStart], CHAIN);
+      const block = Math.max(Number(blockThen), GENESIS_BLOCK);
+      const spThen = await call(POOL, abi.convertToAssets, [ONE_SHARE], block);
+      // Kept signed on purpose. A settlement shortfall that outruns the first-loss buffer is booked
+      // against the pool (`impairedLoss`) and DROPS the share price, so a negative number here is a
+      // real lender loss. Clamping it at zero would report a loss as break-even.
+      if (Number(spThen) > 0) apyBase = (Number(spNow) / Number(spThen) - 1) * (365 / days) * 100;
+    } catch (e) {
+      // a failed historical read must not fake a number; the pool is simply reported at 0
+      apyBase = 0;
+    }
   }
 
   // USDT0 is Tether's omnichain dollar; price it, with a $1 fallback if the price API has no key for it
@@ -56,8 +67,13 @@ const apy = async () => {
     if (k && p[k].price) price = p[k].price;
   } catch (e) {}
 
-  const tvlUsd = (Number(totalAssets) / 1e6) * price;
+  // `totalAssets()` is the pool's FULL claim: idle cash + principal already lent out (less any
+  // impairment and the unvested-fee lock). So it is the SUPPLY side, and tvlUsd — which DefiLlama
+  // defines as what is actually sitting in the pool — has to net the lent-out principal back off.
+  // Using totalAssets for both would count every borrowed dollar twice.
+  const totalSupplyUsd = (Number(totalAssets) / 1e6) * price;
   const totalBorrowUsd = (Number(principalOut) / 1e6) * price;
+  const tvlUsd = Math.max(0, totalSupplyUsd - totalBorrowUsd);
 
   return [
     {
@@ -66,11 +82,11 @@ const apy = async () => {
       project: 'lodestar-protocol',
       symbol: 'USDT0',
       tvlUsd,
-      apyBase: Math.max(0, apyBase),
+      apyBase,
       underlyingTokens: [USDT0],
-      totalSupplyUsd: tvlUsd + totalBorrowUsd,
+      totalSupplyUsd,
       totalBorrowUsd,
-      ltv: 0.5,
+      ltv: 0.5, // highest tier on the book: FXRP, 7-day term
       poolMeta: 'lodUSDT0: fees from 7/30/90-day no-liquidation loans, no lockup',
       url: 'https://lodestarprotocol.xyz/app#lend',
     },

--- a/src/adaptors/lodestar-protocol/index.js
+++ b/src/adaptors/lodestar-protocol/index.js
@@ -1,0 +1,85 @@
+// Lodestar (Flare): no-liquidation, fixed-term lending. Lenders supply USDT0 to an ERC-4626 pool
+// (lodUSDT0) and earn the one-time fees borrowers pay up front; nothing is emitted, so the only yield
+// is the share price rising. The APY below is therefore the realised share-price change, annualised
+// over a trailing window, which is exactly what a depositor would have earned. It reads 0 while the
+// book is empty rather than quoting a projection.
+//
+// NOT the same protocol as `lodestar` / `lodestar-v1` (Lodestar Finance on Arbitrum). Slug
+// `lodestar-protocol`, after lodestarprotocol.xyz.
+const sdk = require('@defillama/sdk');
+const utils = require('../utils');
+
+const CHAIN = 'flare';
+const POOL = '0x87b09bE7A253C2af187c9af17cDEDcEAf4A9780E'; // LodestarPool, ERC-4626, genesis 2026-08-29
+const USDT0 = '0xe7cd86e13AC4309349F30B3435a9d337750fC82D'; // 6 decimals
+const GENESIS_BLOCK = 68517390; // the pool did not exist before this; the window never reaches back past it
+const GENESIS_TS = 1756425600; // 2026-08-29 00:00 UTC
+const ONE_SHARE = '1000000000000'; // lodUSDT0 is 12 dp (6 dp asset + 6 dp virtual offset)
+const WINDOW_DAYS = 30;
+
+const abi = {
+  totalAssets: 'function totalAssets() view returns (uint256)',
+  principalOut: 'function principalOut() view returns (uint256)',
+  convertToAssets: 'function convertToAssets(uint256 shares) view returns (uint256)',
+};
+
+const call = async (target, abiStr, params, block) =>
+  (await sdk.api.abi.call({ target, abi: abiStr, params, chain: CHAIN, block })).output;
+
+const apy = async () => {
+  const now = Math.floor(Date.now() / 1000);
+  const [totalAssets, principalOut, spNow] = await Promise.all([
+    call(POOL, abi.totalAssets),
+    call(POOL, abi.principalOut),
+    call(POOL, abi.convertToAssets, [ONE_SHARE]),
+  ]);
+
+  // share price at the start of the window, or at genesis if the pool is younger than the window
+  const windowStart = Math.max(now - WINDOW_DAYS * 86400, GENESIS_TS);
+  let apyBase = 0;
+  try {
+    const [blockThen] = await utils.getBlocksByTime([windowStart], CHAIN);
+    const block = Math.max(Number(blockThen), GENESIS_BLOCK);
+    const spThen = await call(POOL, abi.convertToAssets, [ONE_SHARE], block);
+    const days = Math.max(1, (now - windowStart) / 86400);
+    if (Number(spThen) > 0) apyBase = (Number(spNow) / Number(spThen) - 1) * (365 / days) * 100;
+  } catch (e) {
+    // a failed historical read must not fake a number; the pool is simply reported with apyBase 0
+    apyBase = 0;
+  }
+
+  // USDT0 is Tether's omnichain dollar; price it, with a $1 fallback if the price API has no key for it
+  let price = 1;
+  try {
+    const p = (await utils.getPriceApiData(`/prices/current/${CHAIN}:${USDT0}`)).coins;
+    const k = Object.keys(p)[0];
+    if (k && p[k].price) price = p[k].price;
+  } catch (e) {}
+
+  const tvlUsd = (Number(totalAssets) / 1e6) * price;
+  const totalBorrowUsd = (Number(principalOut) / 1e6) * price;
+
+  return [
+    {
+      pool: `${POOL.toLowerCase()}-${CHAIN}`,
+      chain: utils.formatChain(CHAIN),
+      project: 'lodestar-protocol',
+      symbol: 'USDT0',
+      tvlUsd,
+      apyBase: Math.max(0, apyBase),
+      underlyingTokens: [USDT0],
+      totalSupplyUsd: tvlUsd + totalBorrowUsd,
+      totalBorrowUsd,
+      ltv: 0.5,
+      poolMeta: 'lodUSDT0: fees from 7/30/90-day no-liquidation loans, no lockup',
+      url: 'https://lodestarprotocol.xyz/app#lend',
+    },
+  ];
+};
+
+module.exports = {
+  protocolId: 'FILL_FROM_https://api.llama.fi/protocols_ONCE_lodestar-protocol_IS_LISTED',
+  timetravel: false,
+  apy,
+  url: 'https://lodestarprotocol.xyz/app#lend',
+};

--- a/src/adaptors/lodestar-protocol/index.js
+++ b/src/adaptors/lodestar-protocol/index.js
@@ -78,7 +78,7 @@ const apy = async () => {
 };
 
 module.exports = {
-  protocolId: 'FILL_FROM_https://api.llama.fi/protocols_ONCE_lodestar-protocol_IS_LISTED',
+  protocolId: '8565',
   timetravel: false,
   apy,
   url: 'https://lodestarprotocol.xyz/app#lend',


### PR DESCRIPTION
Adds the yield adapter for **Lodestar Protocol** on Flare (protocolId `8565`, listed via DefiLlama-Adapters PR #20759).

Lodestar is no-liquidation fixed-term lending. Lenders supply USD₮0 to an ERC-4626 vault (`lodUSDT0`) and earn the one-time fees borrowers pay up front. There are no emissions, so the only yield is the share price rising.

**How the APY is computed:** realised share-price change over a trailing 30-day window (or since genesis, whichever is shorter), annualised — i.e. exactly what a depositor would have earned. It reads 0 while the book has no loans rather than quoting a projection.

- Pool: `0x87b09bE7A253C2af187c9af17cDEDcEAf4A9780E` (LodestarPool, ERC-4626)
- Asset: USD₮0 `0xe7cd86e13AC4309349F30B3435a9d337750fC82D` (6 dp)
- Reports `tvlUsd`, `apyBase`, `totalSupplyUsd`, `totalBorrowUsd`, `ltv`

`npm run test --adapter=lodestar-protocol` passes (15/15).

Note: this is **not** the same protocol as `lodestar` / `lodestar-v1` (Lodestar Finance on Arbitrum). The slug `lodestar-protocol` follows the project's domain, lodestarprotocol.xyz, to keep the two apart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lodestar Protocol support on Flare.
  * Added lending pool metrics, including TVL, borrows, supply, loan-to-value, and annualized base APY.
  * Annualized base APY now reflects realized share-price changes over a trailing 30-day period.
  * Added USDT0 pricing with a $1 fallback when market pricing is unavailable.
  * Added safeguards for newer pools and unavailable historical data, defaulting APY to 0 when reliable calculations are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->