### PR TITLE
fix merkl dbl count

### DIFF
--- a/src/adaptors/merkl/merkl-additional-reward.js
+++ b/src/adaptors/merkl/merkl-additional-reward.js
@@ -20,6 +20,9 @@ const ancestorsOf = (campaign, campaignsById) => {
     ancestors.add(String(parentId));
     parentId = campaignsById[String(parentId)]?.parentCampaignId;
   }
+  if (campaign.rootCampaignId != null) {
+    ancestors.add(String(campaign.rootCampaignId));
+  }
   return ancestors;
 };
 
@@ -53,7 +56,9 @@ const toCandidate = (opportunity, campaignsById) => ({
   isBorrow: isBorrowAction(opportunity),
   rewardTokens: [
     ...new Set(
-      opportunity.rewardsRecord?.breakdowns.map((x) => x.token.address) || []
+      opportunity.rewardsRecord?.breakdowns
+        ?.map((x) => x.token?.address)
+        .filter(Boolean) || []
     ),
   ],
   contributions: toContributions(opportunity, campaignsById),
@@ -99,20 +104,24 @@ const resolveRewards = (candidates) => {
   return entry;
 };
 
+const PAGE_SIZE = 100;
+const MAX_PAGES = 50;
+
 const fetchLiveOpportunities = async (protocolId) => {
   const opportunities = [];
-  for (let page = 0; ; page++) {
+  for (let page = 0; page < MAX_PAGES; page++) {
     const data = await merklGet('/v4/opportunities', {
       params: {
         mainProtocolId: protocolId,
         status: 'LIVE',
         campaigns: true,
-        items: 100,
+        items: PAGE_SIZE,
         page,
       },
     });
-    if (!data.length) break;
+    if (!Array.isArray(data) || !data.length) break;
     opportunities.push(...data);
+    if (data.length < PAGE_SIZE) break;
   }
   return opportunities;
 };

--- a/src/adaptors/merkl/merkl-additional-reward.js
+++ b/src/adaptors/merkl/merkl-additional-reward.js
@@ -1,127 +1,176 @@
 const { networks, chainAliases } = require('./config');
-const { merklGet, getRewardApr } = require('./merkl-client');
+const { merklGet, getCampaignAprBreakdowns } = require('./merkl-client');
 
-const getChainAliases = (canonical) =>
-  chainAliases[canonical] || [canonical];
+const getChainAliases = (canonical) => chainAliases[canonical] || [canonical];
 
 // Merkl exposes an `action` per opportunity: BORROW, LEND, POOL, HOLD, DROP.
 // BORROW campaigns reward borrowers (→ apyRewardBorrow); everything else
 // rewards holders/suppliers/LPs (→ apyReward).
-const isBorrowAction = (pool) => pool.action === 'BORROW';
+const isBorrowAction = (opportunity) => opportunity.action === 'BORROW';
 
-const mergeEntries = (a, b) => {
-  const merged = {
-    rewardTokens: [
-      ...new Set([
-        ...(a.rewardTokens || []),
-        ...(b.rewardTokens || []),
-      ]),
-    ],
-  };
-  if (a.apyReward !== undefined || b.apyReward !== undefined) {
-    merged.apyReward = (a.apyReward || 0) + (b.apyReward || 0);
+// Merkl spawns a sub-campaign for every forwarder it recognises (Curve gauges,
+// Pendle SY/LP/YT, vault wrappers) and lists each one as its own opportunity
+// with its own APR. A sub-campaign re-reports a slice of its parent's budget,
+// so a pool must not count a campaign together with one of its ancestors.
+// Sibling sub-campaigns are distinct slices and do add up.
+const ancestorsOf = (campaign, campaignsById) => {
+  const ancestors = new Set();
+  let parentId = campaign.parentCampaignId;
+  while (parentId != null && !ancestors.has(String(parentId))) {
+    ancestors.add(String(parentId));
+    parentId = campaignsById[String(parentId)]?.parentCampaignId;
   }
-  if (a.apyRewardBorrow !== undefined || b.apyRewardBorrow !== undefined) {
-    merged.apyRewardBorrow =
-      (a.apyRewardBorrow || 0) + (b.apyRewardBorrow || 0);
-  }
-  return merged;
+  return ancestors;
 };
 
-exports.addMerklRewardApy = async (
-  pools,
-  protocolId,
-  poolAddressGetter,
-) => {
-  try {
-    let merklPools = [];
-    let pageI = 0;
-
-    while (true) {
-      let data;
-      try {
-        data = await merklGet('/v4/opportunities', {
-          params: {
-            mainProtocolId: protocolId,
-            status: 'LIVE',
-            items: 100,
-            page: pageI,
+const toContributions = (opportunity, campaignsById) => {
+  const byCampaignId = Object.fromEntries(
+    (opportunity.campaigns || []).map((c) => [String(c.campaignId), c])
+  );
+  const breakdowns = getCampaignAprBreakdowns(opportunity);
+  if (!breakdowns.length) {
+    return opportunity.apr > 0
+      ? [
+          {
+            id: `opportunity:${opportunity.id}`,
+            ancestors: new Set(),
+            apr: opportunity.apr,
           },
-        });
-      } catch (err) {
-        console.log(`failed to fetch Merkl data for ${protocolId}: ${err}`);
-        break;
-      }
+        ]
+      : [];
+  }
+  return breakdowns.map(({ campaignId, apr }) => {
+    const campaign = byCampaignId[String(campaignId)];
+    return {
+      id: campaign ? String(campaign.id) : `campaign:${campaignId}`,
+      ancestors: campaign ? ancestorsOf(campaign, campaignsById) : new Set(),
+      apr,
+    };
+  });
+};
 
-      if (data.length === 0) break;
-      merklPools.push(...data);
-      pageI++;
+const toCandidate = (opportunity, campaignsById) => ({
+  isBorrow: isBorrowAction(opportunity),
+  rewardTokens: [
+    ...new Set(
+      opportunity.rewardsRecord?.breakdowns.map((x) => x.token.address) || []
+    ),
+  ],
+  contributions: toContributions(opportunity, campaignsById),
+});
+
+// Token-address matching exists for adapters keyed on a receipt token (an
+// aToken, a vault share) whose Merkl identifier is a market hash. POOL
+// campaigns list their LP's constituent tokens instead, which a constituent
+// holder does not earn, so those only ever match by identifier.
+const positionTokens = (opportunity, candidate) => {
+  if (candidate.isBorrow || opportunity.action === 'POOL') return [];
+  const id = opportunity.identifier.toLowerCase();
+  return [
+    ...new Set(
+      (opportunity.tokens || [])
+        .map((t) => t?.address?.toLowerCase())
+        .filter((addr) => addr && addr !== id)
+    ),
+  ];
+};
+
+// Each campaign counts once per pool. A campaign is skipped when one of its
+// ancestors is already counted, and it evicts any already-counted descendant.
+const resolveRewards = (candidates) => {
+  const chosen = new Map();
+  for (const candidate of candidates) {
+    for (const contribution of candidate.contributions) {
+      if (chosen.has(contribution.id)) continue;
+      if ([...contribution.ancestors].some((id) => chosen.has(id))) continue;
+      for (const [id, existing] of chosen) {
+        if (existing.ancestors.has(contribution.id)) chosen.delete(id);
+      }
+      chosen.set(contribution.id, { ...contribution, candidate });
+    }
+  }
+  const entry = { rewardTokens: [] };
+  for (const { apr, candidate } of chosen.values()) {
+    const field = candidate.isBorrow ? 'apyRewardBorrow' : 'apyReward';
+    entry[field] = (entry[field] || 0) + apr;
+    entry.rewardTokens.push(...candidate.rewardTokens);
+  }
+  entry.rewardTokens = [...new Set(entry.rewardTokens)];
+  return entry;
+};
+
+const fetchLiveOpportunities = async (protocolId) => {
+  const opportunities = [];
+  for (let page = 0; ; page++) {
+    const data = await merklGet('/v4/opportunities', {
+      params: {
+        mainProtocolId: protocolId,
+        status: 'LIVE',
+        campaigns: true,
+        items: 100,
+        page,
+      },
+    });
+    if (!data.length) break;
+    opportunities.push(...data);
+  }
+  return opportunities;
+};
+
+exports.addMerklRewardApy = async (pools, protocolId, poolAddressGetter) => {
+  try {
+    let opportunities;
+    try {
+      opportunities = await fetchLiveOpportunities(protocolId);
+    } catch (err) {
+      console.log(`failed to fetch Merkl data for ${protocolId}: ${err}`);
+      return pools;
     }
 
-    const merklPoolsMap = {};
+    const byIdentifier = {};
+    const byPositionToken = {};
     for (const canonical of Object.values(networks)) {
       for (const alias of getChainAliases(canonical)) {
-        merklPoolsMap[alias] = {};
+        byIdentifier[alias] = {};
+        byPositionToken[alias] = {};
       }
     }
 
-    merklPools.forEach(pool => {
-      const canonical = networks[pool.chainId];
-      if (!canonical) {
-        return;
-      }
+    const campaignsById = Object.fromEntries(
+      opportunities.flatMap((o) =>
+        (o.campaigns || []).map((c) => [String(c.id), c])
+      )
+    );
 
-      const isBorrow = isBorrowAction(pool);
-      const rewardTokens = [
-        ...new Set(
-          pool.rewardsRecord?.breakdowns.map(x => x.token.address) || [],
-        ),
-      ];
-      const apr = getRewardApr(pool);
-      const entry = isBorrow
-        ? { apyRewardBorrow: apr, rewardTokens }
-        : { apyReward: apr, rewardTokens };
-      const id = pool.identifier.toLowerCase();
-      // Also index under each token address so adapters keying on a
-      // receipt/wrapper token (e.g. an aToken or vault share) can match
-      // an opportunity whose primary identifier is the underlying market.
-      // Skipped for BORROW campaigns: their tokens[] may list debt or
-      // collateral assets that don't represent the rewarded position.
-      const tokenAddrs = isBorrow
-        ? []
-        : [...new Set(
-            (pool.tokens || [])
-              .map(t => t?.address?.toLowerCase())
-              .filter(Boolean),
-          )];
+    for (const opportunity of opportunities) {
+      const canonical = networks[opportunity.chainId];
+      if (!canonical) continue;
+
+      const candidate = toCandidate(opportunity, campaignsById);
+      const id = opportunity.identifier.toLowerCase();
+      const tokens = positionTokens(opportunity, candidate);
       for (const alias of getChainAliases(canonical)) {
-        const existingId = merklPoolsMap[alias][id];
-        merklPoolsMap[alias][id] = existingId
-          ? mergeEntries(existingId, entry)
-          : entry;
-        for (const addr of tokenAddrs) {
-          const existing = merklPoolsMap[alias][addr];
-          if (!existing) {
-            merklPoolsMap[alias][addr] = entry;
-          } else if (existing !== entry) {
-            // Multiple Merkl campaigns share this token address (e.g. a
-            // supply + boost pair, or a supply + borrow campaign on the
-            // same market). Combine APRs per side and union reward tokens
-            // so no campaign silently wins the fallback match.
-            merklPoolsMap[alias][addr] = mergeEntries(existing, entry);
-          }
+        (byIdentifier[alias][id] ||= []).push(candidate);
+        for (const addr of tokens) {
+          (byPositionToken[alias][addr] ||= []).push(candidate);
         }
       }
-    });
+    }
 
-    return pools.map(pool => {
-      const poolAddress = poolAddressGetter ? poolAddressGetter(pool) : pool.pool;
-      const merklRewards = merklPoolsMap[pool.chain.toLowerCase()]?.[poolAddress.toLowerCase()];
+    return pools.map((pool) => {
+      const poolAddress = (
+        poolAddressGetter ? poolAddressGetter(pool) : pool.pool
+      ).toLowerCase();
+      const chain = pool.chain.toLowerCase();
+      // An identifier match is positive evidence the pool is the rewarded
+      // position; a token-address match is a guess, so it only fills in when
+      // nothing is identified by the address.
+      const candidates =
+        byIdentifier[chain]?.[poolAddress] ||
+        byPositionToken[chain]?.[poolAddress];
+      if (!candidates) return pool;
 
-      if (!merklRewards) {
-        return pool;
-      }
-
+      const merklRewards = resolveRewards(candidates);
       const updated = { ...pool };
       let changed = false;
 
@@ -133,7 +182,7 @@ exports.addMerklRewardApy = async (
         updated.apyRewardBorrow = merklRewards.apyRewardBorrow;
         changed = true;
       }
-      if (changed && merklRewards.rewardTokens?.length) {
+      if (changed && merklRewards.rewardTokens.length) {
         updated.rewardTokens = [
           ...new Set([
             ...(pool.rewardTokens || []),
@@ -147,10 +196,7 @@ exports.addMerklRewardApy = async (
         ((merklRewards.apyReward > 0 && pool.apyReward) ||
           (merklRewards.apyRewardBorrow > 0 && pool.apyRewardBorrow))
       ) {
-        console.log(
-          'pool already has matching apy reward field(s)',
-          pool.pool,
-        );
+        console.log('pool already has matching apy reward field(s)', pool.pool);
       }
       return changed ? updated : pool;
     });

--- a/src/adaptors/merkl/merkl-client.js
+++ b/src/adaptors/merkl/merkl-client.js
@@ -33,20 +33,21 @@ const TARGET_APR_DISTRIBUTION_TYPES = new Set([
   'AAVE_V4_NET_APR',
 ]);
 
-const getRewardApr = (opportunity) => {
-  const breakdowns = opportunity.aprRecord?.breakdowns?.filter(
-    (x) => x.type === 'CAMPAIGN'
-  );
-  if (!breakdowns?.length) return opportunity.apr;
-
-  return breakdowns.reduce(
-    (acc, x) =>
-      acc +
-      (TARGET_APR_DISTRIBUTION_TYPES.has(x.distributionType)
+const getCampaignAprBreakdowns = (opportunity) =>
+  (opportunity.aprRecord?.breakdowns || [])
+    .filter((x) => x.type === 'CAMPAIGN')
+    .map((x) => ({
+      campaignId: x.identifier,
+      apr: TARGET_APR_DISTRIBUTION_TYPES.has(x.distributionType)
         ? Math.max(0, x.value - (opportunity.nativeApr || 0))
-        : x.value),
-    0
-  );
+        : x.value,
+    }));
+
+const getRewardApr = (opportunity) => {
+  const breakdowns = getCampaignAprBreakdowns(opportunity);
+  if (!breakdowns.length) return opportunity.apr;
+
+  return breakdowns.reduce((acc, x) => acc + x.apr, 0);
 };
 
 module.exports = {
@@ -54,4 +55,5 @@ module.exports = {
   getMerklHeaders,
   merklGet,
   getRewardApr,
+  getCampaignAprBreakdowns,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Merkl reward APR calculations by accounting for campaign-level contributions and ancestry.
  * Prevented parent and child campaigns from being counted twice.
  * Applied more accurate matching for pool and borrow positions.
  * Deduplicated reward tokens and separated borrow versus non-borrow APRs.
  * Preserved existing pool data when campaign information cannot be fetched.
  * Improved campaign data retrieval by stopping safely after short responses or a maximum number of pages.
  * Added a fallback to opportunity APR values when campaign-level breakdowns are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->