### PR TITLE
feat: add ai-hedge yield adapter

### DIFF
--- a/src/adaptors/ai-hedge/index.js
+++ b/src/adaptors/ai-hedge/index.js
@@ -1,0 +1,40 @@
+const utils = require('../utils');
+
+const LISTINGS_URL =
+  process.env.AI_HEDGE_LISTINGS_URL ||
+  'https://server-yield.aihedge.finance/api/v1/listings/vaults';
+
+async function apy() {
+  const vaults = await utils.getData(LISTINGS_URL);
+
+  return vaults
+    .filter((v) => v.tvlUsd > 0)
+    .map((v) => {
+      const pool = {
+        pool: `${v.vault}-${v.chain}`.toLowerCase(),
+        chain: utils.formatChain(v.chain),
+        project: 'ai-hedge',
+        symbol: v.symbol,
+        tvlUsd: v.tvlUsd,
+        apyBase:
+          typeof v.apyBase === 'number' && Number.isFinite(v.apyBase)
+            ? v.apyBase
+            : 0,
+        underlyingTokens: [v.underlying.toLowerCase()],
+        url: v.depositUrl,
+      };
+
+      if (typeof v.apy7d === 'number' && Number.isFinite(v.apy7d)) {
+        pool.apyBase7d = v.apy7d;
+      }
+
+      return pool;
+    });
+}
+
+module.exports = {
+  protocolId: '8288',
+  timetravel: false,
+  apy,
+  url: 'https://dapp.aihedge.finance/yield',
+};

--- a/src/adaptors/ai-hedge/index.js
+++ b/src/adaptors/ai-hedge/index.js
@@ -4,6 +4,10 @@ const LISTINGS_URL =
   process.env.AI_HEDGE_LISTINGS_URL ||
   'https://server-yield.aihedge.finance/api/v1/listings/vaults';
 
+/**
+ * Fetches and formats active AI Hedge ERC-4626 vault yield and TVL metrics.
+ * @returns {Promise<Array<{pool: string, chain: string, project: string, symbol: string, tvlUsd: number, apyBase: number, apyBase7d?: number, underlyingTokens: string[], url: string}>>} Array of formatted pool objects for DeFiLlama
+ */
 async function apy() {
   const vaults = await utils.getData(LISTINGS_URL);
 


### PR DESCRIPTION
### Protocol
- **Name:** AI Hedge
- **Protocol Slug:** `ai-hedge` (Protocol ID: 8288)
- **Website:** https://dapp.aihedge.finance/yield

### Changes
- Add yield adapter for AI Hedge ERC-4626 multi-strategy vaults on Ethereum and Base.
- Metrics are sourced directly from the protocol's public endpoint `https://server-yield.aihedge.finance/api/v1/listings/vaults`.
- APYs reflect realized net returns based on rolling share-price changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for displaying AI Hedge vault listings.
  - Excludes vaults with zero total value locked.
  - Shows normalized pool information with validated current and seven-day APY values.
  - Added AI Hedge protocol metadata and a link to its platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->