### PR TITLE
hipo: read the widened treasury state, and drop the second call

### DIFF
--- a/src/adaptors/hipo/index.js
+++ b/src/adaptors/hipo/index.js
@@ -29,31 +29,26 @@ module.exports = {
       );
     }
 
-    await sleep(1000);
-
-    const getTimes = await utils.getData(
-      'https://toncenter.com/api/v3/runGetMethod',
-      {
-        address,
-        method: 'get_times',
-        stack: [],
-      }
-    );
-    if (getTimes.exit_code !== 0) {
-      throw new Error(
-        'Expected a zero exit code, but got ' + getTimes.exit_code
-      );
-    }
-
     // The treasury stores the hGRAM/GRAM exchange rate before and after the
-    // latest round's loan repayments (fixed-point, 1e9 = 1.0). The rate is
-    // updated once per validation round, so the growth between the two rates
-    // accrued over a single round duration.
-    const previousRate = Number(getTreasuryState.stack[11].value);
-    const currentRate = Number(getTreasuryState.stack[12].value);
+    // latest round's loan repayments (fixed-point, 1e9 = 1.0), and alongside
+    // them the interval those two rates grew over.
+    //
+    // get_treasury_state mirrors the treasury's storage order, and an upgrade
+    // on 2026-09-06 inserted deficit at index 5 and round_duration +
+    // last_settled_round after the rate pair, taking the tuple from 21 values
+    // to 24. Every index from 5 on moved.
+    const previousRate = Number(getTreasuryState.stack[12].value);
+    const currentRate = Number(getTreasuryState.stack[13].value);
 
-    const currentRoundSince = Number(getTimes.stack[0].value);
-    const nextRoundSince = Number(getTimes.stack[3].value);
+    // Seconds that current_rate took to grow out of previous_rate, measured on
+    // chain between the last two settled rounds. This used to be worked out
+    // from a second get_times call as next_round_since - current_round_since,
+    // which is a round LENGTH -- not the same thing. The treasury only moves
+    // the rates when a round it lent into settles, so a round in which nothing
+    // was lent widens this interval instead of passing unnoticed, and
+    // annualising by a round length would report an unchanged APY for a pool
+    // whose real rate of growth had halved.
+    const roundDuration = Number(getTreasuryState.stack[14].value);
 
     if (!Number.isFinite(previousRate) || previousRate <= 0) {
       throw new Error('Invalid previous rate: ' + previousRate);
@@ -61,8 +56,6 @@ module.exports = {
     if (!Number.isFinite(currentRate) || currentRate <= 0) {
       throw new Error('Invalid current rate: ' + currentRate);
     }
-
-    const roundDuration = nextRoundSince - currentRoundSince;
     if (!Number.isFinite(roundDuration) || roundDuration <= 0) {
       throw new Error('Invalid round duration: ' + roundDuration);
     }
@@ -90,7 +83,3 @@ module.exports = {
     ];
   },
 };
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}


### PR DESCRIPTION
Hipo upgraded its treasury contract on 2026-09-06. `get_treasury_state` mirrors the contract's storage order, and the upgrade inserted `deficit` at index 5 and `round_duration` + `last_settled_round` after the exchange-rate pair, taking the tuple from 21 values to 24. Every index from 5 on moved, so this adapter was reading `loan_codes` and `previous_rate` where it expected the rate pair.

Indices updated: `previous_rate` 11 → 12, `current_rate` 12 → 13.

## The APY period now comes off the same read

It used to be derived from a second `get_times` call as `next_round_since - current_round_since`, which is a round **length**. `round_duration` is the interval the two rates actually grew over, measured on chain between the last two settled rounds.

The two agree while the pool lends into every round, and diverge exactly when it does not: the treasury only moves the rates when a round it lent into settles, so a skipped round roughly doubles the growth per update while a round length stays put. Annualising by the round length would hold the reported APY steady for a pool whose real rate of growth had halved.

That removes one toncenter request per run, so the 1s `sleep` that spaced the two calls goes too, along with the now-unused helper.

## Verification

Ran the adapter's arithmetic against live contract state:

```
previous_rate=1163036853  current_rate=1163402268  round_duration=65536

apyBase          = 16.318861%
apyBaseInception = 5.444984%
```

`16.318861%` is what the protocol's own gauge and MCP server publish for the same rate pair, so the three agree to six decimal places.

I am from the Hipo team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hGRAM APY reporting by reading exchange-rate and round-duration data directly from the treasury state.
  - Updated APY data handling to remain compatible with the expanded treasury state introduced in the September 2026 upgrade.
  - Removed an unnecessary delay during APY data retrieval, helping results load more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->