### PR TITLE
feat: add pools and yield on native core l1

### DIFF
--- a/src/adaptors/native-core-clob/index.js
+++ b/src/adaptors/native-core-clob/index.js
@@ -172,7 +172,7 @@ const apy = async () => {
         }),
         token: null,
         poolMeta: 'Native Pool',
-        url: 'https://app.native.org',
+        url: 'https://app.native.org/native-pool',
       };
     })
     .filter(Boolean);

--- a/src/adaptors/native-core-clob/index.js
+++ b/src/adaptors/native-core-clob/index.js
@@ -1,0 +1,186 @@
+const axios = require('axios');
+const utils = require('../utils');
+
+const POOL_API_URL = 'https://api-ui.native.org/api/v3/earn';
+const CORE_INFO_URL = 'https://api.native.org/info';
+const CORE_REGISTRY_URL = 'https://api-ui.native.org/api/v3/core/registry';
+const USD_SCALE = 10n ** 8n;
+const POOL_CHAIN = 'native_core';
+const CHAIN_PRIORITY = ['ethereum', 'bsc', 'base', 'arbitrum', 'morph'];
+const REQUEST_CONFIG = {
+  headers: {
+    'content-type': 'application/json',
+    'user-agent': 'defillama-yield-adapter/1.0',
+  },
+  timeout: 30_000,
+};
+
+const parseAtoms = (value) => {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
+
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+};
+
+const getChainPriority = (chainKey) => {
+  const priority = CHAIN_PRIORITY.indexOf(chainKey);
+  return priority === -1 ? CHAIN_PRIORITY.length : priority;
+};
+
+const postPoolRequest = async (body) => {
+  const { data } = await axios.post(POOL_API_URL, body, REQUEST_CONFIG);
+
+  if (data?.code !== 0 || !data.data) {
+    throw new Error(
+      `Native Core Pool ${body.type} failed: ${data?.message ?? 'no data'}`
+    );
+  }
+
+  return data.data;
+};
+
+const fetchMarkPrices = async () => {
+  const { data } = await axios.post(
+    CORE_INFO_URL,
+    { type: 'markPrices' },
+    REQUEST_CONFIG
+  );
+
+  if (!Array.isArray(data?.mark_prices)) {
+    throw new Error('Native Core markPrices returned no mark_prices array');
+  }
+
+  return new Map(
+    data.mark_prices.map(({ asset_id: assetId, usd_atoms: usdAtoms }) => [
+      assetId,
+      usdAtoms,
+    ])
+  );
+};
+
+const fetchUnderlyings = async () => {
+  const { data } = await axios.get(CORE_REGISTRY_URL, REQUEST_CONFIG);
+
+  if (data?.code !== 0 || !Array.isArray(data.data?.chains)) {
+    throw new Error(
+      `Native Core registry failed: ${data?.message ?? 'no chains'}`
+    );
+  }
+
+  const chains = [...data.data.chains].sort(
+    (a, b) => getChainPriority(a.chainKey) - getChainPriority(b.chainKey)
+  );
+  const underlyingsByAssetId = new Map();
+
+  for (const chain of chains) {
+    if (!chain.enabled || !Array.isArray(chain.underlyings)) continue;
+
+    for (const underlying of chain.underlyings) {
+      if (
+        !underlying.enabled ||
+        !Number.isInteger(underlying.assetId) ||
+        typeof underlying.nativeSymbol !== 'string' ||
+        !/^0x[a-fA-F0-9]{40}$/.test(underlying.address) ||
+        underlyingsByAssetId.has(underlying.assetId)
+      ) {
+        continue;
+      }
+
+      underlyingsByAssetId.set(underlying.assetId, {
+        address: underlying.address.toLowerCase(),
+        symbol: utils.formatSymbol(underlying.nativeSymbol),
+      });
+    }
+  }
+
+  return underlyingsByAssetId;
+};
+
+const calculateTvlUsd = (amount, decimals, usdAtoms) => {
+  const amountAtoms = parseAtoms(amount);
+  const priceAtoms = parseAtoms(String(usdAtoms));
+
+  if (
+    amountAtoms === null ||
+    priceAtoms === null ||
+    !Number.isInteger(decimals) ||
+    decimals < 0
+  ) {
+    return null;
+  }
+
+  const tvlUsd =
+    (Number(amountAtoms) / 10 ** decimals) *
+    (Number(priceAtoms) / Number(USD_SCALE));
+
+  return Number.isFinite(tvlUsd) && tvlUsd > 0 ? tvlUsd : null;
+};
+
+const formatApy = (projectedApy) => {
+  if (projectedApy === undefined) return 0;
+
+  const apy = Number(projectedApy) * 100;
+  return Number.isFinite(apy) && apy >= 0 ? apy : 0;
+};
+
+const apy = async () => {
+  const [config, pricesByAssetId, underlyingsByAssetId] = await Promise.all([
+    postPoolRequest({ type: 'config' }),
+    fetchMarkPrices(),
+    fetchUnderlyings(),
+  ]);
+
+  if (!Array.isArray(config.assets)) {
+    throw new Error('Native Core Pool config returned no assets array');
+  }
+
+  return config.assets
+    .map((asset) => {
+      if (
+        typeof asset.symbol !== 'string' ||
+        !Number.isInteger(asset.asset_id)
+      ) {
+        return null;
+      }
+
+      const symbol = utils.formatSymbol(asset.symbol);
+      const tvlUsd = calculateTvlUsd(
+        asset.realtime_tvl_amount,
+        asset.balance_decimals,
+        pricesByAssetId.get(asset.asset_id)
+      );
+
+      if (!tvlUsd) return null;
+
+      const underlying = underlyingsByAssetId.get(asset.asset_id);
+      const underlyingToken =
+        underlying?.symbol === symbol ? underlying.address : undefined;
+
+      return {
+        pool: `native-core-clob-${asset.asset_id}`,
+        chain: utils.formatChain(POOL_CHAIN),
+        project: 'native-core-clob',
+        symbol,
+        tvlUsd,
+        apyBase: formatApy(asset.projected_apy),
+        ...(underlyingToken && {
+          underlyingTokens: [underlyingToken],
+          searchTokenOverride: underlyingToken,
+        }),
+        token: null,
+        poolMeta: 'Native Pool',
+        url: 'https://app.native.org',
+      };
+    })
+    .filter(Boolean);
+};
+
+module.exports = {
+  protocolId: '8535',
+  timetravel: false,
+  apy,
+  url: 'https://native.org/',
+};

--- a/src/adaptors/utils.js
+++ b/src/adaptors/utils.js
@@ -252,6 +252,12 @@ exports.formatChain = (chain) => {
       chain.toLowerCase() === 'hyperliquid')
   )
     return 'Hyperliquid L1';
+  if (
+    chain &&
+    (chain.toLowerCase() === 'native_core' ||
+      chain.toLowerCase() === 'native-core')
+  )
+    return 'Native Core';
   if (chain && chain.toLowerCase() === 'core') return 'CORE';
   if (chain && chain.toLowerCase() === 'cronos_zkevm') return 'Cronos zkEVM';
   if (chain && chain.toLowerCase() === 'echelon_initia')


### PR DESCRIPTION
## Summary
- Adds a yield adaptor for Native Pool (earn products) on Native Core (`src/adaptors/native-core-clob`). This is a separate product from the existing EVM Credit Pool adaptor (`native-credit-pool`) which will be retiring soon.
- Attaches the adaptor to the already-listed protocol **Native Core CLOB** (`slug: native-core-clob`, `protocolId: '8535'`)

Pools are built from Native APIs (no on-chain LP/receipt token):
- `POST https://api-ui.native.org/api/v3/earn` `{ type: "config" }` — ticker, `projected_apy`, `realtime_tvl_amount`
- `POST https://api.native.org/info` `{ type: "markPrices" }` — USD mark (`usd_atoms`, 1e8)
- `GET https://api-ui.native.org/api/v3/core/registry` — canonical EVM `underlyingTokens` by `assetId` (prefer Ethereum, then BSC / Base / Arbitrum / Morph)

`apyBase = projected_apy * 100`. `token` is `null` (Core earn is a ledger, not an ERC-20 vault). Display symbols stay Core tickers (USDT / ETH), not wrapped names (USD₮0 / WETH).

## Test plan
- [x] `cd src/adaptors && npm_config_adapter=native-core-clob npm test`
  - Result: **48/48 passed** (1 suite). Jest 0.179s after setup, ~6.8s wall clock.
  - 6 pools: WBTC, ETH, USDC, QQQB, USDT, BNB. Snapshot TVL ~$4.99M. Highest `apyBase` 19.72% (ETH).
- [x] Confirm `chain` is `Native Core` (not `CORE`)
  - Result: all 6 pools emit `chain: 'Native Core'`.
- [x] Confirm `project` / pool ids are `native-core-clob-*` and `protocolId` is `'8535'`
  - Result: `project: 'native-core-clob'`, ids `native-core-clob-{1,2,3,4,6,44}`, listing tests pass against `api.llama.fi/protocols` id `8535`.
- [x] Confirm this does not change `native-credit-pool` output
  - Result: no edits under `src/adaptors/native-credit-pool`. Diff is `src/adaptors/native-core-clob/` plus `formatChain` mapping in `src/adaptors/utils.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added yield tracking for Native Core CLOB pools, including total value locked (TVL) and projected APY.
  - Added support for retrieving pool, pricing, and token information from Native APIs.
  - Added per-asset TVL calculations using real-time balances and prices.
  - Added Native Core chain name recognition and display formatting.
  - Added support for displaying configured underlying token information where available.
  - Invalid pool or asset data is excluded from results to maintain accurate listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->