### PR TITLE
feat: add RHEA DEX, lending and staking yield adapters

### DIFF
--- a/src/adaptors/rhea-dex/index.js
+++ b/src/adaptors/rhea-dex/index.js
@@ -1,0 +1,6 @@
+const data = require('../rhea-lend/data');
+const { getPools } = require('./pools');
+
+const apy = () => getPools(data);
+
+module.exports = { protocolId: '541', timetravel: false, apy };

--- a/src/adaptors/rhea-dex/math.js
+++ b/src/adaptors/rhea-dex/math.js
@@ -1,0 +1,88 @@
+const Big = require('bignumber.js');
+
+const FeeBig = Big.clone({ DECIMAL_PLACES: 340 });
+
+function finiteBig(value, name) {
+  const isAcceptedType =
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    Big.isBigNumber(value);
+  const isUnsafeInteger =
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    !Number.isSafeInteger(value);
+  if (
+    !isAcceptedType ||
+    isUnsafeInteger ||
+    (typeof value === 'string' && value.trim() === '')
+  ) {
+    throw new Error(`Invalid ${name}`);
+  }
+
+  const number = new Big(value);
+  if (!number.isFinite()) throw new Error(`Invalid ${name}`);
+  return number;
+}
+
+function nonNegativeBig(value, name) {
+  const number = finiteBig(value, name);
+  if (number.lt(0)) throw new Error(`Invalid ${name}`);
+  return number;
+}
+
+function finiteNumber(value, nonzeroExpected = !value.isZero()) {
+  const number = value.toNumber();
+  if (!Number.isFinite(number)) throw new Error('Numeric overflow');
+  if (nonzeroExpected && number === 0) throw new Error('Numeric underflow');
+  return number;
+}
+
+function validPrecision(value) {
+  const maximumExponent = Big.config().RANGE[1];
+  if (
+    typeof value !== 'number' ||
+    !Number.isSafeInteger(value) ||
+    value < 0 ||
+    value > maximumExponent
+  ) {
+    throw new Error('Invalid pool precision');
+  }
+  return value;
+}
+
+function lpTvl(amounts, decimals, prices) {
+  if (
+    !Array.isArray(amounts) ||
+    !Array.isArray(decimals) ||
+    !Array.isArray(prices) ||
+    amounts.length === 0 ||
+    amounts.length !== decimals.length ||
+    amounts.length !== prices.length
+  ) {
+    throw new Error('Mismatched pool arrays');
+  }
+
+  const value = amounts.reduce((sum, amount, index) => {
+    const tokenAmount = nonNegativeBig(amount, 'pool amount');
+    const tokenPrice = finiteBig(prices[index], 'pool price');
+    if (!tokenPrice.gt(0)) throw new Error('Invalid pool price');
+    const tokenDecimals = validPrecision(decimals[index]);
+    return sum.plus(tokenAmount.shiftedBy(-tokenDecimals).times(tokenPrice));
+  }, new Big(0));
+
+  if (!value.gt(0)) throw new Error('Invalid pool TVL');
+  return finiteNumber(value);
+}
+
+function feeAnnualPercent(feeUsd24h, tvlUsd) {
+  const fee = nonNegativeBig(feeUsd24h, 'fee');
+  const tvl = finiteBig(tvlUsd, 'TVL');
+  if (!tvl.gt(0)) throw new Error('Invalid TVL');
+
+  const percentage = new FeeBig(fee.toString())
+    .times(36500)
+    .div(new FeeBig(tvl.toString()));
+  return finiteNumber(percentage, fee.gt(0));
+}
+
+module.exports = { lpTvl, feeAnnualPercent };

--- a/src/adaptors/rhea-dex/pools.js
+++ b/src/adaptors/rhea-dex/pools.js
@@ -1,0 +1,164 @@
+const { lpTvl, feeAnnualPercent } = require('./math');
+
+const CONTRACT = 'v2.ref-finance.near';
+const INDEXER_URL = 'https://indexer.ref.finance/proxy/pool/search';
+
+const TOKENS = {
+  'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near': 'USDT.e',
+  'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near': 'USDC.e',
+  '853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near': 'FRAX',
+  'usdt.tether-token.near': 'USDt',
+  '17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1': 'USDC',
+};
+
+const POOLS = [
+  {
+    id: '4514',
+    tokens: [
+      '853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near',
+      '17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1',
+    ],
+  },
+  {
+    id: '4179',
+    tokens: [
+      'usdt.tether-token.near',
+      '17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1',
+      'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near',
+      'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near',
+    ],
+  },
+];
+
+const POOL_IDS = POOLS.map(({ id }) => id);
+const TOKEN_IDS = [...new Set(POOLS.flatMap(({ tokens }) => tokens))];
+
+function finiteNumber(value) {
+  if (
+    (typeof value !== 'string' && typeof value !== 'number') ||
+    (typeof value === 'string' && value.trim() === '')
+  ) {
+    return undefined;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function exactTokenSet(actual, expected) {
+  if (!Array.isArray(actual) || actual.length !== expected.length) return false;
+  const actualSet = new Set(actual);
+  if (actualSet.size !== actual.length) return false;
+  return expected.every((tokenId) => actualSet.has(tokenId));
+}
+
+function indexRows(response) {
+  if (response?.code !== 0 || !Array.isArray(response?.data?.list)) {
+    throw new Error('Invalid RHEA pool search response');
+  }
+
+  const rows = new Map(POOL_IDS.map((id) => [id, []]));
+  for (const row of response.data.list) {
+    const id = String(row?.id);
+    if (rows.has(id)) rows.get(id).push(row);
+  }
+  return rows;
+}
+
+function buildPool(config, chainPool, indexerPool, quotes, block) {
+  const tokenIds = chainPool?.token_account_ids;
+  if (!exactTokenSet(tokenIds, config.tokens)) {
+    throw new Error(`Unexpected token composition for pool ${config.id}`);
+  }
+
+  const poolQuotes = tokenIds.map((tokenId) => {
+    const quote = quotes.get(tokenId);
+    if (!quote) throw new Error(`Missing price for ${tokenId}`);
+    return quote;
+  });
+  const tvlUsd = lpTvl(
+    chainPool.amounts,
+    poolQuotes.map(({ decimals }) => decimals),
+    poolQuotes.map(({ price }) => price)
+  );
+  const indexerTvlUsd = finiteNumber(indexerPool.tvl);
+  if (indexerTvlUsd === undefined || indexerTvlUsd <= 0) {
+    throw new Error(`Invalid indexer TVL for pool ${config.id}`);
+  }
+  if (Math.abs(indexerTvlUsd - tvlUsd) / tvlUsd > 0.01) {
+    console.warn('RHEA DEX TVL mismatch', {
+      poolId: config.id,
+      blockHeight: block.height,
+      blockTimestamp: block.timestamp,
+      chainAmounts: chainPool.amounts,
+      quotes: tokenIds.map((tokenId, index) => ({
+        tokenId,
+        price: poolQuotes[index].price,
+        decimals: poolQuotes[index].decimals,
+      })),
+      chainTvlUsd: tvlUsd,
+      indexerTvlUsd,
+      feeSource: {
+        endpoint: INDEXER_URL,
+        feeVolumeUsd24h: indexerPool.fee_volume_24h,
+        volumeUsd24h: indexerPool.volume_24h,
+      },
+    });
+    throw new Error(`TVL mismatch for pool ${config.id}`);
+  }
+
+  const apyBase = feeAnnualPercent(indexerPool.fee_volume_24h, tvlUsd);
+  const volumeUsd1d = finiteNumber(indexerPool.volume_24h);
+  const row = {
+    pool: `rhea-dex-${CONTRACT}-${config.id}-near`,
+    chain: 'NEAR',
+    project: 'rhea-dex',
+    symbol: tokenIds.map((tokenId) => TOKENS[tokenId]).join('-'),
+    tvlUsd,
+    apyBase,
+    underlyingTokens: tokenIds,
+    token: null,
+    ...(volumeUsd1d > 0 ? { volumeUsd1d } : {}),
+    url: `https://app.rhea.finance/sauce/${config.id}`,
+  };
+  return row;
+}
+
+async function getPools(client) {
+  const block = await client.finalBlock();
+  const [indexerResponse, quotes, chainResults] = await Promise.all([
+    client.getJson(INDEXER_URL, { pool_id_list: POOL_IDS.join(',') }),
+    client.prices(TOKEN_IDS),
+    Promise.allSettled(
+      POOLS.map(({ id }) =>
+        client.view(CONTRACT, 'get_pool', { pool_id: Number(id) }, block.height)
+      )
+    ),
+  ]);
+  const rows = indexRows(indexerResponse);
+  const failures = [];
+  const pools = [];
+
+  for (let index = 0; index < POOLS.length; index += 1) {
+    const config = POOLS[index];
+    const chainResult = chainResults[index];
+    try {
+      if (chainResult.status === 'rejected') throw chainResult.reason;
+      const matches = rows.get(config.id);
+      if (matches.length !== 1) {
+        throw new Error(`Expected one indexer row for pool ${config.id}`);
+      }
+      pools.push(
+        buildPool(config, chainResult.value, matches[0], quotes, block)
+      );
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+
+  if (pools.length === 0) {
+    throw new AggregateError(failures, 'No valid RHEA DEX pools');
+  }
+  return pools;
+}
+
+module.exports = { getPools };

--- a/src/adaptors/rhea-lend/data.js
+++ b/src/adaptors/rhea-lend/data.js
@@ -1,0 +1,259 @@
+const axios = require('axios');
+
+const RPC_URL = 'https://free.rpc.fastnear.com';
+const PRICE_URL = 'https://coins.llama.fi/prices/current/';
+const TIMEOUT_MS = 15000;
+const RETRY_DELAYS_MS = [500, 1000];
+
+function limiter(maxConcurrent) {
+  let active = 0;
+  const waiting = [];
+
+  const acquire = () => {
+    if (active < maxConcurrent) {
+      active += 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => waiting.push(resolve));
+  };
+
+  const release = () => {
+    const next = waiting.shift();
+    if (next) next();
+    else active -= 1;
+  };
+
+  return async (request) => {
+    await acquire();
+    try {
+      return await request();
+    } finally {
+      release();
+    }
+  };
+}
+
+function retryable(error) {
+  const status = error?.response?.status;
+  if (status === 429 || (status >= 500 && status <= 599)) return true;
+  return error?.isAxiosError === true && error.response === undefined;
+}
+
+function statusOf(error) {
+  if (Number.isInteger(error?.response?.status)) {
+    return String(error.response.status);
+  }
+  return error?.isAxiosError === true ? 'network' : 'unknown';
+}
+
+function sanitizedError(context, category, status, cause) {
+  return new Error(`${context} ${category} (${status})`, { cause });
+}
+
+function numeric(value, name) {
+  if (
+    (typeof value !== 'number' && typeof value !== 'string') ||
+    (typeof value === 'string' && value.trim() === '')
+  ) {
+    throw new Error(`invalid ${name}`);
+  }
+  const number = Number(value);
+  if (!Number.isFinite(number)) throw new Error(`invalid ${name}`);
+  return number;
+}
+
+function createDataClient(options = {}) {
+  const http = options.http || axios;
+  const now = options.now || Date.now;
+  const sleep =
+    options.sleep ||
+    ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const diagnostic = options.diagnostic || console.warn;
+  const runLimited = limiter(4);
+
+  async function request(run, context) {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        return await runLimited(run);
+      } catch (error) {
+        if (!retryable(error) || attempt === 2) {
+          throw sanitizedError(
+            context,
+            'transport error',
+            statusOf(error),
+            error
+          );
+        }
+        await sleep(RETRY_DELAYS_MS[attempt]);
+      }
+    }
+    throw new Error(`${context} transport error (unknown)`);
+  }
+
+  async function getJson(url, params) {
+    const response = await request(
+      () =>
+        http.get(url, {
+          params,
+          timeout: TIMEOUT_MS,
+          responseType: 'text',
+          transformResponse: [(body) => body],
+        }),
+      'RHEA GET'
+    );
+    if (typeof response.data !== 'string') return response.data;
+    try {
+      return JSON.parse(response.data);
+    } catch (error) {
+      throw sanitizedError('RHEA GET', 'invalid JSON', 'schema', error);
+    }
+  }
+
+  async function rpc(payload, context) {
+    const response = await request(
+      () => http.post(RPC_URL, payload, { timeout: TIMEOUT_MS }),
+      context
+    );
+    const body = response?.data;
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      throw sanitizedError(context, 'invalid response', 'schema', body);
+    }
+    if (body.error !== undefined) {
+      throw sanitizedError(context, 'RPC error', 'application', body.error);
+    }
+    if (!body.result || typeof body.result !== 'object') {
+      throw sanitizedError(context, 'invalid response', 'schema', body);
+    }
+    if (body.result.error !== undefined) {
+      throw sanitizedError(
+        context,
+        'contract error',
+        'application',
+        body.result.error
+      );
+    }
+    return body.result;
+  }
+
+  async function view(contract, method, args = {}, blockHeight) {
+    if (typeof contract !== 'string' || typeof method !== 'string') {
+      throw new Error('Invalid NEAR view target');
+    }
+    if (
+      blockHeight !== undefined &&
+      (!Number.isSafeInteger(blockHeight) || blockHeight <= 0)
+    ) {
+      throw new Error('Invalid NEAR block height');
+    }
+
+    const params = {
+      request_type: 'call_function',
+      ...(blockHeight === undefined
+        ? { finality: 'final' }
+        : { block_id: blockHeight }),
+      account_id: contract,
+      method_name: method,
+      args_base64: Buffer.from(JSON.stringify(args)).toString('base64'),
+    };
+    const result = await rpc(
+      { jsonrpc: '2.0', id: 'rhea-yields', method: 'query', params },
+      `${contract}/${method}`
+    );
+
+    try {
+      return JSON.parse(Buffer.from(result.result).toString());
+    } catch (error) {
+      throw sanitizedError(
+        `${contract}/${method}`,
+        'invalid JSON',
+        'schema',
+        error
+      );
+    }
+  }
+
+  async function finalBlock() {
+    const result = await rpc(
+      {
+        jsonrpc: '2.0',
+        id: 'rhea-yields',
+        method: 'block',
+        params: { finality: 'final' },
+      },
+      'NEAR final block'
+    );
+    const height = result.header?.height;
+    const timestampNanosec = numeric(
+      result.header?.timestamp_nanosec,
+      'block timestamp'
+    );
+    const timestamp = timestampNanosec / 1e9;
+    if (!Number.isSafeInteger(height) || height <= 0 || timestamp < 0) {
+      throw sanitizedError(
+        'NEAR final block',
+        'invalid response',
+        'schema',
+        result.header
+      );
+    }
+    return { height, timestamp };
+  }
+
+  function quote(value, nowSeconds) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('missing quote');
+    }
+    const price = numeric(value.price, 'price');
+    const decimals = numeric(value.decimals, 'decimals');
+    const timestamp = numeric(value.timestamp, 'timestamp');
+    const confidence = numeric(value.confidence, 'confidence');
+    const age = nowSeconds - timestamp;
+    if (
+      price <= 0 ||
+      !Number.isInteger(decimals) ||
+      decimals < 0 ||
+      decimals > 36 ||
+      confidence < 0.5 ||
+      age < 0 ||
+      age > 3600
+    ) {
+      throw new Error('invalid quote values');
+    }
+    return { price, decimals, timestamp, confidence };
+  }
+
+  async function prices(tokenIds) {
+    if (
+      !Array.isArray(tokenIds) ||
+      tokenIds.length === 0 ||
+      tokenIds.some((id) => typeof id !== 'string' || id.trim() === '')
+    ) {
+      throw new Error('Invalid token IDs');
+    }
+    const ids = [...new Set(tokenIds)];
+    const data = await getJson(
+      PRICE_URL + ids.map((id) => `near:${id}`).join(',')
+    );
+    if (!data?.coins || typeof data.coins !== 'object') {
+      throw new Error('Invalid price response');
+    }
+
+    const nowSeconds = now() / 1000;
+    const result = new Map();
+    for (const tokenId of ids) {
+      try {
+        result.set(tokenId, quote(data.coins[`near:${tokenId}`], nowSeconds));
+      } catch (error) {
+        diagnostic(`RHEA price ${tokenId}: ${error.message}`);
+      }
+    }
+    if (result.size === 0) throw new Error('No valid prices');
+    return result;
+  }
+
+  return { view, finalBlock, prices, getJson };
+}
+
+const client = createDataClient();
+
+module.exports = { createDataClient, ...client };

--- a/src/adaptors/rhea-lend/index.js
+++ b/src/adaptors/rhea-lend/index.js
@@ -1,0 +1,8 @@
+const data = require('./data');
+const { getPools } = require('./pools');
+
+async function apy() {
+  return getPools(data);
+}
+
+module.exports = { protocolId: '1546', timetravel: false, apy };

--- a/src/adaptors/rhea-lend/math.js
+++ b/src/adaptors/rhea-lend/math.js
@@ -1,0 +1,101 @@
+const Big = require('bignumber.js');
+
+const MAX_SUPPORTED_DECIMALS = 36;
+
+function finiteBig(value, name) {
+  const isAcceptedType =
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    Big.isBigNumber(value);
+  const isUnsafeInteger =
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    !Number.isSafeInteger(value);
+  if (
+    !isAcceptedType ||
+    isUnsafeInteger ||
+    (typeof value === 'string' && value.trim() === '')
+  ) {
+    throw new Error(`Invalid ${name}`);
+  }
+
+  const number = new Big(value);
+  if (!number.isFinite()) throw new Error(`Invalid ${name}`);
+  return number;
+}
+
+function nonNegativeBig(value, name) {
+  const number = finiteBig(value, name);
+  if (number.lt(0)) throw new Error(`Invalid ${name}`);
+  return number;
+}
+
+function finiteNumber(value) {
+  const number = value.toNumber();
+  if (!Number.isFinite(number)) throw new Error('Numeric overflow');
+  if (!value.isZero() && number === 0) throw new Error('Numeric underflow');
+  return number;
+}
+
+function validPrecision(value, name) {
+  if (
+    typeof value !== 'number' ||
+    !Number.isSafeInteger(value) ||
+    value < 0 ||
+    value > MAX_SUPPORTED_DECIMALS
+  ) {
+    throw new Error(`Invalid ${name}`);
+  }
+  return value;
+}
+
+function decimalPrecision(decimals, extraDecimals) {
+  const precision = decimals + extraDecimals;
+  if (!Number.isSafeInteger(precision) || precision > MAX_SUPPORTED_DECIMALS) {
+    throw new Error('Invalid total decimals');
+  }
+  return precision;
+}
+
+function lendingAmounts(asset, decimals, price) {
+  const tokenDecimals = validPrecision(decimals, 'decimals');
+  const extraDecimals = validPrecision(
+    asset.config.extra_decimals,
+    'extra decimals'
+  );
+  const tokenPrice = finiteBig(price, 'price');
+  if (!tokenPrice.gt(0)) throw new Error('Invalid price');
+
+  const supplied = nonNegativeBig(asset.supplied.balance, 'supplied');
+  const reserved = nonNegativeBig(asset.reserved, 'reserved');
+  const protocolFee = nonNegativeBig(asset.prot_fee, 'prot_fee');
+  const borrowed = nonNegativeBig(asset.borrowed.balance, 'borrowed');
+  const marginDebtValue =
+    asset.margin_debt === undefined ? '0' : asset.margin_debt?.balance;
+  const pendingDebtValue =
+    asset.margin_pending_debt === undefined ? '0' : asset.margin_pending_debt;
+  const marginDebt = nonNegativeBig(marginDebtValue, 'margin debt');
+  const pendingDebt = nonNegativeBig(pendingDebtValue, 'pending debt');
+  const rate = nonNegativeBig(asset.supply_apr, 'supply_apr').times(100);
+
+  const supply = supplied.plus(reserved).plus(protocolFee);
+  const borrow = borrowed.plus(marginDebt).plus(pendingDebt);
+  if (supply.lt(borrow)) throw new Error('Unexpected lending accounting');
+
+  const precision = decimalPrecision(tokenDecimals, extraDecimals);
+  const bigResult = {
+    totalSupplyUsd: supply.shiftedBy(-precision).times(tokenPrice),
+    totalBorrowUsd: borrow.shiftedBy(-precision).times(tokenPrice),
+    tvlUsd: supply.minus(borrow).shiftedBy(-precision).times(tokenPrice),
+    apyBase: rate,
+  };
+
+  return Object.fromEntries(
+    Object.entries(bigResult).map(([name, value]) => [
+      name,
+      finiteNumber(value),
+    ])
+  );
+}
+
+module.exports = { lendingAmounts };

--- a/src/adaptors/rhea-lend/pools.js
+++ b/src/adaptors/rhea-lend/pools.js
@@ -1,0 +1,117 @@
+const Big = require('bignumber.js');
+const { lendingAmounts } = require('./math');
+
+const CONTRACT = 'contract.main.burrow.near';
+const MARKETS = [
+  {
+    tokenId: '17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1',
+    symbol: 'USDC',
+  },
+  { tokenId: 'usdt.tether-token.near', symbol: 'USDt' },
+  {
+    tokenId: 'a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.factory.bridge.near',
+    symbol: 'USDC.e',
+  },
+  {
+    tokenId: 'dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near',
+    symbol: 'USDT.e',
+  },
+  {
+    tokenId: '6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near',
+    symbol: 'DAI',
+  },
+  {
+    tokenId: '853d955acef822db058eb8505911ed77f175b99e.factory.bridge.near',
+    symbol: 'FRAX',
+  },
+];
+
+function borrowYield(asset) {
+  if (!Object.prototype.hasOwnProperty.call(asset, 'borrow_apr')) return {};
+  const raw = asset.borrow_apr;
+  if (
+    (typeof raw !== 'number' && typeof raw !== 'string') ||
+    (typeof raw === 'string' && raw.trim() === '') ||
+    (typeof raw === 'number' &&
+      Number.isInteger(raw) &&
+      !Number.isSafeInteger(raw))
+  ) {
+    throw new Error('Invalid borrow_apr');
+  }
+  const percent = new Big(raw).times(100);
+  const apyBaseBorrow = percent.toNumber();
+  if (
+    !percent.isFinite() ||
+    percent.lt(0) ||
+    !Number.isFinite(apyBaseBorrow) ||
+    (!percent.isZero() && apyBaseBorrow === 0)
+  ) {
+    throw new Error('Invalid borrow_apr');
+  }
+  return { apyBaseBorrow };
+}
+
+function hasActiveRewards(asset) {
+  return (
+    Array.isArray(asset.farms) &&
+    asset.farms.some(
+      (farm) =>
+        farm?.rewards &&
+        typeof farm.rewards === 'object' &&
+        !Array.isArray(farm.rewards) &&
+        Object.keys(farm.rewards).length > 0
+    )
+  );
+}
+
+async function getPools(client, diagnostic = console.warn) {
+  const tokenIds = MARKETS.map(({ tokenId }) => tokenId);
+  const [assets, quotes] = await Promise.all([
+    client.view(CONTRACT, 'get_assets', { token_ids: tokenIds }),
+    client.prices(tokenIds),
+  ]);
+  if (!Array.isArray(assets)) throw new Error('Invalid lending assets');
+  if (!(quotes instanceof Map)) throw new Error('Invalid lending prices');
+
+  const rows = [];
+  for (const market of MARKETS) {
+    try {
+      const matches = assets.filter(
+        (asset) => asset?.token_id === market.tokenId
+      );
+      if (matches.length !== 1) {
+        throw new Error(
+          matches.length === 0 ? 'asset missing' : 'duplicate asset'
+        );
+      }
+      const asset = matches[0];
+      if (asset.config?.can_deposit !== true) {
+        throw new Error('deposit disabled');
+      }
+      const quote = quotes.get(market.tokenId);
+      if (!quote) throw new Error('price missing');
+
+      const row = {
+        pool: `rhea-lend-${market.tokenId}-near`,
+        chain: 'NEAR',
+        project: 'rhea-lend',
+        symbol: market.symbol,
+        ...lendingAmounts(asset, quote.decimals, quote.price),
+        ...borrowYield(asset),
+        underlyingTokens: [market.tokenId],
+        token: null,
+        url: `https://app.rhea.finance/tokenDetail/${market.tokenId}?pageType=main`,
+      };
+      if (hasActiveRewards(asset)) {
+        diagnostic(`RHEA lending ${market.symbol}: active rewards omitted`);
+      }
+      rows.push(row);
+    } catch (error) {
+      diagnostic(`RHEA lending ${market.symbol}: skipped (${error.message})`);
+    }
+  }
+  if (rows.length === 0) throw new Error('No valid RHEA lending markets');
+  return rows;
+}
+
+module.exports = { getPools };

--- a/src/adaptors/rhea-lst/data.js
+++ b/src/adaptors/rhea-lst/data.js
@@ -1,0 +1,172 @@
+const BigNumber = require('bignumber.js');
+const shared = require('../rhea-lend/data');
+const { assertConservation, assertShareIdentity } = require('./math');
+
+const XRHEA_CONTRACT = 'xtoken.rhealab.near';
+const RHEA_TOKEN = 'token.rhealab.near';
+const RNEAR_CONTRACT = 'lst.rhealab.near';
+const RNEAR_APY_URL = 'https://api.rhea.finance/get-rnear-apy';
+
+function object(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid ${name}`);
+  }
+  return value;
+}
+
+function rawInteger(value, name) {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    throw new Error(`Invalid ${name}`);
+  }
+  return value;
+}
+
+function blockHeight(value) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('Invalid staking block height');
+  }
+  return value;
+}
+
+function tokenMetadata(value, expectedDecimals, name) {
+  const metadata = object(value, `${name} token metadata`);
+  if (metadata.decimals !== expectedDecimals) {
+    throw new Error(`Invalid ${name} token decimals`);
+  }
+  return metadata;
+}
+
+function exitFees(value) {
+  const fees = object(value, 'RHEA exit fees');
+  const entries = Object.entries(fees);
+  if (
+    entries.length === 0 ||
+    entries.some(
+      ([days, bps]) =>
+        !/^\d+$/.test(days) ||
+        typeof bps !== 'number' ||
+        !Number.isSafeInteger(bps) ||
+        bps < 0 ||
+        bps > 10000
+    )
+  ) {
+    throw new Error('Invalid RHEA exit fee schedule');
+  }
+  return fees;
+}
+
+async function xrheaSnapshot(height, client = shared) {
+  const fixedHeight = blockHeight(height);
+  const [metadataValue, supplyValue, virtualPriceValue, tokenValue, feesValue] =
+    await Promise.all([
+      client.view(XRHEA_CONTRACT, 'contract_metadata', {}, fixedHeight),
+      client.view(XRHEA_CONTRACT, 'ft_total_supply', {}, fixedHeight),
+      client.view(XRHEA_CONTRACT, 'get_virtual_price', {}, fixedHeight),
+      client.view(XRHEA_CONTRACT, 'ft_metadata', {}, fixedHeight),
+      client.view(XRHEA_CONTRACT, 'get_exit_fee_bps', {}, fixedHeight),
+    ]);
+
+  const metadata = object(metadataValue, 'xRHEA contract metadata');
+  if (metadata.locked_token_id !== RHEA_TOKEN) {
+    throw new Error('Invalid xRHEA locked token');
+  }
+  const supply = rawInteger(supplyValue, 'xRHEA supply');
+  const virtualPrice = rawInteger(virtualPriceValue, 'xRHEA virtual price');
+  const receiptMetadata = tokenMetadata(tokenValue, 18, 'xRHEA');
+  const fees = exitFees(feesValue);
+
+  const locked = rawInteger(
+    metadata.locked_token_amount,
+    'locked_token_amount'
+  );
+  const currentLocked = rawInteger(
+    metadata.cur_locked_token_amount,
+    'cur_locked_token_amount'
+  );
+  rawInteger(metadata.reward_per_sec, 'reward_per_sec');
+  const undistributed = rawInteger(
+    metadata.undistributed_reward_amount,
+    'undistributed_reward_amount'
+  );
+  const currentUndistributed = rawInteger(
+    metadata.cur_undistributed_reward_amount,
+    'cur_undistributed_reward_amount'
+  );
+
+  assertConservation(
+    locked,
+    undistributed,
+    currentLocked,
+    currentUndistributed
+  );
+  assertShareIdentity(currentLocked, supply, virtualPrice, 8);
+
+  return {
+    metadata,
+    supply,
+    virtualPrice,
+    tokenMetadata: receiptMetadata,
+    exitFees: fees,
+  };
+}
+
+async function rnearSnapshot(height, client = shared) {
+  const fixedHeight = blockHeight(height);
+  const [summaryValue, supplyValue, tokenValue] = await Promise.all([
+    client.view(RNEAR_CONTRACT, 'get_summary', {}, fixedHeight),
+    client.view(RNEAR_CONTRACT, 'ft_total_supply', {}, fixedHeight),
+    client.view(RNEAR_CONTRACT, 'ft_metadata', {}, fixedHeight),
+  ]);
+
+  const summary = object(summaryValue, 'rNEAR summary');
+  const totalShares = rawInteger(
+    summary.total_share_amount,
+    'rNEAR total_share_amount'
+  );
+  const totalStaked = rawInteger(
+    summary.total_staked_near_amount,
+    'rNEAR total_staked_near_amount'
+  );
+  const pricePerShare = rawInteger(summary.ft_price, 'rNEAR ft_price');
+  const supply = rawInteger(supplyValue, 'rNEAR supply');
+  const receiptMetadata = tokenMetadata(tokenValue, 24, 'rNEAR');
+
+  if (!new BigNumber(supply).eq(totalShares)) {
+    throw new Error('rNEAR supply does not match summary');
+  }
+  assertShareIdentity(totalStaked, totalShares, pricePerShare, 24);
+
+  return { summary, supply, tokenMetadata: receiptMetadata };
+}
+
+async function nearApy(client = shared) {
+  const body = await client.getJson(RNEAR_APY_URL);
+  if (
+    !body ||
+    typeof body !== 'object' ||
+    Array.isArray(body) ||
+    body.code !== 0
+  ) {
+    throw new Error('Invalid NEAR APY response');
+  }
+  if (
+    (typeof body.data !== 'number' && typeof body.data !== 'string') ||
+    (typeof body.data === 'string' && !/^\d+(?:\.\d+)?$/.test(body.data))
+  ) {
+    throw new Error('Invalid NEAR APY value');
+  }
+
+  const exact = new BigNumber(body.data);
+  const result = exact.toNumber();
+  if (
+    !exact.isFinite() ||
+    exact.lt(0) ||
+    !Number.isFinite(result) ||
+    (!exact.isZero() && result === 0)
+  ) {
+    throw new Error('Invalid NEAR APY value');
+  }
+  return result;
+}
+
+module.exports = { xrheaSnapshot, rnearSnapshot, nearApy };

--- a/src/adaptors/rhea-lst/index.js
+++ b/src/adaptors/rhea-lst/index.js
@@ -1,0 +1,7 @@
+const { getPools } = require('./pools');
+
+async function apy() {
+  return getPools();
+}
+
+module.exports = { protocolId: '6985', timetravel: false, apy };

--- a/src/adaptors/rhea-lst/math.js
+++ b/src/adaptors/rhea-lst/math.js
@@ -1,0 +1,126 @@
+const BigNumber = require('bignumber.js');
+
+const Big = BigNumber.clone({ DECIMAL_PLACES: 80 });
+const MAX_SUPPORTED_DECIMALS = 36;
+const SECONDS_PER_YEAR = 31536000;
+
+function finiteBig(value, name) {
+  const accepted =
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    BigNumber.isBigNumber(value);
+  const unsafeInteger =
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    !Number.isSafeInteger(value);
+  if (
+    !accepted ||
+    unsafeInteger ||
+    (typeof value === 'string' && value.trim() === '')
+  ) {
+    throw new Error(`Invalid ${name}`);
+  }
+
+  const number = new Big(value);
+  if (!number.isFinite()) throw new Error(`Invalid ${name}`);
+  return number;
+}
+
+function nonNegativeBig(value, name) {
+  const number = finiteBig(value, name);
+  if (number.lt(0)) throw new Error(`Invalid ${name}`);
+  return number;
+}
+
+function precision(value) {
+  if (
+    typeof value !== 'number' ||
+    !Number.isSafeInteger(value) ||
+    value < 0 ||
+    value > MAX_SUPPORTED_DECIMALS
+  ) {
+    throw new Error('Invalid precision');
+  }
+  return value;
+}
+
+function finiteNumber(value) {
+  const number = value.toNumber();
+  if (!Number.isFinite(number)) throw new Error('Numeric overflow');
+  if (!value.isZero() && number === 0) throw new Error('Numeric underflow');
+  return number;
+}
+
+function unsignedRaw(value, name) {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    throw new Error(`Invalid ${name}`);
+  }
+  return new Big(value);
+}
+
+function value(raw, decimals, price) {
+  const amount = nonNegativeBig(raw, 'balance');
+  const tokenPrice = finiteBig(price, 'price');
+  const tokenDecimals = precision(decimals);
+  if (!tokenPrice.gt(0)) throw new Error('Invalid price');
+
+  return finiteNumber(amount.shiftedBy(-tokenDecimals).times(tokenPrice));
+}
+
+function rate(rewardPerSec, locked, remaining) {
+  const speed = nonNegativeBig(rewardPerSec, 'reward speed');
+  const balance = finiteBig(locked, 'locked balance');
+  const reserve = nonNegativeBig(remaining, 'remaining reward');
+  if (!balance.gt(0)) throw new Error('Invalid locked balance');
+  if (reserve.isZero()) return 0;
+
+  const annualRate = speed.times(SECONDS_PER_YEAR).div(balance).times(100);
+  if (!speed.isZero() && annualRate.isZero()) {
+    throw new Error('Numeric underflow');
+  }
+  return finiteNumber(annualRate);
+}
+
+function assertConservation(
+  locked,
+  undistributed,
+  currentLocked,
+  currentUndistributed
+) {
+  const stored = unsignedRaw(locked, 'locked balance').plus(
+    unsignedRaw(undistributed, 'undistributed reward')
+  );
+  const current = unsignedRaw(currentLocked, 'current locked balance').plus(
+    unsignedRaw(currentUndistributed, 'current undistributed reward')
+  );
+  if (!stored.eq(current)) throw new Error('RHEA reward conservation failed');
+}
+
+function assertShareIdentity(
+  underlyingRaw,
+  shareSupplyRaw,
+  pricePerShareRaw,
+  priceDecimals
+) {
+  const scale = new Big(10).pow(precision(priceDecimals));
+  const underlying = unsignedRaw(underlyingRaw, 'underlying balance');
+  const supply = unsignedRaw(shareSupplyRaw, 'share supply');
+  const pricePerShare = unsignedRaw(pricePerShareRaw, 'price per share');
+  if (!supply.gt(0) || !pricePerShare.gt(0)) {
+    throw new Error('Invalid share identity inputs');
+  }
+
+  const difference = underlying
+    .times(scale)
+    .minus(supply.times(pricePerShare))
+    .abs();
+  const tolerance = supply.plus(scale);
+  if (difference.gt(tolerance)) throw new Error('Share identity failed');
+}
+
+module.exports = {
+  value,
+  rate,
+  assertConservation,
+  assertShareIdentity,
+};

--- a/src/adaptors/rhea-lst/pools.js
+++ b/src/adaptors/rhea-lst/pools.js
@@ -1,0 +1,106 @@
+const shared = require('../rhea-lend/data');
+const { xrheaSnapshot, rnearSnapshot, nearApy } = require('./data');
+const { value, rate } = require('./math');
+
+const DEFAULT_CLIENT = { ...shared, diagnostic: console.warn };
+const PRICE_IDS = ['token.rhealab.near', 'wrap.near'];
+
+function quotePrice(quotes, tokenId) {
+  const quote = quotes?.get?.(tokenId);
+  if (
+    !quote ||
+    typeof quote !== 'object' ||
+    typeof quote.price !== 'number' ||
+    !Number.isFinite(quote.price) ||
+    quote.price <= 0
+  ) {
+    throw new Error(`Missing ${tokenId} price`);
+  }
+  return quote.price;
+}
+
+function feeSchedule(exitFees) {
+  return Object.entries(exitFees)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([days, bps]) => `${days}d ${bps / 100}%`)
+    .join(', ');
+}
+
+async function xrheaPool(height, quotes, client) {
+  const price = quotePrice(quotes, 'token.rhealab.near');
+  const snapshot = await xrheaSnapshot(height, client);
+  const metadata = snapshot.metadata;
+
+  return {
+    pool: 'rhea-lst-xtoken.rhealab.near-near',
+    chain: 'NEAR',
+    project: 'rhea-lst',
+    symbol: 'XRHEA',
+    token: 'xtoken.rhealab.near',
+    underlyingTokens: ['token.rhealab.near'],
+    tvlUsd: value(metadata.cur_locked_token_amount, 18, price),
+    apy: rate(
+      metadata.reward_per_sec,
+      metadata.cur_locked_token_amount,
+      metadata.cur_undistributed_reward_amount
+    ),
+    pricePerShare: value(snapshot.virtualPrice, 8, 1),
+    poolMeta:
+      'RHEA staking; current reward annualization before position-dependent exit fees; ' +
+      `cooldown earns no yield; exit fees: ${feeSchedule(snapshot.exitFees)}`,
+    url: 'https://app.rhea.finance/stake',
+  };
+}
+
+async function rnearPool(height, quotes, client) {
+  const price = quotePrice(quotes, 'wrap.near');
+  const [snapshot, apy] = await Promise.all([
+    rnearSnapshot(height, client),
+    nearApy(client),
+  ]);
+  const summary = snapshot.summary;
+
+  return {
+    pool: 'rhea-lst-lst.rhealab.near-near',
+    chain: 'NEAR',
+    project: 'rhea-lst',
+    symbol: 'rNEAR',
+    token: 'lst.rhealab.near',
+    underlyingTokens: ['wrap.near'],
+    tvlUsd: value(summary.total_staked_near_amount, 24, price),
+    apy,
+    pricePerShare: value(summary.ft_price, 24, 1),
+    isIntrinsicSource: true,
+    poolMeta:
+      'NEAR liquid staking; APY source window and netting are unverified',
+    url: 'https://app.rhea.finance/stake',
+  };
+}
+
+async function getPools(client = DEFAULT_CLIENT) {
+  const [{ height }, quotes] = await Promise.all([
+    client.finalBlock(),
+    client.prices(PRICE_IDS),
+  ]);
+  const results = await Promise.allSettled([
+    xrheaPool(height, quotes, client),
+    rnearPool(height, quotes, client),
+  ]);
+  const labels = ['xRHEA', 'rNEAR'];
+  const diagnostic =
+    typeof client.diagnostic === 'function' ? client.diagnostic : console.warn;
+  const pools = [];
+
+  results.forEach((result, index) => {
+    if (result.status === 'fulfilled') pools.push(result.value);
+    else {
+      const message = result.reason?.message || String(result.reason);
+      diagnostic(`rhea-lst ${labels[index]}: ${message}`);
+    }
+  });
+
+  if (pools.length === 0) throw new Error('No usable RHEA staking pools');
+  return pools;
+}
+
+module.exports = { getPools };


### PR DESCRIPTION
## Summary

Adds three RHEA yield adapters on NEAR, covering 10 configured pools:

- `rhea-dex`: FRAX-USDC (pool 4514) and USDt-USDC-USDT.e-USDC.e (pool 4179) liquidity pools.
- `rhea-lend`: USDC, USDt, USDC.e, USDT.e, DAI and FRAX lending markets.
- `rhea-lst`: RHEA to xRHEA staking and NEAR to rNEAR liquid staking.

## Data sources and calculations

- USD prices come from DefiLlama's current-prices API.
- DEX pool balances come from `get_pool` on `v2.ref-finance.near`, with reads pinned to one final NEAR block. TVL is calculated from token balances and USD prices.
- DEX 24-hour fees and trading volume come from `https://indexer.ref.finance/proxy/pool/search`. Base yield is reported as `apyBase = fee_volume_24h / tvlUsd * 365 * 100`, without compounding. Trading volume is reported as `volumeUsd1d` when positive.
- DEX TVL is cross-checked against the indexer; the current implementation excludes pools whose TVL differs by more than 1%.
- Lending data comes from `contract.main.burrow.near`. TVL is total supply minus total borrow, including the accounted reserves, protocol fees and margin debt. Supply and borrow annual rates are converted to percentages.
- Staking balances and exchange rates come from `xtoken.rhealab.near` and `lst.rhealab.near`, with reads pinned to one final NEAR block. xRHEA yield is calculated by annualizing current reward emissions against active staked RHEA. rNEAR APY comes from `https://api.rhea.finance/get-rnear-apy`.
- For staking pools, `pricePerShare` represents underlying tokens per receipt token.

## Validation

- `rhea-dex`: 18 official tests passed in the latest GitHub Actions run, returning 2 pools.
- `rhea-lend`: 54 official tests passed locally, returning 6 pools.
- `rhea-lst`: 25 official tests passed locally, returning 2 pools.
- The lending and staking adapter files are unchanged by the DEX addition.

## Methodology notes

- DEX yield includes trading fees only; lending reports base yield only. Additional farming or reward incentives are omitted.
- xRHEA yield is reported before position-dependent exit fees. The cooldown period earns no yield. Exit-fee tiers are included in `poolMeta`; their treatment under the minimum-attainable-yield methodology needs review.
- The rNEAR APY endpoint does not expose its calculation window or fee treatment. These details and the acceptability of this API source need confirmation.
- Historical queries are not supported (`timetravel: false`). Pools below DefiLlama's display threshold may be returned by the adapters without appearing on the website.