### PR TITLE
midas-rwa: add mGLO (Base, Robinhood Chain) and mGLOBAL (Ethereum)

### DIFF
--- a/src/adaptors/midas-rwa/addresses.js
+++ b/src/adaptors/midas-rwa/addresses.js
@@ -140,6 +140,14 @@ const contractAddresses = {
       denomination: 'BTC',
       url: 'https://midas.app/mevbtc',
     },
+    mGLOBAL: {
+      address: getAddress('0x7433806912Eae67919e66aea853d46Fa0aef98A8'),
+      // Midas only deployed growth-adjusted MidasDataFeed wrappers for mGLOBAL
+      // (deposit +7% / redemption -7%), so the unadjusted NAV is read from the
+      // raw aggregator instead of a `dataFeed` wrapper.
+      aggregator: getAddress('0x66Aa9fcD63DF74e1f67A9452E6E59Fbc67f75E38'),
+      url: 'https://midas.app/mglobal',
+    },
   },
   base: {
     mBASIS: {
@@ -171,6 +179,12 @@ const contractAddresses = {
       address: getAddress('0xccbad2823328BCcAEa6476Df3Aa529316aB7474A'),
       dataFeed: getAddress('0x030b69280892c888670EDCDCD8B69Fd8026A0BF3'),
       url: 'https://midas.app/mevusd',
+    },
+    mGLO: {
+      address: getAddress('0xFCc9Cc1209651Ed8867332d6F664CF82743A2584'),
+      // Same as mGLOBAL: no unadjusted wrapper exists, read the raw aggregator.
+      aggregator: getAddress('0x6B593a5FAbb90F36e125562Db833f761d274fcBC'),
+      url: 'https://midas.app/mglo',
     },
   },
   sapphire: {
@@ -322,6 +336,13 @@ const contractAddresses = {
       address: getAddress('0xb31BeA5c2a43f942a3800558B1aa25978da75F8a'),
       dataFeed: getAddress('0x2EB410e4cb94E2E9E3cdE3F7b405BE4fCC076Bc9'),
       url: 'https://midas.app/mhyper',
+    },
+  },
+  robinhood: {
+    mGLO: {
+      address: getAddress('0xFEd493F38c1aAcb4EA4e6A11F8b9287849EE0096'),
+      aggregator: getAddress('0x49D9Dd1Fa6EA3709aB8A5d5f16a1cf207eb91dd0'),
+      url: 'https://midas.app/mglo',
     },
   },
   '0g': {

--- a/src/adaptors/midas-rwa/chainlinkHelpers.js
+++ b/src/adaptors/midas-rwa/chainlinkHelpers.js
@@ -84,6 +84,15 @@ async function getRoundById(aggregatorAddress, chain, roundId) {
   };
 }
 
+// Error signatures returned by RPCs that do not hold state for the requested
+// historical block (non-archive nodes or pruned history).
+const MISSING_ARCHIVE_STATE_RE =
+  /missing trie node|metadata is not found|header not found|state (is )?not available|no state|pruned|archive/i;
+
+function isMissingArchiveStateError(error) {
+  return MISSING_ARCHIVE_STATE_RE.test(String(error?.message ?? error));
+}
+
 // Get historical price data with fallback
 async function getHistoricalPrice(aggregatorAddress, chain, latestRound) {
   const historicalTimestamp = latestRound.updatedAt - 6 * SECONDS_PER_DAY;
@@ -132,11 +141,20 @@ async function getHistoricalPrice(aggregatorAddress, chain, latestRound) {
     return historicalData;
   } catch (error) {
     // Reading a past round through an archive call needs archive state, which
-    // some public RPCs (e.g. Robinhood Chain) do not serve. `getRoundData` is a
-    // plain storage read at head, so fall back to the previous round instead
-    // of dropping the product.
+    // some public RPCs (e.g. Robinhood Chain) do not serve. Only in that case
+    // fall back to the previous round: `getRoundData` is a plain storage read
+    // at head and each round carries its own `updatedAt`, so computeAPY still
+    // annualizes over the real interval. Any other error is left as before.
+    if (!isMissingArchiveStateError(error)) {
+      console.warn(
+        `MidasRWA: Failed to fetch historical price data at block ${historicalBlock} for ${aggregatorAddress}:`,
+        error.message
+      );
+      return null;
+    }
+
     console.warn(
-      `MidasRWA: Failed to fetch historical price data at block ${historicalBlock} for ${aggregatorAddress}, falling back to previous round:`,
+      `MidasRWA: No archive state at block ${historicalBlock} for ${aggregatorAddress}, falling back to previous round:`,
       error.message
     );
     const previousRoundId = latestRound.roundId - 1;

--- a/src/adaptors/midas-rwa/chainlinkHelpers.js
+++ b/src/adaptors/midas-rwa/chainlinkHelpers.js
@@ -131,11 +131,29 @@ async function getHistoricalPrice(aggregatorAddress, chain, latestRound) {
 
     return historicalData;
   } catch (error) {
+    // Reading a past round through an archive call needs archive state, which
+    // some public RPCs (e.g. Robinhood Chain) do not serve. `getRoundData` is a
+    // plain storage read at head, so fall back to the previous round instead
+    // of dropping the product.
     console.warn(
-      `MidasRWA: Failed to fetch historical price data at block ${historicalBlock} for ${aggregatorAddress}:`,
+      `MidasRWA: Failed to fetch historical price data at block ${historicalBlock} for ${aggregatorAddress}, falling back to previous round:`,
       error.message
     );
-    return null;
+    const previousRoundId = latestRound.roundId - 1;
+    const previousRound = await getRoundById(
+      aggregatorAddress,
+      chain,
+      previousRoundId
+    ).catch(() => null);
+
+    if (!previousRound) {
+      console.warn(
+        `MidasRWA: No previous round data available for round ${previousRoundId}`
+      );
+      return null;
+    }
+
+    return previousRound;
   }
 }
 

--- a/src/adaptors/midas-rwa/tokenHelpers.js
+++ b/src/adaptors/midas-rwa/tokenHelpers.js
@@ -2,45 +2,85 @@ const sdk = require('@defillama/sdk');
 const { convertPriceToUSD } = require('./convertPriceToUSD');
 const { getAggregatorAddress, getPriceData } = require('./chainlinkHelpers');
 const dataFeedAbi = require('./abi/dataFeedAbi.json');
+const basicDataFeedAbi = require('./abi/basicDatafeedAbi.json');
 const erc20Abi = require('./abi/erc20Abi.json');
 
 const PRICE_SCALE_FACTOR = BigInt(10 ** 10);
 
+// Most products expose a MidasDataFeed wrapper (`dataFeed`) whose
+// `getDataInBase18()` is the unadjusted NAV and whose `aggregator()` points at
+// the underlying Chainlink-style feed. A few products (mGLO, mGLOBAL) only have
+// growth-adjusted wrappers (deposit +7% / redemption -7%), so for those the
+// config carries `aggregator` directly: the NAV is read from the raw feed's
+// `latestRoundData()` (8 decimals) and scaled to base18 here.
+function scaleToBase18(rawAnswer) {
+  return (BigInt(rawAnswer.toString()) * PRICE_SCALE_FACTOR).toString();
+}
+
 // Fetch current prices and supply data
 async function fetchCurrentData(chain, tokens) {
-  const priceCalls = [];
-  const supplyCalls = [];
+  const entries = Object.entries(tokens);
 
-  for (const [token, tokenData] of Object.entries(tokens)) {
-    priceCalls.push({
-      target: tokenData.dataFeed,
-      params: [],
-      token,
-    });
+  const dataFeedCalls = [];
+  const dataFeedIndexes = [];
+  const aggregatorCalls = [];
+  const aggregatorIndexes = [];
 
-    supplyCalls.push({
-      target: tokenData.address,
-      params: [],
-      token,
-    });
-  }
+  entries.forEach(([, tokenData], index) => {
+    if (tokenData.dataFeed) {
+      dataFeedCalls.push({ target: tokenData.dataFeed, params: [] });
+      dataFeedIndexes.push(index);
+    } else {
+      aggregatorCalls.push({ target: tokenData.aggregator, params: [] });
+      aggregatorIndexes.push(index);
+    }
+  });
 
-  const [priceResults, supplyResults] = await Promise.all([
-    sdk.api.abi.multiCall({
-      abi: dataFeedAbi.find((m) => m.name === 'getDataInBase18'),
-      calls: priceCalls,
-      chain,
-      permitFailure: true,
-    }),
-    sdk.api.abi.multiCall({
-      abi: erc20Abi.find((m) => m.name === 'totalSupply'),
-      calls: supplyCalls,
-      chain,
-      permitFailure: true,
-    }),
-  ]);
+  const supplyCalls = entries.map(([, tokenData]) => ({
+    target: tokenData.address,
+    params: [],
+  }));
 
-  return { priceResults, supplyResults };
+  const [dataFeedResults, aggregatorResults, supplyResults] = await Promise.all(
+    [
+      dataFeedCalls.length
+        ? sdk.api.abi.multiCall({
+            abi: dataFeedAbi.find((m) => m.name === 'getDataInBase18'),
+            calls: dataFeedCalls,
+            chain,
+            permitFailure: true,
+          })
+        : { output: [] },
+      aggregatorCalls.length
+        ? sdk.api.abi.multiCall({
+            abi: basicDataFeedAbi.find((m) => m.name === 'latestRoundData'),
+            calls: aggregatorCalls,
+            chain,
+            permitFailure: true,
+          })
+        : { output: [] },
+      sdk.api.abi.multiCall({
+        abi: erc20Abi.find((m) => m.name === 'totalSupply'),
+        calls: supplyCalls,
+        chain,
+        permitFailure: true,
+      }),
+    ]
+  );
+
+  // Re-align both price sources to the token order, normalised to base18.
+  const priceOutput = new Array(entries.length);
+  dataFeedResults.output.forEach((result, i) => {
+    priceOutput[dataFeedIndexes[i]] = result;
+  });
+  aggregatorResults.output.forEach((result, i) => {
+    priceOutput[aggregatorIndexes[i]] =
+      result?.success && result.output
+        ? { success: true, output: scaleToBase18(result.output[1]) }
+        : { success: false };
+  });
+
+  return { priceResults: { output: priceOutput }, supplyResults };
 }
 
 // Convert Chainlink price to USD
@@ -73,10 +113,9 @@ async function processToken(
   );
   const supply = BigInt(supplyResult.output);
 
-  const aggregatorAddress = await getAggregatorAddress(
-    tokenData.dataFeed,
-    chain
-  );
+  const aggregatorAddress =
+    tokenData.aggregator ??
+    (await getAggregatorAddress(tokenData.dataFeed, chain));
 
   if (!aggregatorAddress) {
     console.warn(


### PR DESCRIPTION
Closes #2964

## What

Adds three Midas products to `midas-rwa`, and Robinhood Chain as a new chain for the adapter:

| product | chain | token | supply |
|---|---|---|---|
| mGLOBAL | Ethereum | `0x7433806912Eae67919e66aea853d46Fa0aef98A8` | 66.2M |
| mGLO | Base | `0xFCc9Cc1209651Ed8867332d6F664CF82743A2584` | 26.5M |
| mGLO | Robinhood Chain | `0xFEd493F38c1aAcb4EA4e6A11F8b9287849EE0096` | 34.5M |

All three are already posted as collateral on Morpho Blue and Aave Horizon. Until now they only showed up in the yields data as `apyBase: 0` collateral rows with no source pool behind them.

## Why the obvious fix didn't work

#2964 stalled because the wrapper reachable from the Morpho oracle for mGLO has no `aggregator()`, so a plain `dataFeed` entry gets skipped by `getAggregatorAddress()`.

Midas' own deployment list explains it (`midas-apps/contracts`, `config/constants/addresses.ts`). For mGLO and mGLOBAL there is no unadjusted `MidasDataFeed`. Midas deployed two growth-adjusted wrappers, `dataFeedDv` (+7%, deposits) and `dataFeedRv` (-7%, redemptions), on top of a raw aggregator. Checked on-chain:

```
# Base, mGLO
dataFeedDv  0x2095e2B0…  aggregator() -> 0x5289F0E8… (the +7% feed)   getDataInBase18() -> 1.07e18
raw feed    0x6B593a5F…  latestRoundData() -> answer 1.00e8              description "mGLO/USD"

# Ethereum, mGLOBAL
dataFeedDv  0x58476f45…  aggregator() -> 0x494F142c… (the +7% feed)   getDataInBase18() -> 1.0878e18
raw feed    0x66Aa9fcD…  latestRoundData() -> answer 1.01665e8          description "mGLOBAL/USD"
```

Pointing `dataFeed` at the Dv wrapper would overstate TVL by 7% and compute APY off an adjusted series. So this PR reads the raw feed.

## Changes

- `addresses.js`: the new entries carry `aggregator` instead of `dataFeed`. Existing entries are untouched.
- `tokenHelpers.js`: `fetchCurrentData` runs a second multicall (`latestRoundData`) for `aggregator` entries, scales the 8-decimal answer to base18, and re-aligns both result sets to token order. `processToken` uses the configured aggregator directly instead of calling `aggregator()` on a wrapper.
- `chainlinkHelpers.js`: when the archive `eth_call` for the historical round fails (Robinhood's public RPC serves no archive state), fall back to `getRoundData(roundId - 1)`, a storage read at head. Same fallback the function already uses for the same-round case.

No new dependencies. No lockfile changes.

## Output

`npm run test --adapter=midas-rwa` passes, 48 → 51 pools:

```
mGLOBAL  Ethereum         tvlUsd 67,337,940   apyBase 7.13   isIntrinsicSource
mGLO     Robinhood Chain  tvlUsd 34,515,613   apyBase 0.00   isIntrinsicSource
mGLO     Base             tvlUsd 26,487,520   apyBase 0.00
```

mGLO's feed has printed 1.00 on every round so far (3 rounds on Base since June, 2 on Robinhood), so 0% is what the feed says today. The TVL is real and the APY follows the feed as soon as NAV moves. `isIntrinsicSource` lands via the existing `markIntrinsicSources` logic, so the Morpho and Aave Horizon collateral rows can pick the yield up.

## Left out

mGLO on Ethereum (`0x1DD91a11…`) has ~2.5 tokens of supply. Placeholder deployment, skipped on purpose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for mGLO and mGLOBAL pricing across Ethereum, Base, and Robinhood.
  - Added support for assets using direct price feeds, expanding compatibility with additional token configurations.

- **Bug Fixes**
  - Improved historical price retrieval when archive data is unavailable by using the previous available round.
  - Improved current price and supply updates by handling multiple data sources concurrently while preserving token order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->