### PR TITLE
rename stake-dao -> stake-dao-yield

### DIFF
--- a/migrations/1788590933219_rename-stake-dao-to-stake-dao-yield.js
+++ b/migrations/1788590933219_rename-stake-dao-to-stake-dao-yield.js
@@ -1,0 +1,7 @@
+exports.up = (pgm) => {
+  pgm.sql(`UPDATE config SET project = 'stake-dao-yield' WHERE project = 'stake-dao'`);
+};
+
+exports.down = (pgm) => {
+  pgm.sql(`UPDATE config SET project = 'stake-dao' WHERE project = 'stake-dao-yield'`);
+};

--- a/src/adaptors/stake-dao-yield/index.js
+++ b/src/adaptors/stake-dao-yield/index.js
@@ -109,7 +109,7 @@ const poolsFunction = async () => {
         {
           pool: `sd-${strat.key}-${CHAINS[strat.chainId]}`.toLowerCase(),
           chain: utils.formatChain(CHAINS[strat.chainId]),
-          project: 'stake-dao',
+          project: 'stake-dao-yield',
           symbol: symbol ? symbol : null,
           poolMeta,
           tvlUsd: strat.tvl,
@@ -132,7 +132,7 @@ const poolsFunction = async () => {
       return {
         pool: locker.sdToken.symbol.toLowerCase(),
         chain: utils.formatChain(CHAINS[locker.chainId]),
-        project: 'stake-dao',
+        project: 'stake-dao-yield',
         symbol: locker.sdToken.symbol,
         poolMeta: locker.protocol ? utils.formatChain(locker.protocol) : null,
         tvlUsd: locker.tvl,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated project identification from “stake-dao” to “stake-dao-yield” across relevant pools.
  * Updated existing configuration records to use the new project name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->