### PR TITLE
add stackingdao yields + fix zest v1/v2 adapters

### DIFF
--- a/src/adaptors/stackingdao/index.js
+++ b/src/adaptors/stackingdao/index.js
@@ -37,6 +37,7 @@ const TXS_PER_PAGE = 50;
 const MAX_TX_PAGES = 4;
 
 const RETRY = { retries: 3, delayMs: 8000 };
+const HTTP = { timeout: 30000 };
 
 const toNum = (cv) => {
   const v = cvToValue(cv);
@@ -47,16 +48,16 @@ const toNum = (cv) => {
 const readOnly = async (contract, fn, tip) => {
   const [address, name] = contract.split('.');
   const url = `${HIRO}/v2/contracts/call-read/${address}/${name}/${fn}${tip ? `?tip=${tip.replace(/^0x/, '')}` : ''}`;
-  const { data } = await withRetry(() => axios.post(url, { sender: DEPLOYER, arguments: [] }), RETRY);
+  const { data } = await withRetry(() => axios.post(url, { sender: DEPLOYER, arguments: [] }, HTTP), RETRY);
   if (!data.okay) throw new Error(`${contract}.${fn} failed: ${data.cause}`);
   return toNum(hexToCV(data.result));
 };
 
-const getJson = async (path) => (await withRetry(() => axios.get(`${HIRO}${path}`), RETRY)).data;
+const getJson = async (path) => (await withRetry(() => axios.get(`${HIRO}${path}`, HTTP), RETRY)).data;
 
 const fetchPrices = async () => {
   const { data } = await withRetry(
-    () => axios.get(getPriceApiUrl('/prices/current/coingecko:blockstack,coingecko:bitcoin')),
+    () => axios.get(getPriceApiUrl('/prices/current/coingecko:blockstack,coingecko:bitcoin'), HTTP),
     RETRY
   );
   return {
@@ -119,7 +120,7 @@ const fetchLatestClaimBatch = async () => {
 };
 
 const fetchLstApys = async (prices) => {
-  const [batch, pox, commissionBps, ststxbtcBps, ststxBps, supplyBtcV1, supplyBtcV2, supplyStstx, ratio] =
+  const [batch, pox, commissionBps, ststxbtcBps, ststxBps, supplyBtcV1, supplyBtcV2, supplyStstx, liveEscrow, ratio] =
     await Promise.all([
       fetchLatestClaimBatch(),
       getJson('/v2/pox'),
@@ -129,11 +130,12 @@ const fetchLstApys = async (prices) => {
       readOnly(CONTRACTS.ststxbtcTokenV1, 'get-total-supply'),
       readOnly(CONTRACTS.ststxbtcTokenV2, 'get-total-supply'),
       readOnly(CONTRACTS.ststxToken, 'get-total-supply'),
+      readOnly(CONTRACTS.dataStx, 'get-live-escrow'),
       readOnly(CONTRACTS.dataStx, 'get-stx-per-ststx'),
     ]);
 
   const ststxbtcStx = (supplyBtcV1 + supplyBtcV2) / 1e6;
-  const ststxStx = (supplyStstx / 1e6) * (ratio / 1e6);
+  const ststxStx = (Math.max(supplyStstx - liveEscrow, 0) / 1e6) * (ratio / 1e6);
   const result = { ststxStx, ststxbtcStx, ststx: null, ststxbtc: null };
   if (!batch || batch.grossSats <= 0 || ststxStx <= 0 || ststxbtcStx <= 0) return result;
 
@@ -157,7 +159,10 @@ const resolveTipAtBurnHeight = async (burnHeight) => {
   for (let offset = 0; offset <= 10; offset++) {
     const candidates = offset === 0 ? [burnHeight] : [burnHeight + offset, burnHeight - offset];
     for (const h of candidates) {
-      const data = await getJson(`/extended/v2/burn-blocks/${h}/blocks?limit=1`).catch(() => null);
+      const data = await getJson(`/extended/v2/burn-blocks/${h}/blocks?limit=1`).catch((error) => {
+        if (error.response?.status === 404) return null;
+        throw error;
+      });
       const block = data?.results?.[0];
       if (block?.index_block_hash) return block.index_block_hash;
     }
@@ -166,13 +171,14 @@ const resolveTipAtBurnHeight = async (burnHeight) => {
 };
 
 const fetchStbtc = async (prices) => {
-  const [pox, ratioNow, supplyNow] = await Promise.all([
+  const [pox, ratioNow, supplyNow, pendingShares] = await Promise.all([
     getJson('/v2/pox'),
     readOnly(CONTRACTS.dataStbtc, 'get-sbtc-per-stbtc'),
     readOnly(CONTRACTS.stbtcToken, 'get-total-supply'),
+    readOnly(CONTRACTS.dataStbtc, 'get-pending-shares'),
   ]);
   const ratio = ratioNow / 1e8;
-  const supply = supplyNow / 1e8;
+  const supply = Math.max(supplyNow - pendingShares, 0) / 1e8;
   const result = { tvlUsd: supply * ratio * prices.btc, apy: null };
   if (supply < STBTC_MIN_SUPPLY) return result;
 

--- a/src/adaptors/stackingdao/index.js
+++ b/src/adaptors/stackingdao/index.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const { hexToCV, cvToValue } = require('@stacks/transactions');
-const { getPriceApiUrl } = require('../utils');
+const { getPriceApiUrl, withRetry } = require('../utils');
 
 const HIRO = 'https://api.hiro.so';
 const DEPLOYER = 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG';
@@ -36,18 +36,7 @@ const STBTC_MIN_SUPPLY = 0.001;
 const TXS_PER_PAGE = 50;
 const MAX_TX_PAGES = 4;
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const withRetry = async (fn, attempts = 4) => {
-  for (let i = 0; ; i++) {
-    try {
-      return await fn();
-    } catch (error) {
-      if (error.response?.status !== 429 || i >= attempts - 1) throw error;
-      await sleep(10000 * (i + 1));
-    }
-  }
-};
+const RETRY = { retries: 3, delayMs: 8000 };
 
 const toNum = (cv) => {
   const v = cvToValue(cv);
@@ -58,16 +47,17 @@ const toNum = (cv) => {
 const readOnly = async (contract, fn, tip) => {
   const [address, name] = contract.split('.');
   const url = `${HIRO}/v2/contracts/call-read/${address}/${name}/${fn}${tip ? `?tip=${tip.replace(/^0x/, '')}` : ''}`;
-  const { data } = await withRetry(() => axios.post(url, { sender: DEPLOYER, arguments: [] }));
+  const { data } = await withRetry(() => axios.post(url, { sender: DEPLOYER, arguments: [] }), RETRY);
   if (!data.okay) throw new Error(`${contract}.${fn} failed: ${data.cause}`);
   return toNum(hexToCV(data.result));
 };
 
-const getJson = async (path) => (await withRetry(() => axios.get(`${HIRO}${path}`))).data;
+const getJson = async (path) => (await withRetry(() => axios.get(`${HIRO}${path}`), RETRY)).data;
 
 const fetchPrices = async () => {
-  const { data } = await axios.get(
-    getPriceApiUrl('/prices/current/coingecko:blockstack,coingecko:bitcoin')
+  const { data } = await withRetry(
+    () => axios.get(getPriceApiUrl('/prices/current/coingecko:blockstack,coingecko:bitcoin')),
+    RETRY
   );
   return {
     stx: data.coins['coingecko:blockstack'].price,

--- a/src/adaptors/stackingdao/index.js
+++ b/src/adaptors/stackingdao/index.js
@@ -1,0 +1,269 @@
+const axios = require('axios');
+const { hexToCV, cvToValue } = require('@stacks/transactions');
+const { getPriceApiUrl } = require('../utils');
+
+const HIRO = 'https://api.hiro.so';
+const DEPLOYER = 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG';
+const CHAIN = 'Stacks';
+const URL = 'https://app.stackingdao.com';
+
+const CONTRACTS = {
+  ststxToken: `${DEPLOYER}.ststx-token`,
+  ststxbtcTokenV1: `${DEPLOYER}.ststxbtc-token`,
+  ststxbtcTokenV2: `${DEPLOYER}.ststxbtc-token-v2`,
+  stbtcToken: `${DEPLOYER}.stbtc-token`,
+  dataStx: `${DEPLOYER}.data-stx-v2`,
+  dataStbtc: `${DEPLOYER}.data-stbtc-v1`,
+  rewards: `${DEPLOYER}.rewards-pox5-v1`,
+  poolData: `${DEPLOYER}.data-pools-stbtc-v1`,
+};
+
+const SIGNER_MANAGERS = [
+  'stacking-dao',
+  'juicy-stake',
+  'xverse',
+  'infstones',
+  'hashkey',
+  'foundry',
+  'blockdaemon',
+].map((slug) => `${DEPLOYER}.signer-manager-${slug}-v1`);
+
+const CYCLES_PER_YEAR = 25;
+const REWARD_PHASE_PAYOUT_FRACTION = 0.95;
+const BURN_BLOCKS_PER_DAY = 144;
+const STBTC_WINDOWS_DAYS = [30, 14, 7];
+const STBTC_MIN_SUPPLY = 0.001;
+const TXS_PER_PAGE = 50;
+const MAX_TX_PAGES = 4;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const withRetry = async (fn, attempts = 4) => {
+  for (let i = 0; ; i++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (error.response?.status !== 429 || i >= attempts - 1) throw error;
+      await sleep(10000 * (i + 1));
+    }
+  }
+};
+
+const toNum = (cv) => {
+  const v = cvToValue(cv);
+  if (typeof v === 'object' && v !== null && 'value' in v) return Number(v.value);
+  return Number(v);
+};
+
+const readOnly = async (contract, fn, tip) => {
+  const [address, name] = contract.split('.');
+  const url = `${HIRO}/v2/contracts/call-read/${address}/${name}/${fn}${tip ? `?tip=${tip.replace(/^0x/, '')}` : ''}`;
+  const { data } = await withRetry(() => axios.post(url, { sender: DEPLOYER, arguments: [] }));
+  if (!data.okay) throw new Error(`${contract}.${fn} failed: ${data.cause}`);
+  return toNum(hexToCV(data.result));
+};
+
+const getJson = async (path) => (await withRetry(() => axios.get(`${HIRO}${path}`))).data;
+
+const fetchPrices = async () => {
+  const { data } = await axios.get(
+    getPriceApiUrl('/prices/current/coingecko:blockstack,coingecko:bitcoin')
+  );
+  return {
+    stx: data.coins['coingecko:blockstack'].price,
+    btc: data.coins['coingecko:bitcoin'].price,
+  };
+};
+
+const fetchManagerClaims = async (manager) => {
+  const rows = [];
+  for (let page = 0; page < MAX_TX_PAGES; page++) {
+    const data = await getJson(
+      `/extended/v2/addresses/${manager}/transactions?limit=${TXS_PER_PAGE}&offset=${page * TXS_PER_PAGE}`
+    );
+    const results = data.results || [];
+    rows.push(...results.map((row) => row.tx || row));
+    if (results.length < TXS_PER_PAGE) break;
+  }
+  return rows
+    .filter(
+      (tx) =>
+        tx.tx_type === 'contract_call' &&
+        tx.tx_status === 'success' &&
+        tx.contract_call?.function_name === 'claim-rewards'
+    )
+    .map((tx) => ({
+      txId: tx.tx_id,
+      burnHeight: tx.burn_block_height,
+      cycleId: Number(tx.contract_call.function_args?.[1]?.repr.replace(/^u/, '')),
+    }))
+    .filter((claim) => Number.isFinite(claim.cycleId));
+};
+
+const claimedSats = async (txId) => {
+  const data = await getJson(`/extended/v1/tx/${txId}?event_limit=100`);
+  return (data.events || []).reduce((sum, event) => {
+    const asset = event.asset;
+    if (event.event_type !== 'fungible_token_asset' || !asset) return sum;
+    if (!asset.asset_id.toLowerCase().includes('sbtc-token')) return sum;
+    if (asset.recipient !== CONTRACTS.rewards) return sum;
+    return sum + Number(asset.amount);
+  }, 0);
+};
+
+const fetchLatestClaimBatch = async () => {
+  const claims = [];
+  for (const manager of SIGNER_MANAGERS) {
+    claims.push(...(await fetchManagerClaims(manager)));
+  }
+  if (!claims.length) return null;
+  const cycleId = Math.max(...claims.map((c) => c.cycleId));
+  const batch = claims.filter((c) => c.cycleId === cycleId);
+  let grossSats = 0;
+  for (const claim of batch) grossSats += await claimedSats(claim.txId);
+  return {
+    cycleId,
+    grossSats,
+    burnHeight: Math.max(...batch.map((c) => c.burnHeight)),
+  };
+};
+
+const fetchLstApys = async (prices) => {
+  const [batch, pox, commissionBps, ststxbtcBps, ststxBps, supplyBtcV1, supplyBtcV2, supplyStstx, ratio] =
+    await Promise.all([
+      fetchLatestClaimBatch(),
+      getJson('/v2/pox'),
+      readOnly(CONTRACTS.poolData, 'get-pool-commission'),
+      readOnly(CONTRACTS.rewards, 'get-ststxbtc-bps'),
+      readOnly(CONTRACTS.rewards, 'get-ststx-bps'),
+      readOnly(CONTRACTS.ststxbtcTokenV1, 'get-total-supply'),
+      readOnly(CONTRACTS.ststxbtcTokenV2, 'get-total-supply'),
+      readOnly(CONTRACTS.ststxToken, 'get-total-supply'),
+      readOnly(CONTRACTS.dataStx, 'get-stx-per-ststx'),
+    ]);
+
+  const ststxbtcStx = (supplyBtcV1 + supplyBtcV2) / 1e6;
+  const ststxStx = (supplyStstx / 1e6) * (ratio / 1e6);
+  const result = { ststxStx, ststxbtcStx, ststx: null, ststxbtc: null };
+  if (!batch || batch.grossSats <= 0 || ststxStx <= 0 || ststxbtcStx <= 0) return result;
+
+  const cycleStart = pox.first_burnchain_block_height + batch.cycleId * pox.reward_cycle_length;
+  const elapsed = Math.min(Math.max(batch.burnHeight - cycleStart, 0), pox.reward_phase_block_length);
+  const progress = elapsed / pox.reward_phase_block_length;
+  if (progress <= 0) return result;
+
+  const multiplier = Math.max(REWARD_PHASE_PAYOUT_FRACTION / progress, 1);
+  const netPerCycle = batch.grossSats * multiplier * (1 - commissionBps / 1e4);
+  const annualBtc = (netPerCycle * CYCLES_PER_YEAR) / 1e8;
+  const apy = (bps, poolStx) => (((annualBtc * bps) / 1e4) * prices.btc) / (poolStx * prices.stx) * 100;
+  const compound = (simple) => (Math.pow(1 + simple / 100 / CYCLES_PER_YEAR, CYCLES_PER_YEAR) - 1) * 100;
+
+  result.ststxbtc = apy(ststxbtcBps, ststxbtcStx);
+  result.ststx = compound(apy(ststxBps, ststxStx));
+  return result;
+};
+
+const resolveTipAtBurnHeight = async (burnHeight) => {
+  for (let offset = 0; offset <= 10; offset++) {
+    const candidates = offset === 0 ? [burnHeight] : [burnHeight + offset, burnHeight - offset];
+    for (const h of candidates) {
+      const data = await getJson(`/extended/v2/burn-blocks/${h}/blocks?limit=1`).catch(() => null);
+      const block = data?.results?.[0];
+      if (block?.index_block_hash) return block.index_block_hash;
+    }
+  }
+  return null;
+};
+
+const fetchStbtc = async (prices) => {
+  const [pox, ratioNow, supplyNow] = await Promise.all([
+    getJson('/v2/pox'),
+    readOnly(CONTRACTS.dataStbtc, 'get-sbtc-per-stbtc'),
+    readOnly(CONTRACTS.stbtcToken, 'get-total-supply'),
+  ]);
+  const ratio = ratioNow / 1e8;
+  const supply = supplyNow / 1e8;
+  const result = { tvlUsd: supply * ratio * prices.btc, apy: null };
+  if (supply < STBTC_MIN_SUPPLY) return result;
+
+  for (const days of STBTC_WINDOWS_DAYS) {
+    const tip = await resolveTipAtBurnHeight(pox.current_burnchain_block_height - days * BURN_BLOCKS_PER_DAY);
+    if (!tip) continue;
+    const [ratioPast, supplyPast] = await Promise.all([
+      readOnly(CONTRACTS.dataStbtc, 'get-sbtc-per-stbtc', tip).catch(() => null),
+      readOnly(CONTRACTS.stbtcToken, 'get-total-supply', tip).catch(() => null),
+    ]);
+    if (!ratioPast || ratioPast <= 0 || ratioNow <= ratioPast) continue;
+    if (!supplyPast || supplyPast / 1e8 < STBTC_MIN_SUPPLY) continue;
+    const apy = (Math.pow(ratioNow / ratioPast, 365 / days) - 1) * 100;
+    if (Number.isFinite(apy) && apy > 0 && apy < 100) {
+      result.apy = apy;
+      break;
+    }
+  }
+  return result;
+};
+
+const apy = async () => {
+  const prices = await fetchPrices();
+  const empty = { ststx: null, ststxbtc: null };
+  const [lst, stbtc] = await Promise.all([
+    fetchLstApys(prices).catch((error) => {
+      console.log(`stackingdao: LST read failed: ${error.message}`);
+      return empty;
+    }),
+    fetchStbtc(prices).catch((error) => {
+      console.log(`stackingdao: stBTC read failed: ${error.message}`);
+      return { apy: null };
+    }),
+  ]);
+
+  const pools = [];
+  if (lst.ststx !== null) {
+    pools.push({
+      pool: `${CONTRACTS.ststxToken}-stackingdao-${CHAIN}`.toLowerCase(),
+      chain: CHAIN,
+      project: 'stackingdao',
+      symbol: 'stSTX',
+      tvlUsd: lst.ststxStx * prices.stx,
+      apyBase: lst.ststx,
+      underlyingTokens: ['coingecko:blockstack'],
+      token: CONTRACTS.ststxToken,
+      url: `${URL}/stack`,
+    });
+  }
+  if (lst.ststxbtc !== null) {
+    pools.push({
+      pool: `${CONTRACTS.ststxbtcTokenV2}-stackingdao-${CHAIN}`.toLowerCase(),
+      chain: CHAIN,
+      project: 'stackingdao',
+      symbol: 'stSTXbtc',
+      tvlUsd: lst.ststxbtcStx * prices.stx,
+      apyBase: lst.ststxbtc,
+      underlyingTokens: ['coingecko:blockstack'],
+      token: CONTRACTS.ststxbtcTokenV2,
+      url: `${URL}/stack`,
+    });
+  }
+  if (stbtc.apy !== null) {
+    pools.push({
+      pool: `${CONTRACTS.stbtcToken}-stackingdao-${CHAIN}`.toLowerCase(),
+      chain: CHAIN,
+      project: 'stackingdao',
+      symbol: 'stBTC',
+      tvlUsd: stbtc.tvlUsd,
+      apyBase: stbtc.apy,
+      underlyingTokens: ['SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token'],
+      token: CONTRACTS.stbtcToken,
+      url: `${URL}/stack`,
+    });
+  }
+  return pools;
+};
+
+module.exports = {
+  protocolId: '3934',
+  timetravel: false,
+  apy,
+  url: URL,
+};

--- a/src/adaptors/zest-v1/index.js
+++ b/src/adaptors/zest-v1/index.js
@@ -1,11 +1,14 @@
 const axios = require('axios');
-const { getPriceApiUrl } = require('../utils');
+const { getPriceApiUrl, withRetry } = require('../utils');
 const {
-  callReadOnlyFunction,
+  ClarityType,
   contractPrincipalCV,
+  cvToHex,
+  hexToCV,
 } = require('@stacks/transactions');
-const { StacksMainnet } = require('@stacks/network');
 
+const HIRO = 'https://api.hiro.so';
+const RETRY = { retries: 3, delayMs: 8000 };
 const DEPLOYER = 'SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N';
 const POOL_READ = 'pool-read-v2-1-4';
 const POOL_VAULT = `${DEPLOYER}.pool-vault`;
@@ -65,9 +68,25 @@ const ASSETS = [
   },
 ];
 
+const unwrap = (cv) => {
+  if (cv.type === ClarityType.ResponseOk) return unwrap(cv.value);
+  if (cv.type === ClarityType.Tuple) return cv.data;
+  return cv;
+};
+
+const readOnly = async (contractName, functionName, functionArgs = []) => {
+  const url = `${HIRO}/v2/contracts/call-read/${DEPLOYER}/${contractName}/${functionName}`;
+  const { data } = await withRetry(
+    () => axios.post(url, { sender: DEPLOYER, arguments: functionArgs.map(cvToHex) }),
+    RETRY
+  );
+  if (!data.okay) throw new Error(`${contractName}.${functionName} failed: ${data.cause}`);
+  return unwrap(hexToCV(data.result));
+};
+
 const fetchPrices = async () => {
   const keys = [...new Set(ASSETS.flatMap((a) => a.priceKeys))].join(',');
-  const { data } = await axios.get(getPriceApiUrl(`/prices/current/${keys}`));
+  const { data } = await withRetry(() => axios.get(getPriceApiUrl(`/prices/current/${keys}`)), RETRY);
   return data.coins;
 };
 
@@ -79,8 +98,9 @@ const getPrice = (prices, priceKeys) => {
 };
 
 const fetchVaultBalances = async () => {
-  const { data } = await axios.get(
-    `https://api.hiro.so/extended/v1/address/${POOL_VAULT}/balances`
+  const { data } = await withRetry(
+    () => axios.get(`${HIRO}/extended/v1/address/${POOL_VAULT}/balances`),
+    RETRY
   );
   const balances = { stx: Number(data.stx.balance) };
   Object.entries(data.fungible_tokens || {}).forEach(([assetId, tokenData]) => {
@@ -89,17 +109,9 @@ const fetchVaultBalances = async () => {
   return balances;
 };
 
-const fetchReserve = async (network, asset) => {
+const fetchReserve = async (asset) => {
   const [address, name] = asset.contract.split('.');
-  const result = await callReadOnlyFunction({
-    contractAddress: DEPLOYER,
-    contractName: POOL_READ,
-    functionName: 'get-reserve-data',
-    functionArgs: [contractPrincipalCV(address, name)],
-    network,
-    senderAddress: DEPLOYER,
-  });
-  const data = result.data;
+  const data = await readOnly(POOL_READ, 'get-reserve-data', [contractPrincipalCV(address, name)]);
   return {
     supplyApy: Number(data['current-liquidity-rate'].value) / RATE_SCALE,
     borrowApy: Number(data['current-variable-borrow-rate'].value) / RATE_SCALE,
@@ -109,7 +121,6 @@ const fetchReserve = async (network, asset) => {
 };
 
 const apy = async () => {
-  const network = new StacksMainnet();
   const [prices, balances] = await Promise.all([fetchPrices(), fetchVaultBalances()]);
   const pools = [];
 
@@ -120,7 +131,7 @@ const apy = async () => {
         console.log(`Skipping ${asset.symbol}: price not available`);
         continue;
       }
-      const reserve = await fetchReserve(network, asset);
+      const reserve = await fetchReserve(asset);
       const scale = Math.pow(10, asset.decimals);
       const available = (asset.native ? balances.stx : balances[asset.contract] || 0) / scale;
       const totalBorrowUsd = (reserve.totalBorrowed / scale) * price;

--- a/src/adaptors/zest-v1/index.js
+++ b/src/adaptors/zest-v1/index.js
@@ -1,169 +1,156 @@
-const { callReadOnlyFunction, contractPrincipalCV } = require("@stacks/transactions");
-const { StacksMainnet } = require("@stacks/network");
+const axios = require('axios');
+const { getPriceApiUrl } = require('../utils');
+const {
+  callReadOnlyFunction,
+  contractPrincipalCV,
+} = require('@stacks/transactions');
+const { StacksMainnet } = require('@stacks/network');
 
-const STACKS_COINGECKO = {
-  STX: 'coingecko:blockstack',
-  stSTX: 'coingecko:blockstack',
-  aeUSDC: 'coingecko:usd-coin',
-  DIKO: 'coingecko:arkadiko-protocol',
+const DEPLOYER = 'SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N';
+const POOL_READ = 'pool-read-v2-1-4';
+const POOL_VAULT = `${DEPLOYER}.pool-vault`;
+const CHAIN = 'Stacks';
+const URL = 'https://app.zestprotocol.com/market/legacy';
+const RATE_SCALE = 1e6;
+
+const ASSETS = [
+  {
+    symbol: 'sBTC',
+    contract: 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token',
+    decimals: 8,
+    priceKeys: ['stacks:SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token', 'coingecko:bitcoin'],
+  },
+  {
+    symbol: 'STX',
+    contract: `${DEPLOYER}.wstx`,
+    decimals: 6,
+    priceKeys: ['coingecko:blockstack'],
+    native: true,
+  },
+  {
+    symbol: 'stSTX',
+    contract: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token',
+    decimals: 6,
+    priceKeys: ['stacks:SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token', 'coingecko:blockstack'],
+  },
+  {
+    symbol: 'stSTXbtc',
+    contract: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststxbtc-token-v2',
+    decimals: 6,
+    priceKeys: ['stacks:SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststxbtc-token-v2::ststxbtc', 'coingecko:blockstack'],
+  },
+  {
+    symbol: 'aeUSDC',
+    contract: 'SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc',
+    decimals: 6,
+    priceKeys: ['stacks:SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc', 'coingecko:usd-coin'],
+  },
+  {
+    symbol: 'USDh',
+    contract: 'SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.usdh-token-v1',
+    decimals: 8,
+    priceKeys: ['stacks:SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.usdh-token-v1', 'coingecko:usd-coin'],
+  },
+  {
+    symbol: 'USDT',
+    contract: 'SP2XD7417HGPRTREMKF748VNEQPDRR0RMANB7X1NK.token-susdt',
+    decimals: 8,
+    priceKeys: ['stacks:SP2XD7417HGPRTREMKF748VNEQPDRR0RMANB7X1NK.token-susdt', 'coingecko:tether'],
+  },
+  {
+    symbol: 'ALEX',
+    contract: 'SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex',
+    decimals: 8,
+    priceKeys: ['stacks:SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex', 'coingecko:alexgo'],
+  },
+];
+
+const fetchPrices = async () => {
+  const keys = [...new Set(ASSETS.flatMap((a) => a.priceKeys))].join(',');
+  const { data } = await axios.get(getPriceApiUrl(`/prices/current/${keys}`));
+  return data.coins;
 };
 
-const AssetConfig = {
-    stSTX: {
-        assetAddress: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG',
-        contractName: 'ststx-token',
-        oracleContractName: 'ststx-oracle-v1-4',
-        decimals: 6,
-    },
-    aeUSDC: {
-        assetAddress: 'SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K',
-        contractName: 'token-aeusdc',
-        oracleContractName: 'aeusdc-oracle-v1-0',
-        decimals: 6,
-    },
-    STX: {
-        assetAddress: 'SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N',
-        contractName: 'wstx',
-        oracleContractName: 'stx-oracle-v1-3',
-        decimals: 6,
-    },
-    DIKO: {
-        assetAddress: 'SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR',
-        contractName: 'arkadiko-token',
-        oracleContractName: 'diko-oracle-v1-1',
-        decimals: 6,
-    },
-}
-
-async function getAddressBalances() {
-    try {
-        const response = await fetch(
-            "https://api.hiro.so/extended/v1/address/SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N.pool-vault/balances",
-            {
-                method: "GET",
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            }
-        );
-
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const data = await response.json();
-        
-        // Process the balances
-        const processedBalances = {
-            STX: Number(data.stx.balance) / Math.pow(10, 6) // STX has 6 decimals
-        };
-
-        // Process fungible tokens
-        Object.entries(data.fungible_tokens).forEach(([fullTokenId, tokenData]) => {
-            const [addressAndContract] = fullTokenId.split('::');
-            const [address, contractName] = addressAndContract.split('.');
-
-            const matchingAsset = Object.entries(AssetConfig).find(([_, config]) => 
-                config.assetAddress === address && config.contractName === contractName
-            );
-
-            if (matchingAsset) {
-                const [assetKey, config] = matchingAsset;
-                processedBalances[assetKey] = Number(tokenData.balance) / Math.pow(10, config.decimals);
-            }
-        });
-
-        return processedBalances;
-    } catch (error) {
-        console.error('Error fetching address balances:', error);
-    }
-}
-
-async function getZestPools() {
-  try {
-    const contractAddress = 'SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N';
-    const network = new StacksMainnet();
-
-    const chain = 'Stacks';
-
-    const pools = [];
-
-    const balances = await getAddressBalances();
-    // Reserve data
-    for (const [assetKey, asset] of Object.entries(AssetConfig)) {
-        const {assetAddress, contractName, oracleContractName} = asset;
-
-        let supplyApy = 0.0;
-        let tvlUsd = 0.0;
-        let price = 0.0;
-
-        // Fetch yields
-        try {
-            const reserveData = await callReadOnlyFunction({
-                contractAddress,
-                contractName: 'pool-read-v1-3-2',
-                functionName: 'get-reserve-data',
-                network,
-                functionArgs: [
-                    contractPrincipalCV(assetAddress, contractName),
-                ],
-                senderAddress: contractAddress,
-            });
-
-            if (reserveData.data) {
-                supplyApy = Number(reserveData.data['current-liquidity-rate'].value) / 1000000;
-                borrowApy = Number(reserveData.data['current-variable-borrow-rate'].value) / 1000000;
-                ltv = Number(reserveData.data['base-ltv-as-collateral'].value) / 100000000;
-            }
-
-        } catch (error) {
-            console.log(`Error fetching yields: ${error}`);
-        }
-
-        try {
-            const result = await callReadOnlyFunction({
-                contractAddress,
-                contractName: oracleContractName,
-                functionName: 'get-price',
-                network,
-                functionArgs: [],
-                senderAddress: contractAddress,
-            });
-
-            // Get price and calculate TVL using the balance
-            price = Number(result.value) / 100000000;
-            const assetBalance = balances[assetKey] || 0;
-            tvlUsd = price * assetBalance;
-            
-        } catch (error) {
-            console.log(`Error fetching TVL: ${error}`);
-        }
-
-        pools.push({
-            pool: `${assetAddress}.${contractName}-${chain}`.toLowerCase(),
-            chain: chain,
-            project: 'zest-v1',
-            symbol: assetKey,
-            tvlUsd: tvlUsd,
-            apyBase: supplyApy,
-            underlyingTokens: [STACKS_COINGECKO[assetKey] || `${assetAddress}.${contractName}`],
-        });
-    }
-  return pools;
-  } catch (e) {
-    if (e instanceof Error) {
-        if (!e.message.includes('UnwrapFailure')) {
-            console.log(e);
-        }
-    }
-    return [];
+const getPrice = (prices, priceKeys) => {
+  for (const key of priceKeys) {
+    if (prices[key]?.price) return prices[key].price;
   }
+  return null;
+};
 
-}
+const fetchVaultBalances = async () => {
+  const { data } = await axios.get(
+    `https://api.hiro.so/extended/v1/address/${POOL_VAULT}/balances`
+  );
+  const balances = { stx: Number(data.stx.balance) };
+  Object.entries(data.fungible_tokens || {}).forEach(([assetId, tokenData]) => {
+    balances[assetId.split('::')[0]] = Number(tokenData.balance);
+  });
+  return balances;
+};
+
+const fetchReserve = async (network, asset) => {
+  const [address, name] = asset.contract.split('.');
+  const result = await callReadOnlyFunction({
+    contractAddress: DEPLOYER,
+    contractName: POOL_READ,
+    functionName: 'get-reserve-data',
+    functionArgs: [contractPrincipalCV(address, name)],
+    network,
+    senderAddress: DEPLOYER,
+  });
+  const data = result.data;
+  return {
+    supplyApy: Number(data['current-liquidity-rate'].value) / RATE_SCALE,
+    borrowApy: Number(data['current-variable-borrow-rate'].value) / RATE_SCALE,
+    ltv: Number(data['base-ltv-as-collateral'].value) / 1e8,
+    totalBorrowed: Number(data['total-borrows-variable'].value) + Number(data['total-borrows-stable'].value),
+  };
+};
+
+const apy = async () => {
+  const network = new StacksMainnet();
+  const [prices, balances] = await Promise.all([fetchPrices(), fetchVaultBalances()]);
+  const pools = [];
+
+  for (const asset of ASSETS) {
+    try {
+      const price = getPrice(prices, asset.priceKeys);
+      if (!price) {
+        console.log(`Skipping ${asset.symbol}: price not available`);
+        continue;
+      }
+      const reserve = await fetchReserve(network, asset);
+      const scale = Math.pow(10, asset.decimals);
+      const available = (asset.native ? balances.stx : balances[asset.contract] || 0) / scale;
+      const totalBorrowUsd = (reserve.totalBorrowed / scale) * price;
+      const tvlUsd = available * price;
+
+      pools.push({
+        pool: `${asset.contract}-${CHAIN}`.toLowerCase(),
+        chain: CHAIN,
+        project: 'zest-v1',
+        symbol: asset.symbol,
+        tvlUsd,
+        apyBase: reserve.supplyApy,
+        apyBaseBorrow: reserve.borrowApy,
+        totalSupplyUsd: tvlUsd + totalBorrowUsd,
+        totalBorrowUsd,
+        ltv: reserve.ltv,
+        underlyingTokens: [asset.contract],
+        token: asset.contract,
+        url: URL,
+      });
+    } catch (error) {
+      console.log(`Error processing ${asset.symbol}: ${error.message}`);
+    }
+  }
+  return pools;
+};
 
 module.exports = {
   protocolId: '4420',
   timetravel: false,
-  apy: getZestPools,
-  url: 'https://app.zestprotocol.com/assets',
+  apy,
+  url: URL,
 };

--- a/src/adaptors/zest-v1/index.js
+++ b/src/adaptors/zest-v1/index.js
@@ -9,6 +9,7 @@ const {
 
 const HIRO = 'https://api.hiro.so';
 const RETRY = { retries: 3, delayMs: 8000 };
+const HTTP = { timeout: 30000 };
 const DEPLOYER = 'SP2VCQJGH7PHP2DJK7Z0V48AGBHQAW3R3ZW1QF4N';
 const POOL_READ = 'pool-read-v2-1-4';
 const POOL_VAULT = `${DEPLOYER}.pool-vault`;
@@ -77,7 +78,7 @@ const unwrap = (cv) => {
 const readOnly = async (contractName, functionName, functionArgs = []) => {
   const url = `${HIRO}/v2/contracts/call-read/${DEPLOYER}/${contractName}/${functionName}`;
   const { data } = await withRetry(
-    () => axios.post(url, { sender: DEPLOYER, arguments: functionArgs.map(cvToHex) }),
+    () => axios.post(url, { sender: DEPLOYER, arguments: functionArgs.map(cvToHex) }, HTTP),
     RETRY
   );
   if (!data.okay) throw new Error(`${contractName}.${functionName} failed: ${data.cause}`);
@@ -86,7 +87,7 @@ const readOnly = async (contractName, functionName, functionArgs = []) => {
 
 const fetchPrices = async () => {
   const keys = [...new Set(ASSETS.flatMap((a) => a.priceKeys))].join(',');
-  const { data } = await withRetry(() => axios.get(getPriceApiUrl(`/prices/current/${keys}`)), RETRY);
+  const { data } = await withRetry(() => axios.get(getPriceApiUrl(`/prices/current/${keys}`), HTTP), RETRY);
   return data.coins;
 };
 
@@ -99,7 +100,7 @@ const getPrice = (prices, priceKeys) => {
 
 const fetchVaultBalances = async () => {
   const { data } = await withRetry(
-    () => axios.get(`${HIRO}/extended/v1/address/${POOL_VAULT}/balances`),
+    () => axios.get(`${HIRO}/extended/v1/address/${POOL_VAULT}/balances`, HTTP),
     RETRY
   );
   const balances = { stx: Number(data.stx.balance) };

--- a/src/adaptors/zest-v2/index.js
+++ b/src/adaptors/zest-v2/index.js
@@ -3,36 +3,35 @@ const { getPriceApiUrl } = require('../utils');
 const {
   callReadOnlyFunction,
   contractPrincipalCV,
+  cvToValue,
 } = require('@stacks/transactions');
 const { StacksMainnet } = require('@stacks/network');
 
 const DEPLOYER = 'SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7';
+const DATA_READER = 'v0-5-data';
+const SBTC = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token';
+const CHAIN = 'Stacks';
+const URL = 'https://app.zestprotocol.com/market/main';
 
 const POOLS = [
   {
     symbol: 'STX',
     vaultContract: 'v0-vault-stx',
-    assetAddress: 'SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7',
-    contractName: 'wstx',
+    underlying: `${DEPLOYER}.wstx`,
     decimals: 6,
     priceKeys: ['coingecko:blockstack'],
   },
   {
     symbol: 'sBTC',
     vaultContract: 'v0-vault-sbtc',
-    assetAddress: 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4',
-    contractName: 'sbtc-token',
+    underlying: SBTC,
     decimals: 8,
-    priceKeys: [
-      'stacks:SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token',
-      'coingecko:bitcoin',
-    ],
+    priceKeys: [`stacks:${SBTC}`, 'coingecko:bitcoin'],
   },
   {
     symbol: 'stSTX',
     vaultContract: 'v0-vault-ststx',
-    assetAddress: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG',
-    contractName: 'ststx-token',
+    underlying: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token',
     decimals: 6,
     priceKeys: [
       'stacks:SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token',
@@ -40,10 +39,9 @@ const POOLS = [
     ],
   },
   {
-    symbol: 'USDC',
+    symbol: 'USDCx',
     vaultContract: 'v0-vault-usdc',
-    assetAddress: 'SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE',
-    contractName: 'usdcx',
+    underlying: 'SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx',
     decimals: 6,
     priceKeys: [
       'stacks:SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx',
@@ -51,10 +49,9 @@ const POOLS = [
     ],
   },
   {
-    symbol: 'USDH',
+    symbol: 'USDh',
     vaultContract: 'v0-vault-usdh',
-    assetAddress: 'SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG',
-    contractName: 'usdh-token-v1',
+    underlying: 'SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.usdh-token-v1',
     decimals: 8,
     priceKeys: [
       'stacks:SPN5AKG35QZSK2M8GAMR4AFX45659RJHDW353HSG.usdh-token-v1',
@@ -64,113 +61,116 @@ const POOLS = [
   {
     symbol: 'stSTXbtc',
     vaultContract: 'v0-vault-ststxbtc',
-    assetAddress: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG',
-    contractName: 'ststxbtc-token-v2',
+    underlying: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststxbtc-token-v2',
     decimals: 6,
     priceKeys: [
-      'stacks:SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststxbtc-token-v2',
+      'stacks:SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststxbtc-token-v2::ststxbtc',
       'coingecko:blockstack',
     ],
   },
+  {
+    symbol: 'stBTC',
+    vaultContract: 'v0-vault-stbtc',
+    underlying: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.stbtc-token',
+    decimals: 8,
+    priceKeys: [`stacks:${SBTC}`, 'coingecko:bitcoin'],
+  },
 ];
 
-async function fetchPrices() {
-  const keys = [...new Set(POOLS.flatMap((p) => p.priceKeys))].join(',');
-  const url = getPriceApiUrl(`/prices/current/${keys}`);
-  const { data } = await axios.get(url);
-  return data.coins;
-}
+const toNum = (cv) => {
+  const v = cvToValue(cv);
+  if (typeof v === 'object' && v !== null && 'value' in v) return Number(v.value);
+  return Number(v);
+};
 
-function getPrice(prices, priceKeys) {
+const readOnly = async (network, contractName, functionName, functionArgs = []) =>
+  callReadOnlyFunction({
+    contractAddress: DEPLOYER,
+    contractName,
+    functionName,
+    functionArgs,
+    network,
+    senderAddress: DEPLOYER,
+  });
+
+const fetchPrices = async () => {
+  const keys = [...new Set(POOLS.flatMap((p) => p.priceKeys))].join(',');
+  const { data } = await axios.get(getPriceApiUrl(`/prices/current/${keys}`));
+  return data.coins;
+};
+
+const getPrice = (prices, priceKeys) => {
   for (const key of priceKeys) {
-    if (prices[key]?.price) return { price: prices[key].price, key };
+    if (prices[key]?.price) return prices[key].price;
   }
   return null;
-}
+};
 
-async function fetchApys(pool, network) {
-  const result = await callReadOnlyFunction({
-    contractAddress: DEPLOYER,
-    contractName: 'v0-1-data',
-    functionName: 'get-asset-apys',
-    network,
-    functionArgs: [contractPrincipalCV(pool.assetAddress, pool.contractName)],
-    senderAddress: DEPLOYER,
-  });
+const fetchRates = async (network, pool) => {
+  const [address, name] = pool.underlying.split('.');
+  const result = await readOnly(network, DATA_READER, 'get-asset-apys', [
+    contractPrincipalCV(address, name),
+  ]);
+  const data = result.value.data;
+  return {
+    supplyApy: Number(data['supply-apy'].value) / 100,
+    borrowApy: Number(data['borrow-apy'].value) / 100,
+  };
+};
 
-  const tupleData = result.value.data;
-  const supplyApy = Number(tupleData['supply-apy'].value) / 100;
-  const borrowApy = Number(tupleData['borrow-apy'].value) / 100;
+const fetchVault = async (network, pool) => {
+  const [assets, debt] = await Promise.all([
+    readOnly(network, pool.vaultContract, 'get-total-assets'),
+    readOnly(network, pool.vaultContract, 'get-debt'),
+  ]);
+  const scale = Math.pow(10, pool.decimals);
+  return { totalAssets: toNum(assets) / scale, totalBorrowed: toNum(debt) / scale };
+};
 
-  return { supplyApy, borrowApy };
-}
+const apy = async () => {
+  const network = new StacksMainnet();
+  const prices = await fetchPrices();
+  const results = [];
 
-async function fetchTotalAssets(pool, network) {
-  const result = await callReadOnlyFunction({
-    contractAddress: DEPLOYER,
-    contractName: pool.vaultContract,
-    functionName: 'get-total-assets',
-    network,
-    functionArgs: [],
-    senderAddress: DEPLOYER,
-  });
-
-  const rawAmount = Number(result.value.value);
-  return rawAmount / Math.pow(10, pool.decimals);
-}
-
-async function getZestV2Pools() {
-  try {
-    const network = new StacksMainnet();
-    const chain = 'Stacks';
-
-    const prices = await fetchPrices();
-
-    const results = [];
-
-    for (const pool of POOLS) {
-      try {
-        const priceResult = getPrice(prices, pool.priceKeys);
-        if (!priceResult) {
-          console.log(`Skipping ${pool.symbol}: price not available`);
-          continue;
-        }
-
-        const [apys, totalAssets] = await Promise.all([
-          fetchApys(pool, network),
-          fetchTotalAssets(pool, network),
-        ]);
-
-        const tvlUsd = totalAssets * priceResult.price;
-
-        results.push({
-          pool: `${DEPLOYER}.${pool.vaultContract}-${chain}`.toLowerCase(),
-          chain: chain,
-          project: 'zest-v2',
-          symbol: pool.symbol,
-          tvlUsd: tvlUsd,
-          apyBase: apys.supplyApy,
-          apyBaseBorrow: apys.borrowApy,
-          borrowToken: `${pool.assetAddress}.${pool.contractName}`,
-          underlyingTokens: [`${pool.assetAddress}.${pool.contractName}`],
-          token: `${pool.assetAddress}.${pool.contractName}`,
-          url: 'https://app.zestprotocol.com/market/main',
-        });
-      } catch (error) {
-        console.log(`Error processing pool ${pool.symbol}: ${error.message}`);
+  for (const pool of POOLS) {
+    try {
+      const price = getPrice(prices, pool.priceKeys);
+      if (!price) {
+        console.log(`Skipping ${pool.symbol}: price not available`);
+        continue;
       }
-    }
+      const [rates, vault] = await Promise.all([
+        fetchRates(network, pool),
+        fetchVault(network, pool),
+      ]);
+      const totalSupplyUsd = vault.totalAssets * price;
+      const totalBorrowUsd = vault.totalBorrowed * price;
 
-    return results;
-  } catch (error) {
-    console.log(`Error in getZestV2Pools: ${error.message}`);
-    return [];
+      results.push({
+        pool: `${DEPLOYER}.${pool.vaultContract}-${CHAIN}`.toLowerCase(),
+        chain: CHAIN,
+        project: 'zest-v2',
+        symbol: pool.symbol,
+        tvlUsd: totalSupplyUsd - totalBorrowUsd,
+        apyBase: rates.supplyApy,
+        apyBaseBorrow: rates.borrowApy,
+        totalSupplyUsd,
+        totalBorrowUsd,
+        borrowToken: pool.underlying,
+        underlyingTokens: [pool.underlying],
+        token: pool.underlying,
+        url: URL,
+      });
+    } catch (error) {
+      console.log(`Error processing pool ${pool.symbol}: ${error.message}`);
+    }
   }
-}
+  return results;
+};
 
 module.exports = {
   protocolId: '7449',
   timetravel: false,
-  apy: getZestV2Pools,
-  url: 'https://app.zestprotocol.com/market/main',
+  apy,
+  url: URL,
 };

--- a/src/adaptors/zest-v2/index.js
+++ b/src/adaptors/zest-v2/index.js
@@ -9,8 +9,10 @@ const {
 
 const HIRO = 'https://api.hiro.so';
 const RETRY = { retries: 3, delayMs: 8000 };
+const HTTP = { timeout: 30000 };
 const DEPLOYER = 'SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7';
-const DATA_READER = 'v0-5-data';
+const DATA_READER = `${DEPLOYER}.v0-5-data`;
+const STBTC_DATA = 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.data-stbtc-v1';
 const SBTC = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token';
 const CHAIN = 'Stacks';
 const URL = 'https://app.zestprotocol.com/market/main';
@@ -76,6 +78,7 @@ const POOLS = [
     underlying: 'SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.stbtc-token',
     decimals: 8,
     priceKeys: [`stacks:${SBTC}`, 'coingecko:bitcoin'],
+    exchangeRate: { contract: STBTC_DATA, fn: 'get-sbtc-per-stbtc', scale: 1e8 },
   },
 ];
 
@@ -85,20 +88,27 @@ const unwrap = (cv) => {
   return cv;
 };
 
-const readOnly = async (contractName, functionName, functionArgs = []) => {
-  const url = `${HIRO}/v2/contracts/call-read/${DEPLOYER}/${contractName}/${functionName}`;
+const readOnly = async (contractId, functionName, functionArgs = []) => {
+  const [address, name] = contractId.split('.');
+  const url = `${HIRO}/v2/contracts/call-read/${address}/${name}/${functionName}`;
   const { data } = await withRetry(
-    () => axios.post(url, { sender: DEPLOYER, arguments: functionArgs.map(cvToHex) }),
+    () => axios.post(url, { sender: DEPLOYER, arguments: functionArgs.map(cvToHex) }, HTTP),
     RETRY
   );
-  if (!data.okay) throw new Error(`${contractName}.${functionName} failed: ${data.cause}`);
+  if (!data.okay) throw new Error(`${contractId}.${functionName} failed: ${data.cause}`);
   return unwrap(hexToCV(data.result));
 };
 
 const fetchPrices = async () => {
   const keys = [...new Set(POOLS.flatMap((p) => p.priceKeys))].join(',');
-  const { data } = await withRetry(() => axios.get(getPriceApiUrl(`/prices/current/${keys}`)), RETRY);
+  const { data } = await withRetry(() => axios.get(getPriceApiUrl(`/prices/current/${keys}`), HTTP), RETRY);
   return data.coins;
+};
+
+const fetchExchangeRate = async (pool) => {
+  if (!pool.exchangeRate) return 1;
+  const { contract, fn, scale } = pool.exchangeRate;
+  return Number((await readOnly(contract, fn)).value) / scale;
 };
 
 const getPrice = (prices, priceKeys) => {
@@ -121,8 +131,8 @@ const fetchRates = async (pool) => {
 
 const fetchVault = async (pool) => {
   const [assets, debt] = await Promise.all([
-    readOnly(pool.vaultContract, 'get-total-assets'),
-    readOnly(pool.vaultContract, 'get-debt'),
+    readOnly(`${DEPLOYER}.${pool.vaultContract}`, 'get-total-assets'),
+    readOnly(`${DEPLOYER}.${pool.vaultContract}`, 'get-debt'),
   ]);
   const scale = Math.pow(10, pool.decimals);
   return { totalAssets: Number(assets.value) / scale, totalBorrowed: Number(debt.value) / scale };
@@ -134,15 +144,17 @@ const apy = async () => {
 
   for (const pool of POOLS) {
     try {
-      const price = getPrice(prices, pool.priceKeys);
-      if (!price) {
+      const basePrice = getPrice(prices, pool.priceKeys);
+      if (!basePrice) {
         console.log(`Skipping ${pool.symbol}: price not available`);
         continue;
       }
-      const [rates, vault] = await Promise.all([
+      const [rates, vault, exchangeRate] = await Promise.all([
         fetchRates(pool),
         fetchVault(pool),
+        fetchExchangeRate(pool),
       ]);
+      const price = basePrice * exchangeRate;
       const totalSupplyUsd = vault.totalAssets * price;
       const totalBorrowUsd = vault.totalBorrowed * price;
 

--- a/src/adaptors/zest-v2/index.js
+++ b/src/adaptors/zest-v2/index.js
@@ -1,12 +1,14 @@
 const axios = require('axios');
-const { getPriceApiUrl } = require('../utils');
+const { getPriceApiUrl, withRetry } = require('../utils');
 const {
-  callReadOnlyFunction,
+  ClarityType,
   contractPrincipalCV,
-  cvToValue,
+  cvToHex,
+  hexToCV,
 } = require('@stacks/transactions');
-const { StacksMainnet } = require('@stacks/network');
 
+const HIRO = 'https://api.hiro.so';
+const RETRY = { retries: 3, delayMs: 8000 };
 const DEPLOYER = 'SP1A27KFY4XERQCCRCARCYD1CC5N7M6688BSYADJ7';
 const DATA_READER = 'v0-5-data';
 const SBTC = 'SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token';
@@ -77,25 +79,25 @@ const POOLS = [
   },
 ];
 
-const toNum = (cv) => {
-  const v = cvToValue(cv);
-  if (typeof v === 'object' && v !== null && 'value' in v) return Number(v.value);
-  return Number(v);
+const unwrap = (cv) => {
+  if (cv.type === ClarityType.ResponseOk) return unwrap(cv.value);
+  if (cv.type === ClarityType.Tuple) return cv.data;
+  return cv;
 };
 
-const readOnly = async (network, contractName, functionName, functionArgs = []) =>
-  callReadOnlyFunction({
-    contractAddress: DEPLOYER,
-    contractName,
-    functionName,
-    functionArgs,
-    network,
-    senderAddress: DEPLOYER,
-  });
+const readOnly = async (contractName, functionName, functionArgs = []) => {
+  const url = `${HIRO}/v2/contracts/call-read/${DEPLOYER}/${contractName}/${functionName}`;
+  const { data } = await withRetry(
+    () => axios.post(url, { sender: DEPLOYER, arguments: functionArgs.map(cvToHex) }),
+    RETRY
+  );
+  if (!data.okay) throw new Error(`${contractName}.${functionName} failed: ${data.cause}`);
+  return unwrap(hexToCV(data.result));
+};
 
 const fetchPrices = async () => {
   const keys = [...new Set(POOLS.flatMap((p) => p.priceKeys))].join(',');
-  const { data } = await axios.get(getPriceApiUrl(`/prices/current/${keys}`));
+  const { data } = await withRetry(() => axios.get(getPriceApiUrl(`/prices/current/${keys}`)), RETRY);
   return data.coins;
 };
 
@@ -106,29 +108,27 @@ const getPrice = (prices, priceKeys) => {
   return null;
 };
 
-const fetchRates = async (network, pool) => {
+const fetchRates = async (pool) => {
   const [address, name] = pool.underlying.split('.');
-  const result = await readOnly(network, DATA_READER, 'get-asset-apys', [
+  const data = await readOnly(DATA_READER, 'get-asset-apys', [
     contractPrincipalCV(address, name),
   ]);
-  const data = result.value.data;
   return {
     supplyApy: Number(data['supply-apy'].value) / 100,
     borrowApy: Number(data['borrow-apy'].value) / 100,
   };
 };
 
-const fetchVault = async (network, pool) => {
+const fetchVault = async (pool) => {
   const [assets, debt] = await Promise.all([
-    readOnly(network, pool.vaultContract, 'get-total-assets'),
-    readOnly(network, pool.vaultContract, 'get-debt'),
+    readOnly(pool.vaultContract, 'get-total-assets'),
+    readOnly(pool.vaultContract, 'get-debt'),
   ]);
   const scale = Math.pow(10, pool.decimals);
-  return { totalAssets: toNum(assets) / scale, totalBorrowed: toNum(debt) / scale };
+  return { totalAssets: Number(assets.value) / scale, totalBorrowed: Number(debt.value) / scale };
 };
 
 const apy = async () => {
-  const network = new StacksMainnet();
   const prices = await fetchPrices();
   const results = [];
 
@@ -140,8 +140,8 @@ const apy = async () => {
         continue;
       }
       const [rates, vault] = await Promise.all([
-        fetchRates(network, pool),
-        fetchVault(network, pool),
+        fetchRates(pool),
+        fetchVault(pool),
       ]);
       const totalSupplyUsd = vault.totalAssets * price;
       const totalBorrowUsd = vault.totalBorrowed * price;


### PR DESCRIPTION
Adds a stackingdao adapter and fixes both Zest adapters, which were reading retired contracts and missing most of the current markets.

stackingdao (new, protocolId 3934)

- stSTX and stSTXbtc APY are derived on chain the same way the protocol's own API computes them: the latest claim-rewards batch paid into rewards-pox5-v1, projected to a full cycle, net of pool commission, annualized over 25 cycles, split by the rewards contract's bps and divided by each pool's STX value. Output matches the protocol API within 0.02 points.
- stBTC APY is trailing growth of the sbtc-per-stbtc ratio over a 30/14/7 day window at historical tips. The pool is omitted rather than estimated if no window is measurable.
- 36 requests per run, all through Hiro's public API with the shared withRetry helper.

zest-v2

- Reads the current v0-5-data reader instead of v0-1-data, which does not know the stBTC market.
- Adds the stBTC vault, priced as sBTC since the token has no feed and is backed ~1:1.
- Fixes the stSTXbtc price key to the suffixed form the coins server resolves.
- Adds totalSupplyUsd and totalBorrowUsd so the borrow side shows. tvlUsd is supply minus borrows.

zest-v1

- Reads pool-read-v2-1-4 instead of the retired pool-read-v1-3-2.
- Covers all eight priced assets including sBTC, which is most of its TVL, and prices via the coins API instead of Zest oracles.

All three pass the harness. Contract reads go through axios so withRetry can act on 429s, which Hiro's public API returns readily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added yield data for StackingDAO on Stacks, covering stSTX, stSTXbtc, and stBTC pools.
  * Added stBTC market data to Zest v2.
  * Added borrowing metrics, supply and borrowing totals, and loan-to-value data to Zest pool results.

* **Improvements**
  * Updated supported assets across Zest integrations, including sBTC, stSTXbtc, USDh, USDT, ALEX, and USDCx.
  * Improved reliability of on-chain data and asset pricing.
  * Updated Zest’s link to its legacy market page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->